### PR TITLE
Don't list duplicate entities under Recent Activity

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -68,6 +68,7 @@ router.get('/', (req, res) => {
 						`bookbrainz.${_.snakeCase(name)}.revision_id`,
 						'bookbrainz.revision.id'
 					)
+					.where('master', true)
 					.orderBy('bookbrainz.revision.created_at', 'desc')
 					.limit(numRevisionsOnHomepage);
 			})


### PR DESCRIPTION
This just constrains Recent Activity to only fetch master revisions.