### PR TITLE
Revert partial-date to React.createClass form

### DIFF
--- a/src/client/components/input/partial-date.jsx
+++ b/src/client/components/input/partial-date.jsx
@@ -25,102 +25,91 @@ const ymdRegex = /^\d{4}-\d{2}-\d{2}$/;
 const ymRegex = /^\d{4}-\d{2}$/;
 const yRegex = /^\d{4}$/;
 
-(() => {
-	'use strict';
-
-	class PartialDate extends React.Component {
-		static validate(value) {
-			if (!value) {
-				return true;
-			}
-
-			const validSyntax = Boolean(
-				ymdRegex.test(value) ||
-				ymRegex.test(value) ||
-				yRegex.test(value)
-			);
-			const validValue = !isNaN(Date.parse(value));
-
-			return validSyntax && validValue;
-		}
-
-		constructor(props) {
-			super(props);
-
-			this.state = {
-				value: this.props.defaultValue,
-				valid: PartialDate.validate(this.props.defaultValue)
-			};
-
-			// React does not autobind non-React class methods
-			this.handleChange = this.handleChange.bind(this);
-		}
-
-		getValue() {
-			return this.validate(this.input.getValue().trim());
-		}
-
-		handleChange() {
-			const input = this.input.getValue().trim();
-
-			if (input.length > 10) {
-				return;
-			}
-
-			this.setState({
-				value: input,
-				valid: PartialDate.validate(input)
-			});
-
-			if (this.props.onChange) {
-				this.props.onChange();
-			}
-		}
-
-		valid() {
-			return this.state.valid;
-		}
-
-		validationState() {
-			let validationClass = null;
-
-			if (this.state.value) {
-				validationClass = this.state.valid ? 'success' : 'error';
-			}
-
-			return validationClass;
-		}
-
-		render() {
-			return (
-				<Input
-					bsStyle={this.validationState()}
-					groupClassName={this.props.groupClassName}
-					help={this.props.help}
-					label={this.props.label}
-					labelClassName={this.props.labelClassName}
-					placeholder={this.props.placeholder}
-					ref={(ref) => this.input = ref}
-					type="text"
-					value={this.state.value}
-					wrapperClassName={this.props.wrapperClassName}
-					onChange={this.handleChange}
-				/>
-			);
-		}
-	}
-
-	PartialDate.displayName = 'PartialDate';
-	PartialDate.propTypes = {
+const PartialDate = React.createClass({
+	displayName: 'partialDateInput',
+	propTypes: {
 		defaultValue: React.PropTypes.string,
 		groupClassName: React.PropTypes.string,
 		help: React.PropTypes.string,
 		label: React.PropTypes.string,
 		labelClassName: React.PropTypes.string,
 		placeholder: React.PropTypes.string,
-		wrapperClassName: React.PropTypes.string,
-		onChange: React.PropTypes.func
-	};
+		wrapperClassName: React.PropTypes.string
+	},
+	getInitialState() {
+		'use strict';
 
-	module.exports = PartialDate;
-})();
+		return {
+			value: this.props.defaultValue,
+			valid: this.validate(this.props.defaultValue)
+		};
+	},
+	getValue() {
+		'use strict';
+		return this.state.value;
+	},
+	handleChange() {
+		'use strict';
+
+		const input = this.input.getValue().trim();
+
+		if (input.length > 10) {
+			return;
+		}
+
+		this.setState({
+			value: input,
+			valid: this.validate(input)
+		});
+	},
+	valid() {
+		'use strict';
+
+		return this.state.valid;
+	},
+	validate(value) {
+		'use strict';
+
+		if (!value) {
+			return true;
+		}
+
+		const validSyntax = Boolean(
+			ymdRegex.test(value) || ymRegex.test(value) || yRegex.test(value)
+		);
+		const validValue = !isNaN(Date.parse(value));
+		return validSyntax && validValue;
+	},
+	validationState() {
+		'use strict';
+
+		let validationClass = null;
+
+		if (this.state.value) {
+			validationClass = this.state.valid ? 'success' : 'error';
+		}
+
+		return validationClass;
+	},
+	render() {
+		'use strict';
+
+		return (
+			<Input
+				bsStyle={this.validationState()}
+				groupClassName={this.props.groupClassName}
+				help={this.props.help}
+				label={this.props.label}
+				labelClassName={this.props.labelClassName}
+				placeholder={this.props.placeholder}
+				ref={(ref) => this.input = ref}
+				type="text"
+				value={this.state.value}
+				wrapperClassName={this.props.wrapperClassName}
+				onChange={this.handleChange}
+			/>
+		);
+	}
+});
+
+module.exports = PartialDate;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
The ES6 version of partial-date does not work and prevents users from creating editions

### Solution
<!-- What does this PR do to fix the problem? -->
Reverts the change back to React.createClass form

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Partial-date class in client/components/input/

It would be preferable to stick with es6 syntax if a fix is found but this could be an issue if pushed to the live server.