### PR TITLE
Pull in entity data set schema changes

### DIFF
--- a/src/client/components/forms/edition.jsx
+++ b/src/client/components/forms/edition.jsx
@@ -87,9 +87,9 @@ module.exports = React.createClass({
 		const data = {
 			aliases: aliasData.slice(0, -1),
 			publicationBbid: editionData.publication,
-			publisherBbid: editionData.publisher,
-			releaseDate: editionData.releaseDate,
-			languageIds: editionData.languages,
+			publishers: editionData.publishers,
+			releaseEvents: editionData.releaseEvents,
+			languages: editionData.languages,
 			formatId: parseInt(editionData.editionFormat, 10),
 			statusId: parseInt(editionData.editionStatus, 10),
 			disambiguation: editionData.disambiguation,

--- a/src/client/components/forms/parts/editionData.jsx
+++ b/src/client/components/forms/parts/editionData.jsx
@@ -166,16 +166,14 @@ const EditionData = React.createClass({
 		let initialDepth = null;
 		let initialWeight = null;
 
-		let publication = null;
-		let publisher = null;
 		const prefillData = this.props.edition;
 		if (prefillData) {
 			if (prefillData.publication) {
-				publication = prefillData.publication;
+				initialPublication = prefillData.publication;
 			}
 
 			if (prefillData.publisherSet.publishers) {
-				publisher = prefillData.publisherSet.publishers[0];
+				initialPublisher = prefillData.publisherSet.publishers[0];
 			}
 
 			if (prefillData.releaseEventSet.releaseEvents) {
@@ -213,23 +211,11 @@ const EditionData = React.createClass({
 		}
 
 		if (this.props.publication) {
-			publication = this.props.publication;
+			initialPublication = this.props.publication;
 		}
 
-		if (publication) {
-			initialPublication = {
-				id: publication.bbid,
-				text: publication.defaultAlias ?
-					publication.defaultAlias.name : null
-			};
-		}
-
-		if (publisher) {
-			initialPublisher = {
-				id: publisher.bbid,
-				text: publisher.defaultAlias ?
-					publisher.defaultAlias.name : null
-			};
+		if (this.props.publisher) {
+			initialPublisher = this.props.publisher;
 		}
 
 		const select2Options = {

--- a/src/client/components/forms/parts/editionData.jsx
+++ b/src/client/components/forms/parts/editionData.jsx
@@ -105,10 +105,27 @@ const EditionData = React.createClass({
 		const publication = this.refs.publication.getValue();
 		const publisher = this.refs.publisher.getValue();
 
+		const releaseEvents = [];
+
+		// If the release date field isn't empty, create a release event
+		// object to represent it
+		if (this.refs.release.getValue()) {
+			const edition = this.props.edition;
+
+			const releaseEventId = edition && edition.releaseEventSet &&
+					edition.releaseEventSet.releaseEvents ?
+				edition.releaseEventSet.releaseEvents[0].id : null;
+
+			releaseEvents.push({
+				id: releaseEventId,
+				date: this.refs.release.getValue()
+			});
+		}
+
 		return {
 			publication: publication ? publication.bbid : null,
 			publishers: publisher ? [publisher.bbid] : null,
-			releaseEvents: [{date: this.refs.release.getValue()}],
+			releaseEvents: releaseEvents,
 			languages: this.refs.languages.getValue().map(
 				(languageId) => parseInt(languageId, 10)
 			),

--- a/src/client/components/forms/parts/editionData.jsx
+++ b/src/client/components/forms/parts/editionData.jsx
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015  Ben Ockmore
- *               2015  Sean Burke
+ * Copyright (C) 2015       Ben Ockmore
+ *               2015-2016  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -107,8 +107,8 @@ const EditionData = React.createClass({
 
 		return {
 			publication: publication ? publication.bbid : null,
-			publisher: publisher ? publisher.bbid : null,
-			releaseDate: this.refs.release.getValue(),
+			publishers: publisher ? [publisher.bbid] : null,
+			releaseEvents: [{date: this.refs.release.getValue()}],
 			languages: this.refs.languages.getValue().map(
 				(languageId) => parseInt(languageId, 10)
 			),
@@ -157,16 +157,16 @@ const EditionData = React.createClass({
 				publication = prefillData.publication;
 			}
 
-			if (prefillData.revision.data.publishers) {
-				publisher = prefillData.revision.data.publishers[0];
+			if (prefillData.publisherSet.publishers) {
+				publisher = prefillData.publisherSet.publishers[0];
 			}
 
-			if (prefillData.revision.data.releaseEvents) {
+			if (prefillData.releaseEventSet.releaseEvents) {
 				initialReleaseDate =
-					prefillData.revision.data.releaseEvents[0].date;
+					prefillData.releaseEventSet.releaseEvents[0].date;
 			}
 
-			initialLanguages = prefillData.revision.data.languages.map(
+			initialLanguages = prefillData.languageSet.languages.map(
 				(language) => language.id
 			);
 			initialEditionFormat = prefillData.editionFormat ?
@@ -205,10 +205,6 @@ const EditionData = React.createClass({
 				text: publication.defaultAlias ?
 					publication.defaultAlias.name : null
 			};
-		}
-
-		if (this.props.publisher) {
-			publisher = this.props.publisher;
 		}
 
 		if (publisher) {

--- a/src/client/components/forms/parts/editionData.jsx
+++ b/src/client/components/forms/parts/editionData.jsx
@@ -125,7 +125,7 @@ const EditionData = React.createClass({
 		return {
 			publication: publication ? publication.bbid : null,
 			publishers: publisher ? [publisher.bbid] : null,
-			releaseEvents: releaseEvents,
+			releaseEvents,
 			languages: this.refs.languages.getValue().map(
 				(languageId) => parseInt(languageId, 10)
 			),

--- a/src/client/components/forms/parts/workData.jsx
+++ b/src/client/components/forms/parts/workData.jsx
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015  Ben Ockmore
- *               2015  Sean Burke
+ * Copyright (C) 2015       Ben Ockmore
+ *               2015-2016  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -78,9 +78,10 @@ const WorkData = React.createClass({
 
 		const prefillData = this.props.work;
 		if (prefillData) {
-			initialLanguages = prefillData.revision.data.languages.map(
-				(language) => language.id
-			);
+			initialLanguages = prefillData.languageSet &&
+				prefillData.languageSet.languages.map(
+					(language) => language.id
+				);
 			initialWorkType = prefillData.workType ?
 				prefillData.workType.id : null;
 			initialDisambiguation = prefillData.disambiguation ?

--- a/src/client/components/input/entity-search.jsx
+++ b/src/client/components/input/entity-search.jsx
@@ -148,17 +148,19 @@ const EntitySearch = React.createClass({
 
 		const options = this.props.options || [];
 
-		let defaultKey = null;
-		if (this.props.defaultValue && this.props.defaultValue.bbid) {
-			options.unshift(entityToOption(this.props.defaultValue));
-			defaultKey = this.props.defaultValue.bbid;
+		function keyFromValue(value) {
+			let key = null;
+
+			if (value && value.bbid) {
+				options.unshift(entityToOption(value));
+				key = value.bbid;
+			}
+
+			return key;
 		}
 
-		let key = null;
-		if (this.props.value && this.props.value.bbid) {
-			options.unshift(entityToOption(this.props.value));
-			key = this.props.value.bbid;
-		}
+		const defaultKey = keyFromValue(this.props.defaultValue);
+		const key = keyFromValue(this.props.value);
 
 		return (
 			<Select

--- a/src/client/components/input/entity-search.jsx
+++ b/src/client/components/input/entity-search.jsx
@@ -29,7 +29,7 @@ const EntitySearch = React.createClass({
 	propTypes: {
 		bsStyle: React.PropTypes.string,
 		defaultValue: React.PropTypes.shape({
-			id: React.PropTypes.string
+			bbid: React.PropTypes.string
 		}),
 		disabled: React.PropTypes.bool,
 		groupClassName: React.PropTypes.string,
@@ -41,7 +41,7 @@ const EntitySearch = React.createClass({
 		select2Options: React.PropTypes.object,
 		standalone: React.PropTypes.bool,
 		value: React.PropTypes.shape({
-			id: React.PropTypes.string
+			bbid: React.PropTypes.string
 		}),
 		wrapperClassName: React.PropTypes.string,
 		onChange: React.PropTypes.func
@@ -72,8 +72,6 @@ const EntitySearch = React.createClass({
 		}
 
 		function entityToOption(entity) {
-			'use strict';
-
 			return {
 				id: entity.bbid,
 				text: entity.defaultAlias ?

--- a/src/client/components/input/entity-search.jsx
+++ b/src/client/components/input/entity-search.jsx
@@ -63,12 +63,25 @@ const EntitySearch = React.createClass({
 		const self = this;
 
 		if (this.props.defaultValue) {
-			this.loadedEntities[this.props.defaultValue.id] =
+			this.loadedEntities[this.props.defaultValue.bbid] =
 				this.props.defaultValue;
 		}
 
 		if (this.props.value) {
-			this.loadedEntities[this.props.value.id] = this.props.value;
+			this.loadedEntities[this.props.value.bbid] = this.props.value;
+		}
+
+		function entityToOption(entity) {
+			'use strict';
+
+			return {
+				id: entity.bbid,
+				text: entity.defaultAlias ?
+					entity.defaultAlias.name : '(unnamed)',
+				disambiguation: entity.disambiguation ?
+					entity.disambiguation.comment : null,
+				type: entity.type
+			};
 		}
 
 		const select2Options = {
@@ -99,14 +112,7 @@ const EntitySearch = React.createClass({
 					});
 
 					return {
-						results: results.map((result) => ({
-							id: result.bbid,
-							text: result.defaultAlias ?
-								result.defaultAlias.name : '(unnamed)',
-							disambiguation: result.disambiguation ?
-								result.disambiguation.comment : null,
-							type: result.type
-						}))
+						results: results.map(entityToOption)
 					};
 				}
 			},
@@ -145,15 +151,15 @@ const EntitySearch = React.createClass({
 		const options = this.props.options || [];
 
 		let defaultKey = null;
-		if (this.props.defaultValue && this.props.defaultValue.id) {
-			options.unshift(this.props.defaultValue);
-			defaultKey = this.props.defaultValue.id;
+		if (this.props.defaultValue && this.props.defaultValue.bbid) {
+			options.unshift(entityToOption(this.props.defaultValue));
+			defaultKey = this.props.defaultValue.bbid;
 		}
 
 		let key = null;
-		if (this.props.value && this.props.value.id) {
-			options.unshift(this.props.value);
-			key = this.props.value.id;
+		if (this.props.value && this.props.value.bbid) {
+			options.unshift(entityToOption(this.props.value));
+			key = this.props.value.bbid;
 		}
 
 		return (

--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015-2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+
+function formatRow(kind, key, lhs, rhs) {
+	if (_.isNil(lhs) && _.isNil(rhs)) {
+		return [];
+	}
+
+	if (kind === 'N' || _.isNil(lhs)) {
+		return {kind: 'N', key, rhs};
+	}
+
+	if (kind === 'D' || _.isNil(rhs)) {
+		return {kind: 'D', key, lhs};
+	}
+
+	return {kind, key, lhs, rhs};
+}
+module.exports.formatRow = formatRow;
+
+function formatChange(change, label, transformer) {
+	return formatRow(
+		change.kind,
+		label,
+		transformer(change.lhs),
+		transformer(change.rhs)
+	);
+}
+module.exports.formatChange = formatChange;
+
+function formatGenderChange(change) {
+	return formatChange(
+		change,
+		'Gender',
+		(side) => side && [side.name]
+	);
+}
+module.exports.formatGenderChange = formatGenderChange;
+
+function formatEndedChange(change) {
+	return [
+		formatChange(
+			change,
+			'Ended',
+			(side) => [_.isNull(side) || side ? 'Yes' : 'No']
+		)
+	];
+}
+module.exports.formatEndedChange = formatEndedChange;
+
+function formatTypeChange(change, label) {
+	return formatChange(change, label, (side) => side && [side.label]);
+}
+module.exports.formatTypeChange = formatTypeChange;
+
+function formatScalarChange(change, label) {
+	return formatChange(change, label, (side) => side && [side]);
+}
+module.exports.formatScalarChange = formatScalarChange;

--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+
+const formatRow = require('./base').formatRow;
+const formatChange = require('./base').formatChange;
+
+function formatNewAnnotation(change) {
+	return formatChange(change, 'Annotation', (side) => [side && side.content]);
+}
+
+function formatNewDisambiguation(change) {
+	return formatChange(
+		change, 'Disambiguation', (side) => [side && side.comment]
+	);
+}
+
+function formatChangedAnnotation(change) {
+	return formatChange(change, 'Annotation', (side) => side && [side]);
+}
+
+function formatChangedDisambiguation(change) {
+	return formatChange(change, 'Disambiguation', (side) => side && [side]);
+}
+
+function formatNewAliasSet(change) {
+	const rhs = change.rhs;
+	const changes = [];
+	if (rhs.defaultAlias && rhs.defaultAliasId) {
+		changes.push(
+			formatRow('N', 'Default Alias', null, [rhs.defaultAlias.name])
+		);
+	}
+
+	if (rhs.aliases && rhs.aliases.length) {
+		changes.push(
+			formatRow(
+				'N', 'Aliases', null, rhs.aliases.map((alias) => alias.name)
+			)
+		);
+	}
+
+	return changes;
+}
+
+function formatAliasAddOrDelete(change) {
+	const lhs = change.item.lhs &&
+		[`${change.item.lhs.name} (${change.item.lhs.sortName})`];
+	const rhs = change.item.rhs &&
+		[`${change.item.rhs.name} (${change.item.rhs.sortName})`];
+
+	return [formatRow(change.item.kind, 'Aliases', lhs, rhs)];
+}
+
+function formatAliasModified(change) {
+	if (change.path.length > 3 && change.path[3] === 'name') {
+		return [
+			formatChange(
+				change,
+				`Alias ${change.path[2]} -> Name`,
+				(side) => side && [side]
+			)
+		];
+	}
+
+	if (change.path.length > 3 && change.path[3] === 'sortName') {
+		return [
+			formatChange(
+				change,
+				`Alias ${change.path[2]} -> Sort Name`,
+				(side) => side && [side]
+			)
+		];
+	}
+
+	if (change.path.length > 3 && change.path[3] === 'language') {
+		return [
+			formatChange(
+				change,
+				`Alias ${change.path[2]} -> Language`,
+				(side) => side && side.name && [side.name]
+			)
+		];
+	}
+
+	if (change.path.length > 3 && change.path[3] === 'primary') {
+		return [
+			formatChange(
+				change,
+				`Alias ${change.path[2]} -> Primary`,
+				(side) => !_.isNull(side) && [side.primary ? 'Yes' : 'No']
+			)
+		];
+	}
+
+	return [];
+}
+
+function formatDefaultAliasModified(change) {
+	if (change.path.length > 2 && change.path[2] === 'name') {
+		return [
+			formatChange(change, 'Default Alias', (side) => side && [side])
+		];
+	}
+
+	return [];
+}
+
+function formatAlias(change) {
+	const aliasSetAdded =
+		change.kind === 'N' && _.isEqual(change.path, ['aliasSet']);
+	if (aliasSetAdded) {
+		return formatNewAliasSet(change);
+	}
+
+	const aliasSetChanged =
+		change.path.length > 1 && change.path[0] === 'aliasSet' &&
+		change.path[1] === 'aliases';
+	if (aliasSetChanged) {
+		if (change.kind === 'A') {
+			// Alias added to or deleted from set
+			return formatAliasAddOrDelete(change);
+		}
+
+		if (change.kind === 'E') {
+			// Entry in alias set changed
+			return formatAliasModified(change);
+		}
+	}
+
+	const defaultAliasChanged =
+		_.isEqual(change.path.slice(0, 2), ['aliasSet', 'defaultAlias']);
+	if (defaultAliasChanged) {
+		return formatDefaultAliasModified(change);
+	}
+
+	return null;
+}
+
+function formatNewIdentifierSet(change) {
+	const rhs = change.rhs;
+	if (rhs.identifiers && rhs.identifiers.length > 0) {
+		return [formatRow(
+			'N', 'Identifiers', null, rhs.identifiers.map(
+				(identifier) => `${identifier.type.label}: ${identifier.value}`
+			)
+		)];
+	}
+
+	return [];
+}
+
+function formatIdentifierAddOrDelete(change) {
+	const lhs = change.item.lhs &&
+		[`${change.item.lhs.type.label}: ${change.item.lhs.value}`];
+	const rhs = change.item.rhs &&
+		[`${change.item.rhs.type.label}: ${change.item.rhs.value}`];
+
+	return [
+		formatRow(change.item.kind, `Identifier ${change.index}`, lhs, rhs)
+	];
+}
+
+function formatIdentifierModified(change) {
+	if (change.path.length > 3 && change.path[3] === 'value') {
+		return [
+			formatChange(
+				change,
+				`Identifier ${change.path[2]} -> Value`,
+				(side) => side && [side]
+			)
+		];
+	}
+
+	if (change.path.length > 4 && change.path[3] === 'type' &&
+			change.path[4] === 'label') {
+		return [
+			formatChange(
+				change,
+				`Identifier ${change.path[2]} -> Type`,
+				(side) => side && [side]
+			)
+		];
+	}
+
+	return [];
+}
+
+function formatIdentifier(change) {
+	const identifierSetAdded =
+		change.kind === 'N' && _.isEqual(change.path, ['identifierSet']);
+	if (identifierSetAdded) {
+		return formatNewIdentifierSet(change);
+	}
+
+	const identifierSetChanged =
+		change.path.length > 1 && change.path[0] === 'identifierSet' &&
+		change.path[1] === 'identifiers';
+	if (identifierSetChanged) {
+		if (change.kind === 'A') {
+			// Identifier added to or deleted from set
+			return formatIdentifierAddOrDelete(change);
+		}
+
+		if (change.kind === 'E') {
+			// Entry in identifier set changed
+			return formatIdentifierModified(change);
+		}
+	}
+
+	return null;
+}
+
+function formatRelationshipAdd(entity, change) {
+	const changes = [];
+	const rhs = change.item.rhs;
+
+	if (!rhs) {
+		return changes;
+	}
+
+	if (rhs.sourceBbid === entity.get('bbid')) {
+		changes.push(
+			formatRow('N', 'Relationship Source Entity', null, [rhs.sourceBbid])
+		);
+	}
+	else {
+		changes.push(
+			formatRow('N', 'Relationship Target Entity', null, [rhs.targetBbid])
+		);
+	}
+
+	if (rhs.type && rhs.type.label) {
+		changes.push(
+			formatRow('N', 'Relationship Type', null, [rhs.type.label])
+		);
+	}
+
+	return changes;
+}
+
+function formatRelationship(entity, change) {
+	if (change.kind === 'A') {
+		if (change.item.kind === 'N') {
+			return formatRelationshipAdd(entity, change);
+		}
+	}
+
+	return null;
+}
+
+function formatEntityChange(entity, change) {
+	const aliasChanged =
+		_.isEqual(change.path, ['aliasSet']) ||
+		_.isEqual(change.path.slice(0, 2), ['aliasSet', 'aliases']) ||
+		_.isEqual(change.path.slice(0, 2), ['aliasSet', 'defaultAlias']);
+	if (aliasChanged) {
+		return formatAlias(change);
+	}
+
+	const identifierChanged =
+		_.isEqual(change.path, ['identifierSet']) ||
+		_.isEqual(change.path.slice(0, 2), ['identifierSet', 'identifiers']);
+	if (identifierChanged) {
+		return formatIdentifier(change);
+	}
+
+	const relationshipChanged =
+		_.isEqual(change.path, ['relationshipSet', 'relationships']);
+	if (relationshipChanged) {
+		return formatRelationship(entity, change);
+	}
+
+	if (_.isEqual(change.path, ['annotation'])) {
+		return formatNewAnnotation(change);
+	}
+
+	if (_.isEqual(change.path, ['annotation', 'content'])) {
+		return formatChangedAnnotation(change);
+	}
+
+	if (_.isEqual(change.path, ['disambiguation'])) {
+		return formatNewDisambiguation(change);
+	}
+
+	if (_.isEqual(change.path, ['disambiguation', 'comment'])) {
+		return formatChangedDisambiguation(change);
+	}
+
+	return null;
+}
+
+function formatEntityDiffs(diffs, entityType, entityFormatter) {
+	if (!diffs) {
+		return [];
+	}
+
+	return diffs.map((diff) => {
+		const formattedDiff = {
+			entity: diff.entity.toJSON()
+		};
+
+		formattedDiff.entity.type = entityType;
+
+		if (!diff.changes) {
+			formattedDiff.changes = [];
+
+			return formattedDiff;
+		}
+
+		const rawChangeSets = diff.changes.map((change) =>
+			formatEntityChange(diff.entity, change) ||
+			entityFormatter &&
+			entityFormatter(change)
+		);
+
+		formattedDiff.changes = _.sortBy(
+			_.flatten(_.compact(rawChangeSets)),
+			'key'
+		);
+
+		return formattedDiff;
+	});
+}
+module.exports.formatEntityDiffs = formatEntityDiffs;

--- a/src/server/helpers/diffFormatters/languageSet.js
+++ b/src/server/helpers/diffFormatters/languageSet.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015-2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const set = require('./set');
+
+function formatNewLanguageSet(change) {
+	function transformer(rhs) {
+		return rhs.languages.map((language) => language.name);
+	}
+
+	return set.formatNewSet(
+		change, 'Languages', 'languages', transformer
+	);
+}
+
+function formatLanguageAddOrDelete(change) {
+	return set.formatItemAddOrDelete(
+		change, `Language ${change.index}`, (side) => side && [side.name]
+	);
+}
+
+function formatLanguageModified(change) {
+	return set.formatItemModified(
+		change, `Language ${change.path[2]}`, ['name']
+	);
+}
+
+function formatLanguageSet(change) {
+	return set.format(
+		change, 'languageSet', 'languages',
+		formatNewLanguageSet,
+		formatLanguageAddOrDelete,
+		formatLanguageModified
+	);
+}
+module.exports.format = formatLanguageSet;
+
+function languageSetChanged(change) {
+	return set.changed(change, 'languageSet', 'languages');
+}
+module.exports.changed = languageSetChanged;

--- a/src/server/helpers/diffFormatters/publisherSet.js
+++ b/src/server/helpers/diffFormatters/publisherSet.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const set = require('./set');
+
+function formatNewPublisherSet(change) {
+	function transformer(rhs) {
+		return rhs.publishers.map((publisher) => publisher.bbid);
+	}
+
+	return set.formatNewSet(
+		change, 'Publisher', 'publishers', transformer
+	);
+}
+
+function formatPublisherAddOrDelete(change) {
+	return set.formatItemAddOrDelete(
+		change, 'Publisher', (side) => side && [side.bbid]
+	);
+}
+
+function formatPublisherModified(change) {
+	return set.formatItemModified(change, 'Publisher', ['bbid']);
+}
+
+function formatPublisherSet(change) {
+	return set.format(
+		change, 'publisherSet', 'publishers',
+		formatNewPublisherSet,
+		formatPublisherAddOrDelete,
+		formatPublisherModified
+	);
+}
+module.exports.format = formatPublisherSet;
+
+function publisherSetChanged(change) {
+	return set.changed(change, 'publisherSet', 'publishers');
+}
+module.exports.changed = publisherSetChanged;

--- a/src/server/helpers/diffFormatters/releaseEventSet.js
+++ b/src/server/helpers/diffFormatters/releaseEventSet.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const set = require('./set');
+
+function formatNewReleaseEventSet(change) {
+	function transformer(rhs) {
+		return rhs.releaseEvents.map((releaseEvent) => releaseEvent.date);
+	}
+
+	return set.formatNewSet(
+		change, 'Release Date', 'releaseEvents', transformer
+	);
+}
+
+function formatReleaseEventAddOrDelete(change) {
+	return set.formatItemAddOrDelete(
+		change, 'Release Date', (side) => side && [side.date]
+	);
+}
+
+function formatReleaseEventModified(change) {
+	return set.formatItemModified(change, 'Release Date', ['date']);
+}
+
+function formatReleaseEventSet(change) {
+	return set.format(
+		change, 'releaseEventSet', 'releaseEvents',
+		formatNewReleaseEventSet,
+		formatReleaseEventAddOrDelete,
+		formatReleaseEventModified
+	);
+}
+module.exports.format = formatReleaseEventSet;
+
+function releaseEventSetChanged(change) {
+	return set.changed(change, 'releaseEventSet', 'releaseEvents');
+}
+module.exports.changed = releaseEventSetChanged;

--- a/src/server/helpers/diffFormatters/set.js
+++ b/src/server/helpers/diffFormatters/set.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015-2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+
+const formatRow = require('./base').formatRow;
+const formatChange = require('./base').formatChange;
+
+function formatNewSet(change, label, itemProp, transformerFunc) {
+	const rhs = change.rhs;
+	if (rhs[itemProp] && rhs[itemProp].length > 0) {
+		return [formatRow('N', label, null, transformerFunc(rhs))];
+	}
+
+	return [];
+}
+module.exports.formatNewSet = formatNewSet;
+
+function formatItemAddOrDelete(change, label, transformerFunc) {
+	return [
+		formatChange(change.item, label, transformerFunc)
+	];
+}
+module.exports.formatItemAddOrDelete = formatItemAddOrDelete;
+
+function formatItemModified(change, label, formattedProps) {
+	if (change.path.length > 3 && _.includes(formattedProps, change.path[3])) {
+		return [
+			formatChange(change, label, (side) => side && [side])
+		];
+	}
+
+	return [];
+}
+module.exports.formatItemModified = formatItemModified;
+
+function formatSet(
+	change, setProp, itemProp, newSetFormatter, addDeleteFormatter,
+	modifyFormatter
+) {
+	const setAdded =
+		change.kind === 'N' && _.isEqual(change.path, [setProp]);
+	if (setAdded) {
+		return newSetFormatter(change);
+	}
+
+	const itemAddDeleteModify =
+		change.path.length > 1 && change.path[0] === setProp &&
+			change.path[1] === itemProp;
+	if (itemAddDeleteModify) {
+		if (change.kind === 'A') {
+			// Item added to or deleted from set
+			return addDeleteFormatter(change);
+		}
+
+		if (change.kind === 'E') {
+			// Item in set changed
+			return modifyFormatter(change);
+		}
+	}
+
+	return null;
+}
+module.exports.format = formatSet;
+
+function setChanged(change, setProp, itemProp) {
+	return _.isEqual(change.path, [setProp]) ||
+		_.isEqual(change.path.slice(0, 2), [setProp, itemProp]);
+}
+module.exports.changed = setChanged;

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -231,13 +231,8 @@ search.generateIndex = () => {
 					.fetchAll({
 						withRelated: baseRelations.concat(behavior.relations)
 					})
-					.then(
-						(collection) => Promise.all(
-							collection.map(
-								(entity) => search.indexEntity(entity.toJSON())
-							)
-						)
-					)
+					.then((collection) => collection.toJSON())
+					.map(search.indexEntity)
 			);
 		})
 		.then(search.refreshIndex);

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -39,7 +39,14 @@ let _client = null;
 search.init = (options) => {
 	const config = _.extend({
 		defer() {
-			return Promise.defer();
+			const defer = {};
+
+			defer.promise = new Promise((resolve, reject) => {
+				defer.resolve = resolve;
+				defer.reject = reject;
+			});
+
+			return defer;
 		}
 	}, options);
 

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -140,13 +140,13 @@ const additionalCreatorProps = [
 
 router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.createEntity(
-		req, res, Creator, _.pick(req.body, additionalCreatorProps)
+		req, res, 'Creator', _.pick(req.body, additionalCreatorProps)
 	)
 );
 
 router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.editEntity(
-		req, res, Creator, _.pick(req.body, additionalCreatorProps)
+		req, res, 'Creator', _.pick(req.body, additionalCreatorProps)
 	)
 );
 

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015  Ben Ockmore
- *               2015  Sean Burke
+ * Copyright (C) 2015       Ben Ockmore
+ *               2015-2016  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -63,11 +63,11 @@ router.param(
 		Edition,
 		[
 			'publication.defaultAlias',
-			'revision.data.languages',
+			'languageSet.languages',
 			'editionFormat',
 			'editionStatus',
-			'revision.data.releaseEvents',
-			'revision.data.publishers.defaultAlias'
+			'releaseEventSet.releaseEvents',
+			'publisherSet.publishers.defaultAlias'
 		],
 		'Edition not found'
 	)

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -194,7 +194,11 @@ const additionalEditionSets = [
 		idField: 'id',
 		entityIdField: 'releaseEventSetId',
 		propName: 'releaseEvents',
-		model: ReleaseEventSet
+		model: ReleaseEventSet,
+		mutableFields: [
+			'date',
+			'areaId'
+		]
 	}
 ];
 

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -31,6 +31,10 @@ const EditionRevision = require('bookbrainz-data').EditionRevision;
 const Publication = require('bookbrainz-data').Publication;
 const Publisher = require('bookbrainz-data').Publisher;
 
+const LanguageSet = require('bookbrainz-data').LanguageSet;
+const PublisherSet = require('bookbrainz-data').PublisherSet;
+const ReleaseEventSet = require('bookbrainz-data').ReleaseEventSet;
+
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 const EditForm = React.createFactory(
@@ -170,15 +174,47 @@ const additionalEditionProps = [
 	'formatId', 'statusId'
 ];
 
+const additionalEditionSets = [
+	{
+		name: 'languageSet',
+		idField: 'id',
+		entityIdField: 'languageSetId',
+		propName: 'languages',
+		model: LanguageSet
+	},
+	{
+		name: 'publisherSet',
+		idField: 'bbid',
+		entityIdField: 'publisherSetId',
+		propName: 'publishers',
+		model: PublisherSet
+	},
+	{
+		name: 'releaseEventSet',
+		idField: 'id',
+		entityIdField: 'releaseEventSetId',
+		propName: 'releaseEvents',
+		model: ReleaseEventSet
+	}
+];
+
 router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.createEntity(
-		req, res, 'Edition', _.pick(req.body, additionalEditionProps)
+		req,
+		res,
+		'Edition',
+		_.pick(req.body, additionalEditionProps),
+		additionalEditionSets
 	)
 );
 
 router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.editEntity(
-		req, res, 'Edition', _.pick(req.body, additionalEditionProps)
+		req,
+		res,
+		'Edition',
+		_.pick(req.body, additionalEditionProps),
+		additionalEditionSets
 	)
 );
 

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -421,9 +421,7 @@ function processEntitySets(derivedSets, currentEntity, body, transacting) {
 			});
 	})
 		.then((newProps) =>
-			_.reduce(newProps, (result, value) => (
-				_.assign(result, value)
-			), {})
+			_.reduce(newProps, (result, value) => _.assign(result, value), {})
 		);
 }
 

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -421,11 +421,9 @@ function processEntitySets(derivedSets, currentEntity, body, transacting) {
 			});
 	})
 		.then((newProps) =>
-			_.reduce(newProps, (result, value, key) => {
-				result[key] = value;
-
-				return result;
-			}, {})
+			_.reduce(newProps, (result, value) => (
+				_.assign(result, value)
+			), {})
 		);
 }
 

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016  Ben Ockmore
+ *               2016  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -111,12 +112,12 @@ module.exports.handleDelete = (req, res, HeaderModel, RevisionModel) => {
 		});
 };
 
-function setHasChanged(oldSet, newSet, compareFields) {
-	const oldSetIds = _.map(oldSet, 'id');
-	const newSetIds = _.map(newSet, 'id');
+function setHasChanged(oldSet, newSet, idField, compareFields) {
+	const oldSetIds = _.map(oldSet, idField);
+	const newSetIds = _.map(newSet, idField);
 
 	const oldSetHash = {};
-	oldSet.forEach((item) => { oldSetHash[item.id] = item; });
+	oldSet.forEach((item) => { oldSetHash[item[idField]] = item; });
 
 	// First, determine whether any items have been deleted, by excluding
 	// all new IDs from the old IDs and checking whether any IDs remain
@@ -130,12 +131,12 @@ function setHasChanged(oldSet, newSet, compareFields) {
 
 	// If not, return true if any items have changed (are not equal)
 	return _.some(newSet, (newItem) => {
-		const oldRepresentation = _.pick(oldSetHash[newItem.id], compareFields);
+		const oldRepresentation =
+			_.pick(oldSetHash[newItem[idField]], compareFields);
 		const newRepresentation = _.pick(newItem, compareFields);
 		return !_.isEqual(oldRepresentation, newRepresentation);
 	});
 }
-module.exports.setHasChanged = setHasChanged;
 
 function unchangedSetItems(oldSet, newSet, compareFields) {
 	console.log(JSON.stringify(oldSet));
@@ -165,7 +166,7 @@ function processFormAliases(
 	const aliasCompareFields =
 		['name', 'sortName', 'languageId', 'primary'];
 	const aliasesHaveChanged = setHasChanged(
-		oldAliases, newAliases, aliasCompareFields
+		oldAliases, newAliases, 'id', aliasCompareFields
 	);
 
 	// If there is no change to the set of aliases, and the default alias is
@@ -225,7 +226,7 @@ function processFormIdentifiers(transacting, oldIdentSet, newIdents) {
 	const identCompareFields =
 		['value', 'typeId'];
 	const identsHaveChanged = setHasChanged(
-		oldIdents, newIdents, identCompareFields
+		oldIdents, newIdents, 'id', identCompareFields
 	);
 
 	// If there is no change to the set of identifiers

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -651,8 +651,7 @@ module.exports.editEntity = (
 					);
 
 				const newRevisionPromise = new Revision({
-					authorId: editorJSON.id,
-					type: entityType
+					authorId: editorJSON.id
 				}).save(null, {transacting});
 
 				// Get the parents of the new revision

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -119,11 +119,12 @@ function setHasChanged(oldSet, newSet, idField, compareFields) {
 	const oldSetHash = {};
 	oldSet.forEach((item) => { oldSetHash[item[idField]] = item; });
 
-	// First, determine whether any items have been deleted, by excluding
-	// all new IDs from the old IDs and checking whether any IDs remain
+	// First, determine whether any items have been deleted or added, by
+	// excluding all new IDs from the old IDs and checking whether any IDs
+	// remain, and vice versa
 	const itemsHaveBeenDeletedOrAdded =
 		_.difference(oldSetIds, newSetIds).length > 0 ||
-		_.difference(oldSetIds, newSetIds).length > 0;
+		_.difference(newSetIds, oldSetIds).length > 0;
 
 	if (itemsHaveBeenDeletedOrAdded) {
 		return true;

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -135,13 +135,13 @@ router.get('/:bbid/edit', auth.isAuthenticated, loadIdentifierTypes,
 
 router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.createEntity(
-		req, res, Publication, _.pick(req.body, 'typeId')
+		req, res, 'Publication', _.pick(req.body, 'typeId')
 	)
 );
 
 router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.editEntity(
-		req, res, Publication, _.pick(req.body, 'typeId')
+		req, res, 'Publication', _.pick(req.body, 'typeId')
 	)
 );
 

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -54,7 +54,7 @@ router.param(
 	'bbid',
 	makeEntityLoader(
 		Publication,
-		['publicationType', 'editions.defaultAlias', 'editions.disambiguation'],
+		['publicationType', 'editions.defaultAlias', 'editions.disambiguation', 'editions.releaseEventSet.releaseEvents'],
 		'Publication not found'
 	)
 );

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -139,13 +139,13 @@ const additionalPublisherProps = [
 
 router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.createEntity(
-		req, res, Publisher, _.pick(req.body, additionalPublisherProps)
+		req, res, 'Publisher', _.pick(req.body, additionalPublisherProps)
 	)
 );
 
 router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.editEntity(
-		req, res, Publisher, _.pick(req.body, additionalPublisherProps)
+		req, res, 'Publisher', _.pick(req.body, additionalPublisherProps)
 	)
 );
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -28,7 +28,8 @@ const utils = require('../../helpers/utils');
 const Work = require('bookbrainz-data').Work;
 const WorkHeader = require('bookbrainz-data').WorkHeader;
 const WorkRevision = require('bookbrainz-data').WorkRevision;
-const bookshelf = require('bookbrainz-data').bookshelf;
+
+const LanguageSet = require('bookbrainz-data').LanguageSet;
 
 /* Middleware loader functions. */
 const makeEntityLoader = require('../../helpers/middleware').makeEntityLoader;
@@ -134,15 +135,25 @@ router.get('/:bbid/edit', auth.isAuthenticated, loadIdentifierTypes,
 	}
 );
 
+const additionalWorkSets = [
+	{
+		name: 'languageSet',
+		idField: 'id',
+		entityIdField: 'languageSetId',
+		propName: 'languages',
+		model: LanguageSet
+	}
+];
+
 router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.createEntity(
-		req, res, 'Work', _.pick(req.body, 'typeId')
+		req, res, 'Work', _.pick(req.body, 'typeId'), additionalWorkSets
 	)
 );
 
 router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.editEntity(
-		req, res, 'Work', _.pick(req.body, 'typeId')
+		req, res, 'Work', _.pick(req.body, 'typeId'), additionalWorkSets
 	)
 );
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015  Ben Ockmore
- *               2015  Sean Burke
+ * Copyright (C) 2015       Ben Ockmore
+ *               2015-2016  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@ router.param(
 	'bbid',
 	makeEntityLoader(
 		Work,
-		['workType', 'revision.data.languages'],
+		['workType', 'languages'],
 		'Work not found'
 	)
 );

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -134,35 +134,15 @@ router.get('/:bbid/edit', auth.isAuthenticated, loadIdentifierTypes,
 	}
 );
 
-function handleWorkChange(req, transacting, entityModel) {
-	const revisionPromise = entityModel.related('revision')
-		.fetch({withRelated: ['data.languages'], transacting});
-
-	// Doing this with knex because bookshelf failed to set data_id.
-	// Tried attach(), with ids and then with models, and also add()
-	const workLanguagesPromise = revisionPromise.then((revision) =>
-		bookshelf.knex('bookbrainz.work_data__language')
-			.transacting(transacting)
-			.insert(
-				req.body.languages.map((id) => ({
-					data_id: revision.related('data').get('id'),
-					language_id: id
-				}))
-			)
-	);
-
-	return workLanguagesPromise;
-}
-
 router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.createEntity(
-		req, res, 'Work', _.pick(req.body, 'typeId'), handleWorkChange
+		req, res, 'Work', _.pick(req.body, 'typeId')
 	)
 );
 
 router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
 	entityRoutes.editEntity(
-		req, res, 'Work', _.pick(req.body, 'typeId'), handleWorkChange
+		req, res, 'Work', _.pick(req.body, 'typeId')
 	)
 );
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -54,7 +54,7 @@ router.param(
 	'bbid',
 	makeEntityLoader(
 		Work,
-		['workType', 'languages'],
+		['workType', 'languageSet.languages'],
 		'Work not found'
 	)
 );

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015	Ben Ockmore
+ * Copyright (C) 2015-2016  Ben Ockmore
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,583 +38,35 @@ const RevisionPage = React.createFactory(
 	require('../../client/components/pages/revision.jsx')
 );
 
-function formatRow(kind, key, lhs, rhs) {
-	if (_.isNil(lhs) && _.isNil(rhs)) {
-		return [];
-	}
+const baseFormatter = require('../helpers/diffFormatters/base');
+const publisherSetFormatter =
+	require('../helpers/diffFormatters/publisherSet');
+const languageSetFormatter =
+	require('../helpers/diffFormatters/languageSet');
+const releaseEventSetFormatter =
+	require('../helpers/diffFormatters/releaseEventSet');
+const entityFormatter = require('../helpers/diffFormatters/entity');
 
-	if (kind === 'N' || _.isNil(lhs)) {
-		return {kind: 'N', key, rhs};
-	}
-
-	if (kind === 'D' || _.isNil(rhs)) {
-		return {kind: 'D', key, lhs};
-	}
-
-	return {kind, key, lhs, rhs};
-}
-
-function formatChange(change, label, transformer) {
-	return formatRow(
-		change.kind,
-		label,
-		transformer(change.lhs),
-		transformer(change.rhs)
-	);
-}
-
-function formatNewAliasSet(change) {
-	const rhs = change.rhs;
-	const changes = [];
-	if (rhs.defaultAlias && rhs.defaultAliasId) {
-		changes.push(
-			formatRow('N', 'Default Alias', null, [rhs.defaultAlias.name])
-		);
-	}
-
-	if (rhs.aliases && rhs.aliases.length) {
-		changes.push(
-			formatRow(
-				'N', 'Aliases', null, rhs.aliases.map((alias) => alias.name)
-			)
-		);
-	}
-
-	return changes;
-}
-
-function formatAliasAddOrDelete(change) {
-	const lhs = change.item.lhs &&
-		[`${change.item.lhs.name} (${change.item.lhs.sortName})`];
-	const rhs = change.item.rhs &&
-		[`${change.item.rhs.name} (${change.item.rhs.sortName})`];
-
-	return [formatRow(change.item.kind, 'Aliases', lhs, rhs)];
-}
-
-function formatAliasModified(change) {
-	if (change.path.length > 3 && change.path[3] === 'name') {
-		return [
-			formatChange(
-				change,
-				`Alias ${change.path[2]} -> Name`,
-				(side) => side && [side]
-			)
-		];
-	}
-
-	if (change.path.length > 3 && change.path[3] === 'sortName') {
-		return [
-			formatChange(
-				change,
-				`Alias ${change.path[2]} -> Sort Name`,
-				(side) => side && [side]
-			)
-		];
-	}
-
-	if (change.path.length > 3 && change.path[3] === 'language') {
-		return [
-			formatChange(
-				change,
-				`Alias ${change.path[2]} -> Language`,
-				(side) => side && side.name && [side.name]
-			)
-		];
-	}
-
-	if (change.path.length > 3 && change.path[3] === 'primary') {
-		return [
-			formatChange(
-				change,
-				`Alias ${change.path[2]} -> Primary`,
-				(side) => !_.isNull(side) && [side.primary ? 'Yes' : 'No']
-			)
-		];
-	}
-
-	return [];
-}
-
-function formatDefaultAliasModified(change) {
-	if (change.path.length > 2 && change.path[2] === 'name') {
-		return [
-			formatChange(change, 'Default Alias', (side) => side && [side])
-		];
-	}
-
-	return [];
-}
-
-function formatAlias(change) {
-	const aliasSetAdded =
-		change.kind === 'N' && _.isEqual(change.path, ['aliasSet']);
-	if (aliasSetAdded) {
-		return formatNewAliasSet(change);
-	}
-
-	const aliasSetChanged =
-		change.path.length > 1 && change.path[0] === 'aliasSet' &&
-		change.path[1] === 'aliases';
-	if (aliasSetChanged) {
-		if (change.kind === 'A') {
-			// Alias added to or deleted from set
-			return formatAliasAddOrDelete(change);
-		}
-
-		if (change.kind === 'E') {
-			// Entry in alias set changed
-			return formatAliasModified(change);
-		}
-	}
-
-	const defaultAliasChanged =
-		_.isEqual(change.path.slice(0, 2), ['aliasSet', 'defaultAlias']);
-	if (defaultAliasChanged) {
-		return formatDefaultAliasModified(change);
-	}
-
-	return null;
-}
-
-function formatNewIdentifierSet(change) {
-	const rhs = change.rhs;
-	if (rhs.identifiers && rhs.identifiers.length > 0) {
-		return [formatRow(
-			'N', 'Identifiers', null, rhs.identifiers.map(
-				(identifier) => `${identifier.type.label}: ${identifier.value}`
-			)
-		)];
-	}
-
-	return [];
-}
-
-function formatIdentifierAddOrDelete(change) {
-	const lhs = change.item.lhs &&
-		[`${change.item.lhs.type.label}: ${change.item.lhs.value}`];
-	const rhs = change.item.rhs &&
-		[`${change.item.rhs.type.label}: ${change.item.rhs.value}`];
-
-	return [
-		formatRow(change.item.kind, `Identifier ${change.index}`, lhs, rhs)
-	];
-}
-
-function formatIdentifierModified(change) {
-	if (change.path.length > 3 && change.path[3] === 'value') {
-		return [
-			formatChange(
-				change,
-				`Identifier ${change.path[2]} -> Value`,
-				(side) => side && [side]
-			)
-		];
-	}
-
-	if (change.path.length > 4 && change.path[3] === 'type' &&
-			change.path[4] === 'label') {
-		return [
-			formatChange(
-				change,
-				`Identifier ${change.path[2]} -> Type`,
-				(side) => side && [side]
-			)
-		];
-	}
-
-	return [];
-}
-
-function formatIdentifier(change) {
-	const identifierSetAdded =
-		change.kind === 'N' && _.isEqual(change.path, ['identifierSet']);
-	if (identifierSetAdded) {
-		return formatNewIdentifierSet(change);
-	}
-
-	const identifierSetChanged =
-		change.path.length > 1 && change.path[0] === 'identifierSet' &&
-		change.path[1] === 'identifiers';
-	if (identifierSetChanged) {
-		if (change.kind === 'A') {
-			// Identifier added to or deleted from set
-			return formatIdentifierAddOrDelete(change);
-		}
-
-		if (change.kind === 'E') {
-			// Entry in identifier set changed
-			return formatIdentifierModified(change);
-		}
-	}
-
-	return null;
-}
-
-function formatNewAnnotation(change) {
-	return formatChange(change, 'Annotation', (side) => [side && side.content]);
-}
-
-function formatNewDisambiguation(change) {
-	return formatChange(
-		change, 'Disambiguation', (side) => [side && side.comment]
-	);
-}
-
-function formatChangedAnnotation(change) {
-	return formatChange(change, 'Annotation', (side) => side && [side]);
-}
-
-function formatChangedDisambiguation(change) {
-	return formatChange(change, 'Disambiguation', (side) => side && [side]);
-}
-
-function formatRelationshipAdd(entity, change) {
-	const changes = [];
-	const rhs = change.item.rhs;
-
-	if (!rhs) {
-		return changes;
-	}
-
-	if (rhs.sourceBbid === entity.get('bbid')) {
-		changes.push(
-			formatRow('N', 'Relationship Source Entity', null, [rhs.sourceBbid])
-		);
-	}
-	else {
-		changes.push(
-			formatRow('N', 'Relationship Target Entity', null, [rhs.targetBbid])
-		);
-	}
-
-	if (rhs.type && rhs.type.label) {
-		changes.push(
-			formatRow('N', 'Relationship Type', null, [rhs.type.label])
-		);
-	}
-
-	return changes;
-}
-
-function formatRelationship(entity, change) {
-	if (change.kind === 'A') {
-		if (change.item.kind === 'N') {
-			return formatRelationshipAdd(entity, change);
-		}
-	}
-
-	return null;
-}
-
-function formatEntityChange(entity, change) {
-	const aliasChanged =
-		_.isEqual(change.path, ['aliasSet']) ||
-		_.isEqual(change.path.slice(0, 2), ['aliasSet', 'aliases']) ||
-		_.isEqual(change.path.slice(0, 2), ['aliasSet', 'defaultAlias']);
-	if (aliasChanged) {
-		return formatAlias(change);
-	}
-
-	const identifierChanged =
-		_.isEqual(change.path, ['identifierSet']) ||
-		_.isEqual(change.path.slice(0, 2), ['identifierSet', 'identifiers']);
-	if (identifierChanged) {
-		return formatIdentifier(change);
-	}
-
-	const relationshipChanged =
-		_.isEqual(change.path, ['relationshipSet', 'relationships']);
-	if (relationshipChanged) {
-		return formatRelationship(entity, change);
-	}
-
-	if (_.isEqual(change.path, ['annotation'])) {
-		return formatNewAnnotation(change);
-	}
-
-	if (_.isEqual(change.path, ['annotation', 'content'])) {
-		return formatChangedAnnotation(change);
-	}
-
-	if (_.isEqual(change.path, ['disambiguation'])) {
-		return formatNewDisambiguation(change);
-	}
-
-	if (_.isEqual(change.path, ['disambiguation', 'comment'])) {
-		return formatChangedDisambiguation(change);
-	}
-
-	return null;
-}
-
-function formatEntityDiffs(diffs, entityType, entityFormatter) {
-	if (!diffs) {
-		return [];
-	}
-
-	return diffs.map((diff) => {
-		const formattedDiff = {
-			entity: diff.entity.toJSON()
-		};
-
-		formattedDiff.entity.type = entityType;
-
-		if (!diff.changes) {
-			formattedDiff.changes = [];
-
-			return formattedDiff;
-		}
-
-		const rawChangeSets = diff.changes.map((change) =>
-			formatEntityChange(diff.entity, change) ||
-			entityFormatter &&
-			entityFormatter(change)
-		);
-
-		formattedDiff.changes = _.sortBy(
-			_.flatten(_.compact(rawChangeSets)),
-			'key'
-		);
-
-		return formattedDiff;
-	});
-}
-
-function formatDateChange(change, label) {
-	return formatChange(change, label, (side) => side && [side]);
-}
-
-function formatGenderChange(change) {
-	return formatChange(
-		change,
-		'Gender',
-		(side) => side && [side.name]
-	);
-}
-
-function formatEndedChange(change) {
-	return [
-		formatChange(
-			change,
-			'Ended',
-			(side) => [_.isNull(side) || side ? 'Yes' : 'No']
-		)
-	];
-}
-
-function formatTypeChange(change, label) {
-	return [
-		formatChange(change, label, (side) => side && [side.label])
-	];
-}
 
 function formatCreatorChange(change) {
 	if (_.isEqual(change.path, ['beginDate'])) {
-		return formatDateChange(change, 'Begin Date');
+		return baseFormatter.formatScalarChange(change, 'Begin Date');
 	}
 
 	if (_.isEqual(change.path, ['endDate'])) {
-		return formatDateChange(change, 'End Date');
+		return baseFormatter.formatScalarChange(change, 'End Date');
 	}
 
 	if (_.isEqual(change.path, ['gender'])) {
-		return formatGenderChange(change);
+		return baseFormatter.formatGenderChange(change);
 	}
 
 	if (_.isEqual(change.path, ['ended'])) {
-		return formatEndedChange(change);
+		return baseFormatter.formatEndedChange(change);
 	}
 
 	if (_.isEqual(change.path, ['type'])) {
-		return formatTypeChange(change, 'Creator Type');
-	}
-
-	return null;
-}
-
-function formatScalarChange(change, label) {
-	return [formatChange(change, label, (side) => side && [side])];
-}
-
-function formatNewReleaseEventSet(change) {
-	const rhs = change.rhs;
-	if (rhs.releaseEvents && rhs.releaseEvents.length > 0) {
-		return [formatRow(
-			'N', 'Release Date', null, rhs.releaseEvents.map(
-				(releaseEvent) => releaseEvent.date
-			)
-		)];
-	}
-
-	return [];
-}
-
-function formatReleaseEventAddOrDelete(change) {
-	const lhs = change.item.lhs && [change.item.lhs.date];
-	const rhs = change.item.rhs && [change.item.rhs.date];
-
-	return [
-		formatRow(change.item.kind, 'Release Date', lhs, rhs)
-	];
-}
-
-function formatReleaseEventModified(change) {
-	if (change.path.length > 3 && change.path[3] === 'date') {
-		return [
-			formatChange(
-				change,
-				'Release Date',
-				(side) => side && [side]
-			)
-		];
-	}
-
-	return [];
-}
-
-function formatReleaseEvent(change) {
-	const releaseEventSetAdded =
-		change.kind === 'N' && _.isEqual(change.path, ['releaseEventSet']);
-	if (releaseEventSetAdded) {
-		return formatNewReleaseEventSet(change);
-	}
-
-	const releaseEventSetChanged =
-		change.path.length > 1 && change.path[0] === 'releaseEventSet' &&
-		change.path[1] === 'releaseEvents';
-	if (releaseEventSetChanged) {
-		if (change.kind === 'A') {
-			// Release event added to or deleted from set
-			return formatReleaseEventAddOrDelete(change);
-		}
-
-		if (change.kind === 'E') {
-			// Entry in release event set changed
-			return formatReleaseEventModified(change);
-		}
-	}
-
-	return null;
-}
-
-function formatNewLanguageSet(change) {
-	const rhs = change.rhs;
-	if (rhs.languages && rhs.languages.length > 0) {
-		return [formatRow(
-			'N', 'Languages', null, rhs.languages.map(
-				(language) => language.name
-			)
-		)];
-	}
-
-	return [];
-}
-
-function formatLanguageAddOrDelete(change) {
-	const lhs = change.item.lhs && [change.item.lhs.name];
-	const rhs = change.item.rhs && [change.item.rhs.name];
-
-	return [
-		formatRow(change.item.kind, `Language ${change.index}`, lhs, rhs)
-	];
-}
-
-function formatLanguageModified(change) {
-	if (change.path.length > 3 && change.path[3] === 'name') {
-		return [
-			formatChange(
-				change,
-				`Language ${change.path[2]}`,
-				(side) => side && [side]
-			)
-		];
-	}
-
-	return [];
-}
-
-function formatLanguage(change) {
-	const languageSetAdded =
-		change.kind === 'N' && _.isEqual(change.path, ['languageSet']);
-	if (languageSetAdded) {
-		return formatNewLanguageSet(change);
-	}
-
-	const releaseEventSetChanged =
-		change.path.length > 1 && change.path[0] === 'languageSet' &&
-		change.path[1] === 'languages';
-	if (releaseEventSetChanged) {
-		if (change.kind === 'A') {
-			// Language added to or deleted from set
-			return formatLanguageAddOrDelete(change);
-		}
-
-		if (change.kind === 'E') {
-			// Entry in language set changed
-			return formatLanguageModified(change);
-		}
-	}
-
-	return null;
-}
-
-function formatNewPublisherSet(change) {
-	const rhs = change.rhs;
-	if (rhs.publishers && rhs.publishers.length > 0) {
-		return [formatRow(
-			'N', 'Publisher', null, rhs.publishers.map(
-				(publisher) => publisher.bbid
-			)
-		)];
-	}
-
-	return [];
-}
-
-function formatPublisherAddOrDelete(change) {
-	const lhs = change.item.lhs && [change.item.lhs.bbid];
-	const rhs = change.item.rhs && [change.item.rhs.bbid];
-
-	return [
-		formatRow(change.item.kind, 'Publisher', lhs, rhs)
-	];
-}
-
-function formatPublisherModified(change) {
-	if (change.path.length > 3 && change.path[3] === 'bbid') {
-		return [
-			formatChange(
-				change,
-				'Publisher',
-				(side) => side && [side]
-			)
-		];
-	}
-
-	return [];
-}
-
-function formatPublisher(change) {
-	const publisherSetAdded =
-		change.kind === 'N' && _.isEqual(change.path, ['publisherSet']);
-	if (publisherSetAdded) {
-		return formatNewPublisherSet(change);
-	}
-
-	const publisherSetChanged =
-		change.path.length > 1 && change.path[0] === 'publisherSet' &&
-		change.path[1] === 'publishers';
-	if (publisherSetChanged) {
-		if (change.kind === 'A') {
-			// Publisher added to or deleted from set
-			return formatPublisherAddOrDelete(change);
-		}
-
-		if (change.kind === 'E') {
-			// Entry in publisher set changed
-			return formatPublisherModified(change);
-		}
+		return baseFormatter.formatTypeChange(change, 'Creator Type');
 	}
 
 	return null;
@@ -622,56 +74,40 @@ function formatPublisher(change) {
 
 function formatEditionChange(change) {
 	if (_.isEqual(change.path, ['publicationBbid'])) {
-		return formatScalarChange(change, 'Publication');
+		return baseFormatter.formatScalarChange(change, 'Publication');
 	}
 
-	const publisherChanged =
-		_.isEqual(change.path, ['publisherSet']) ||
-		_.isEqual(
-			change.path.slice(0, 2), ['publisherSet', 'publishers']
-		);
-
-	if (publisherChanged) {
-		return formatPublisher(change);
+	if (publisherSetFormatter.changed(change)) {
+		return publisherSetFormatter.format(change);
 	}
 
-	const releaseEventChanged =
-		_.isEqual(change.path, ['releaseEventSet']) ||
-		_.isEqual(
-			change.path.slice(0, 2), ['releaseEventSet', 'releaseEvents']
-		);
-
-	if (releaseEventChanged) {
-		return formatReleaseEvent(change);
+	if (releaseEventSetFormatter.changed(change)) {
+		return releaseEventSetFormatter.format(change);
 	}
 
-	const languageChanged =
-		_.isEqual(change.path, ['languageSet']) ||
-		_.isEqual(
-			change.path.slice(0, 2), ['languageSet', 'languages']
-		);
-
-	if (languageChanged) {
-		return formatLanguage(change);
+	if (languageSetFormatter.changed(change)) {
+		return languageSetFormatter.format(change);
 	}
 
 	if (_.isEqual(change.path, ['width']) ||
 			_.isEqual(change.path, ['height']) ||
 			_.isEqual(change.path, ['depth']) ||
 			_.isEqual(change.path, ['weight'])) {
-		return formatScalarChange(change, _.startCase(change.path[0]));
+		return baseFormatter.formatScalarChange(
+			change, _.startCase(change.path[0])
+		);
 	}
 
 	if (_.isEqual(change.path, ['pages'])) {
-		return formatScalarChange(change, 'Page Count');
+		return baseFormatter.formatScalarChange(change, 'Page Count');
 	}
 
 	if (_.isEqual(change.path, ['editionFormat'])) {
-		return formatTypeChange(change, 'Edition Format');
+		return baseFormatter.formatTypeChange(change, 'Edition Format');
 	}
 
 	if (_.isEqual(change.path, ['editionStatus'])) {
-		return formatTypeChange(change, 'Edition Status');
+		return baseFormatter.formatTypeChange(change, 'Edition Status');
 	}
 
 	return null;
@@ -679,37 +115,31 @@ function formatEditionChange(change) {
 
 function formatPublisherChange(change) {
 	if (_.isEqual(change.path, ['beginDate'])) {
-		return formatDateChange(change, 'Begin Date');
+		return baseFormatter.formatScalarChange(change, 'Begin Date');
 	}
 
 	if (_.isEqual(change.path, ['endDate'])) {
-		return formatDateChange(change, 'End Date');
+		return baseFormatter.formatScalarChange(change, 'End Date');
 	}
 
 	if (_.isEqual(change.path, ['ended'])) {
-		return formatEndedChange(change);
+		return baseFormatter.formatEndedChange(change);
 	}
 
 	if (_.isEqual(change.path, ['type'])) {
-		return formatTypeChange(change, 'Publisher Type');
+		return baseFormatter.formatTypeChange(change, 'Publisher Type');
 	}
 
 	return null;
 }
 
 function formatWorkChange(change) {
-	const languageChanged =
-		_.isEqual(change.path, ['languageSet']) ||
-		_.isEqual(
-			change.path.slice(0, 2), ['languageSet', 'languages']
-		);
-
-	if (languageChanged) {
-		return formatLanguage(change);
+	if (languageSetFormatter.changed(change)) {
+		return languageSetFormatter.format(change);
 	}
 
 	if (_.isEqual(change.path, ['type'])) {
-		return formatTypeChange(change, 'Work Type');
+		return baseFormatter.formatTypeChange(change, 'Work Type');
 	}
 
 	return null;
@@ -717,7 +147,7 @@ function formatWorkChange(change) {
 
 function formatPublicationChange(change) {
 	if (_.isEqual(change.path, ['type'])) {
-		return formatTypeChange(change, 'Publication Type');
+		return baseFormatter.formatTypeChange(change, 'Publication Type');
 	}
 
 	return [];
@@ -763,19 +193,31 @@ router.get('/:id', (req, res) => {
 			publicationDiffs
 		) => {
 			const diffs = _.concat(
-				formatEntityDiffs(creatorDiffs, 'Creator', formatCreatorChange),
-				formatEntityDiffs(editionDiffs, 'Edition', formatEditionChange),
-				formatEntityDiffs(
+				entityFormatter.formatEntityDiffs(
+					creatorDiffs,
+					'Creator',
+					formatCreatorChange
+				),
+				entityFormatter.formatEntityDiffs(
+					editionDiffs,
+					'Edition',
+					formatEditionChange
+				),
+				entityFormatter.formatEntityDiffs(
 					publicationDiffs,
 					'Publication',
 					formatPublicationChange
 				),
-				formatEntityDiffs(
+				entityFormatter.formatEntityDiffs(
 					publisherDiffs,
 					'Publisher',
 					formatPublisherChange
 				),
-				formatEntityDiffs(workDiffs, 'Work', formatWorkChange)
+				entityFormatter.formatEntityDiffs(
+					workDiffs,
+					'Work',
+					formatWorkChange
+				)
 			);
 
 			const props = {revision: revision.toJSON(), diffs};

--- a/templates/entity/view/edition.jade
+++ b/templates/entity/view/edition.jade
@@ -15,14 +15,14 @@ block attributes
 
 	dt Languages
 	dd
-		if entity.languageSet.languages
+		if entity.languageSet && entity.languageSet.languages
 			=entity.languageSet.languages.map(function(l){return l.name;}).join(', ')
 		else
 			| ?
 
 	dt Publishers
 	dd
-		if entity.publisherSet.publishers.length > 0
+		if entity.publisherSet && entity.publisherSet.publishers.length > 0
 			each publisher in entity.publisherSet.publishers
 				a(href="/publisher/"+publisher.bbid)
 					=publisher.defaultAlias.name
@@ -30,14 +30,14 @@ block attributes
 			|?
 
 	dt Release Date
-	dd=(entity.releaseEventSet.releaseEvents.length ? entity.releaseEventSet.releaseEvents[0].date : '?')
-	
+	dd=(entity.releaseEventSet && entity.releaseEventSet.releaseEvents && entity.releaseEventSet.releaseEvents.length ? entity.releaseEventSet.releaseEvents[0].date : '?')
+
 	dt Page Count
 	dd=(entity.pages ? entity.pages : '?')
-	
+
 	dt Weight
 	dd=(entity.weight ? entity.weight : '?') + ' g'
-	
+
 	dt Dimensions (W×H×D)
 	dd=(entity.width ? entity.width : '?') + '×' + (entity.height ? entity.height : '?') + '×' + (entity.depth ? entity.depth : '?') + ' mm'
 

--- a/templates/entity/view/edition.jade
+++ b/templates/entity/view/edition.jade
@@ -15,22 +15,22 @@ block attributes
 
 	dt Languages
 	dd
-		if entity.revision.data.languages
-			=entity.revision.data.languages.map(function(l){return l.name;}).join(', ')
+		if entity.languageSet.languages
+			=entity.languageSet.languages.map(function(l){return l.name;}).join(', ')
 		else
 			| ?
 
 	dt Publishers
 	dd
-		if entity.revision.data.publishers.length > 0
-			each publisher in entity.revision.data.publishers
+		if entity.publisherSet.publishers.length > 0
+			each publisher in entity.publisherSet.publishers
 				a(href="/publisher/"+publisher.bbid)
 					=publisher.defaultAlias.name
 		else
 			|?
 
 	dt Release Date
-	dd=(entity.revision.data.releaseEvents.length ? entity.revision.data.releaseEvents[0].date : '?')
+	dd=(entity.releaseEventSet.releaseEvents.length ? entity.releaseEventSet.releaseEvents[0].date : '?')
 	
 	dt Page Count
 	dd=(entity.pages ? entity.pages : '?')

--- a/templates/entity/view/edition.jade
+++ b/templates/entity/view/edition.jade
@@ -15,29 +15,34 @@ block attributes
 
 	dt Languages
 	dd
-		if entity.revision.data.languages
-			=entity.revision.data.languages.map(function(l){return l.name;}).join(', ')
+		if entity.languageSet && entity.languageSet.languages
+			=entity.languageSet.languages.map(function(l){return l.name;}).join(', ')
 		else
 			| ?
 
 	dt Publishers
 	dd
-		if entity.revision.data.publishers.length > 0
-			each publisher in entity.revision.data.publishers
+		if entity.publisherSet && entity.publisherSet.publishers.length > 0
+			each publisher in entity.publisherSet.publishers
 				a(href="/publisher/"+publisher.bbid)
 					=publisher.defaultAlias.name
 		else
-			|?
+			| ?
 
-	dt Release Date
-	dd=(entity.releaseDate ? entity.releaseDate : '?')
-	
+	dt Release Events
+	dd
+		if entity.releaseEventSet && entity.releaseEventSet.releaseEvents.length > 0
+			each releaseEvent in entity.releaseEventSet.releaseEvents
+				=releaseEvent.date
+		else
+			| ?
+
 	dt Page Count
 	dd=(entity.pages ? entity.pages : '?')
-	
+
 	dt Weight
 	dd=(entity.weight ? entity.weight : '?') + ' g'
-	
+
 	dt Dimensions (W×H×D)
 	dd=(entity.width ? entity.width : '?') + '×' + (entity.height ? entity.height : '?') + '×' + (entity.depth ? entity.depth : '?') + ' mm'
 

--- a/templates/entity/view/publication.jade
+++ b/templates/entity/view/publication.jade
@@ -26,5 +26,8 @@ block content
 						a(href='/edition/'+edition.bbid)
 							=(edition.defaultAlias ? edition.defaultAlias.name : '(unnamed)')
 						span.text-muted
-							=(edition.disambiguation ? (' (' + edition.disambiguation.comment + ')') : '')
-					td=(edition.releaseDate ? edition.releaseDate : '?')
+							=(edition.disambiguation && edition.disambiguation.comment ? (' (' + edition.disambiguation.comment + ')') : '')
+					if edition.releaseEventSet && edition.releaseEventSet.releaseEvents && edition.releaseEventSet.releaseEvents[0]
+						td=edition.releaseEventSet.releaseEvents[0].date
+					else
+						td

--- a/templates/entity/view/publisher.jade
+++ b/templates/entity/view/publisher.jade
@@ -28,5 +28,8 @@ block content
 						a(href='/edition/'+edition.bbid)
 							=(edition.defaultAlias ? edition.defaultAlias.name : '(unnamed)')
 						span.text-muted
-							=(edition.disambiguation ? (' (' + edition.disambiguation.comment + ')') : '')
-					td=(edition.releaseDate ? edition.releaseDate : '?')
+							=(edition.disambiguation && edition.disambiguation.comment ? (' (' + edition.disambiguation.comment + ')') : '')
+					if edition.releaseEventSet && edition.releaseEventSet.releaseEvents && edition.releaseEventSet.releaseEvents[0]
+						td=edition.releaseEventSet.releaseEvents[0].date
+					else
+						td

--- a/templates/entity/view/work.jade
+++ b/templates/entity/view/work.jade
@@ -11,7 +11,7 @@ block attributes
 
 	dt Languages
 	dd
-		if entity.revision.data && entity.revision.data.languages
-			=entity.revision.data.languages.map(function(l){return l.name;}).join(', ')
+		if entity.languageSet && entity.languageSet.languages
+			=entity.languages.map(function(l){return l.name;}).join(', ')
 		else
 			| ?

--- a/templates/entity/view/work.jade
+++ b/templates/entity/view/work.jade
@@ -12,6 +12,6 @@ block attributes
 	dt Languages
 	dd
 		if entity.languageSet && entity.languageSet.languages
-			=entity.languages.map(function(l){return l.name;}).join(', ')
+			=entity.languageSet.languages.map(function(l){return l.name;}).join(', ')
 		else
 			| ?


### PR DESCRIPTION
There are two major changes wrapped up in this branch: one, the changes directly related to the entity set implementation in -sql and -data-js, which covers pulling in the model relations that were set up and appropriately changing references; and two, changes to editing to both accommodate and take advantage of these changes. This allows entity editing to be much more generic and, as a major bonus, more easily calculate whether there are changes during editing that necessitate a new revision.

N.B.: While the bulk of these changes have been tested reasonably thoroughly, Edition and Work creation and editing need testing and a general smoketest is needed to make sure that nothing else broke horribly.