### PR TITLE
BB-191 Use correct authentication middleware everywhere

### DIFF
--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -77,8 +77,9 @@ router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
 	entityRoutes.displayDeleteEntity(req, res);
 });
 
-router.post('/:bbid/delete/handler', auth.isAuthenticated, (req, res) =>
-	entityRoutes.handleDelete(req, res, CreatorHeader, CreatorRevision)
+router.post('/:bbid/delete/handler', auth.isAuthenticatedForHandler,
+	(req, res) =>
+		entityRoutes.handleDelete(req, res, CreatorHeader, CreatorRevision)
 );
 
 router.get('/:bbid/revisions', (req, res, next) => {
@@ -138,13 +139,13 @@ const additionalCreatorProps = [
 	'typeId', 'genderId', 'areaId', 'beginDate', 'endDate', 'ended'
 ];
 
-router.post('/create/handler', auth.isAuthenticated, (req, res) =>
+router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.createEntity(
 		req, res, 'Creator', _.pick(req.body, additionalCreatorProps)
 	)
 );
 
-router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.editEntity(
 		req, res, 'Creator', _.pick(req.body, additionalCreatorProps)
 	)

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -99,8 +99,9 @@ router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
 	entityRoutes.displayDeleteEntity(req, res);
 });
 
-router.post('/:bbid/delete/handler', (req, res) =>
-	entityRoutes.handleDelete(req, res, EditionHeader, EditionRevision)
+router.post('/:bbid/delete/handler', auth.isAuthenticatedForHandler,
+	(req, res) =>
+		entityRoutes.handleDelete(req, res, EditionHeader, EditionRevision)
 );
 
 // Creation
@@ -204,7 +205,7 @@ const additionalEditionSets = [
 	}
 ];
 
-router.post('/create/handler', auth.isAuthenticated, (req, res) =>
+router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.createEntity(
 		req,
 		res,
@@ -214,7 +215,7 @@ router.post('/create/handler', auth.isAuthenticated, (req, res) =>
 	)
 );
 
-router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.editEntity(
 		req,
 		res,

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -528,7 +528,11 @@ module.exports.createEntity = (
 			.then((entity) => entity.toJSON());
 	});
 
-	return handler.sendPromiseResult(res, entityCreationPromise, search.indexEntity);
+	return handler.sendPromiseResult(
+		res,
+		entityCreationPromise,
+		search.indexEntity
+	);
 };
 
 module.exports.editEntity = (
@@ -690,5 +694,9 @@ module.exports.editEntity = (
 			.then((entity) => entity.toJSON());
 	});
 
-	return handler.sendPromiseResult(res, entityEditPromise, search.indexEntity);
+	return handler.sendPromiseResult(
+		res,
+		entityEditPromise,
+		search.indexEntity
+	);
 };

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -82,8 +82,14 @@ router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
 	entityRoutes.displayDeleteEntity(req, res);
 });
 
-router.post('/:bbid/delete/handler', (req, res) =>
-	entityRoutes.handleDelete(req, res, PublicationHeader, PublicationRevision)
+router.post('/:bbid/delete/handler', auth.isAuthenticatedForHandler,
+	(req, res) =>
+		entityRoutes.handleDelete(
+			req,
+			res,
+			PublicationHeader,
+			PublicationRevision
+		)
 );
 
 router.get('/:bbid/revisions', (req, res, next) => {
@@ -138,13 +144,13 @@ router.get('/:bbid/edit', auth.isAuthenticated, loadIdentifierTypes,
 	}
 );
 
-router.post('/create/handler', auth.isAuthenticated, (req, res) =>
+router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.createEntity(
 		req, res, 'Publication', _.pick(req.body, 'typeId')
 	)
 );
 
-router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.editEntity(
 		req, res, 'Publication', _.pick(req.body, 'typeId')
 	)

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -90,8 +90,9 @@ router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
 	entityRoutes.displayDeleteEntity(req, res);
 });
 
-router.post('/:bbid/delete/handler', (req, res) =>
-	entityRoutes.handleDelete(req, res, PublisherHeader, PublisherRevision)
+router.post('/:bbid/delete/handler', auth.isAuthenticatedForHandler,
+	(req, res) =>
+		entityRoutes.handleDelete(req, res, PublisherHeader, PublisherRevision)
 );
 
 router.get('/:bbid/revisions', (req, res, next) => {
@@ -150,13 +151,13 @@ const additionalPublisherProps = [
 	'typeId', 'areaId', 'beginDate', 'endDate', 'ended'
 ];
 
-router.post('/create/handler', auth.isAuthenticated, (req, res) =>
+router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.createEntity(
 		req, res, 'Publisher', _.pick(req.body, additionalPublisherProps)
 	)
 );
 
-router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.editEntity(
 		req, res, 'Publisher', _.pick(req.body, additionalPublisherProps)
 	)

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -76,8 +76,9 @@ router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
 	entityRoutes.displayDeleteEntity(req, res);
 });
 
-router.post('/:bbid/delete/handler', (req, res) =>
-	entityRoutes.handleDelete(req, res, WorkHeader, WorkRevision)
+router.post('/:bbid/delete/handler', auth.isAuthenticatedForHandler,
+	(req, res) =>
+		entityRoutes.handleDelete(req, res, WorkHeader, WorkRevision)
 );
 
 router.get('/:bbid/revisions', (req, res, next) => {
@@ -144,13 +145,13 @@ const additionalWorkSets = [
 	}
 ];
 
-router.post('/create/handler', auth.isAuthenticated, (req, res) =>
+router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.createEntity(
 		req, res, 'Work', _.pick(req.body, 'typeId'), additionalWorkSets
 	)
 );
 
-router.post('/:bbid/edit/handler', auth.isAuthenticated, (req, res) =>
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler, (req, res) =>
 	entityRoutes.editEntity(
 		req, res, 'Work', _.pick(req.body, 'typeId'), additionalWorkSets
 	)

--- a/src/server/routes/relationship/edit.js
+++ b/src/server/routes/relationship/edit.js
@@ -162,7 +162,8 @@ function createRelationship(relationship, editorJSON) {
 }
 
 relationshipHelper.addEditRoutes = function addEditRoutes(router) {
-	router.get('/:bbid/relationships', loadEntityRelationships,
+	router.get('/:bbid/relationships', auth.isAuthenticated,
+		loadEntityRelationships,
 		(req, res, next) => {
 			const relationshipTypesPromise = new RelationshipType().fetchAll();
 
@@ -192,7 +193,7 @@ relationshipHelper.addEditRoutes = function addEditRoutes(router) {
 		}
 	);
 
-	router.post('/:bbid/relationships/handler', auth.isAuthenticated,
+	router.post('/:bbid/relationships/handler', auth.isAuthenticatedForHandler,
 		(req, res) => {
 			function relationshipValid(relationship) {
 				return _.has(relationship, 'typeId') &&


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Many routes do not use the correct authentication middleware. Namely, the relationship editor and delete handler routes do not require authentication and handlers were not correctly adapted to use the handler-specific auth route.

### Solution
<!-- What does this PR do to fix the problem? -->
Survey all routes and set correct authentication middleware.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Route authentication for relationship editing, entity deletion, and entity create/edit.