### PR TITLE
BB-154: Align navbar search input with button by forcing line-height and height

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -45,6 +45,11 @@ body {
 .whole-page-form {
 	margin-top: 3em;
 }
+.navbar-form .form-control,
+.navbar-form .input-group-btn>.btn {
+  line-height: 1 !important;
+  height: 34px !important;
+}
 .loading-background {
 	position: fixed;
 	display: inline-block;


### PR DESCRIPTION
I wasn't particularly fond of using !important to force the line-height and height, but this seems to be an issue with Bootstrap itself, so issuing an override is what I deemed best.

The issue can be replicated by visiting [Bootstrap Input-Groups](http://getbootstrap.com/components/#input-groups-basic) and manipulating zoom percentage.

As of now, I propose this solution.

![nav-search](https://cloud.githubusercontent.com/assets/13492593/12073804/16dff088-b0f8-11e5-9186-62b41f574097.png)
