### PR TITLE
Creation achievements

### DIFF
--- a/data/testData.js
+++ b/data/testData.js
@@ -158,6 +158,33 @@ testData.sprinterAttribs = {
 	badgeUrl: 'http://test.com'
 };
 
+testData.workerBeeIAttribs = {
+	id: 1,
+	name: 'Worker Bee I',
+	description: 'create 1 worker',
+	badgeUrl: 'http://test.com'
+};
+
+testData.workerBeeIIAttribs = {
+	id: 2,
+	name: 'Worker Bee II',
+	description: 'create 10 creators',
+	badgeUrl: 'http://test.com'
+};
+
+testData.workerBeeIIIAttribs = {
+	id: 3,
+	name: 'Worker Bee III',
+	description: 'create 100 creators',
+	badgeUrl: 'http://test.com'
+};
+
+testData.workerBeeAttribs = {
+	id: 1,
+	description: 'finish worker bee track',
+	title: 'Worker Bee',
+};
+
 testData.sprinterTitleAttribs = {
 	id: 1,
 	title: 'Sprinter',
@@ -263,6 +290,23 @@ testData.createPublisher = function() {
 		)
 		.then(() =>
 			new TitleType(this.publisherAttribs)
+				.save(null, {method: 'insert'})
+		);
+}
+
+testData.createWorkerBee = function() {
+	return new AchievementType(this.workerBeeIAttribs)
+		.save(null, {method: 'insert'})
+		.then(() =>
+			new AchievementType(this.workerBeeIIAttribs)
+				.save(null, {method: 'insert'})
+		)
+		.then(() =>
+			new AchievementType(this.workerBeeIIIAttribs)
+				.save(null, {method: 'insert'})
+		)
+		.then(() =>
+			new TitleType(this.workerBeeAttribs)
 				.save(null, {method: 'insert'})
 		);
 }

--- a/data/testData.js
+++ b/data/testData.js
@@ -318,6 +318,19 @@ testData.typeRevisionHelper = function(revisionType, rowcount) {
 	};
 }
 
+testData.typeCreationHelper = function(revisionTypeString, rowCount) {
+	return function(type, string, editor) {
+		let rowCountPromise;
+		if (string === revisionTypeString) {
+			rowCountPromise = Promise.resolve(rowCount);
+		}
+		else {
+			rowCountPromise = Promise.resolve(0);
+		}
+		return rowCountPromise;
+	};
+}
+
 testData.truncate = () => utils.truncateTables(Bookshelf, [
 		'bookbrainz.editor',
 		'bookbrainz.editor_type',

--- a/data/testData.js
+++ b/data/testData.js
@@ -161,21 +161,21 @@ testData.sprinterAttribs = {
 testData.workerBeeIAttribs = {
 	id: 1,
 	name: 'Worker Bee I',
-	description: 'create 1 worker',
+	description: 'create 1 work',
 	badgeUrl: 'http://test.com'
 };
 
 testData.workerBeeIIAttribs = {
 	id: 2,
 	name: 'Worker Bee II',
-	description: 'create 10 creators',
+	description: 'create 10 works',
 	badgeUrl: 'http://test.com'
 };
 
 testData.workerBeeIIIAttribs = {
 	id: 3,
 	name: 'Worker Bee III',
-	description: 'create 100 creators',
+	description: 'create 100 works',
 	badgeUrl: 'http://test.com'
 };
 
@@ -189,21 +189,21 @@ testData.workerBeeAttribs = {
 testData.publisherCreatorIAttribs = {
 	id: 1,
 	name: 'Publisher Creator I',
-	description: 'create 1 worker',
+	description: 'create 1 publisher',
 	badgeUrl: 'http://test.com'
 };
 
 testData.publisherCreatorIIAttribs = {
 	id: 2,
 	name: 'Publisher Creator II',
-	description: 'create 10 creators',
+	description: 'create 10 publishers',
 	badgeUrl: 'http://test.com'
 };
 
 testData.publisherCreatorIIIAttribs = {
 	id: 3,
 	name: 'Publisher Creator III',
-	description: 'create 100 creators',
+	description: 'create 100 publishers',
 	badgeUrl: 'http://test.com'
 };
 

--- a/data/testData.js
+++ b/data/testData.js
@@ -185,6 +185,34 @@ testData.workerBeeAttribs = {
 	title: 'Worker Bee',
 };
 
+
+testData.publisherCreatorIAttribs = {
+	id: 1,
+	name: 'Publisher Creator I',
+	description: 'create 1 worker',
+	badgeUrl: 'http://test.com'
+};
+
+testData.publisherCreatorIIAttribs = {
+	id: 2,
+	name: 'Publisher Creator II',
+	description: 'create 10 creators',
+	badgeUrl: 'http://test.com'
+};
+
+testData.publisherCreatorIIIAttribs = {
+	id: 3,
+	name: 'Publisher Creator III',
+	description: 'create 100 creators',
+	badgeUrl: 'http://test.com'
+};
+
+testData.publisherCreatorAttribs = {
+	id: 1,
+	description: 'finish publisher creator track',
+	title: 'Publisher Creator',
+};
+
 testData.sprinterTitleAttribs = {
 	id: 1,
 	title: 'Sprinter',
@@ -307,6 +335,23 @@ testData.createWorkerBee = function() {
 		)
 		.then(() =>
 			new TitleType(this.workerBeeAttribs)
+				.save(null, {method: 'insert'})
+		);
+}
+
+testData.createPublisherCreator = function() {
+	return new AchievementType(this.publisherCreatorIAttribs)
+		.save(null, {method: 'insert'})
+		.then(() =>
+			new AchievementType(this.publisherCreatorIIAttribs)
+				.save(null, {method: 'insert'})
+		)
+		.then(() =>
+			new AchievementType(this.publisherCreatorIIIAttribs)
+				.save(null, {method: 'insert'})
+		)
+		.then(() =>
+			new TitleType(this.publisherCreatorAttribs)
 				.save(null, {method: 'insert'})
 		);
 }

--- a/src/client/components/forms/profile.jsx
+++ b/src/client/components/forms/profile.jsx
@@ -50,12 +50,12 @@ const Select = require('../input/select2.jsx');
 				bio: this.bio.getValue().trim(),
 				title: this.title.getValue()
 			};
-			console.log(data);
+
 			this.setState({waiting: true});
 
 			request.post('/editor/edit/handler')
 				.send(data).promise()
-				.then((res) => {
+				.then(() => {
 					window.location.href = `/editor/${this.props.editor.id}`;
 				});
 		}

--- a/src/client/components/forms/profile.jsx
+++ b/src/client/components/forms/profile.jsx
@@ -47,9 +47,12 @@ const Select = require('../input/select2.jsx');
 			evt.preventDefault();
 			const data = {
 				id: this.props.editor.id,
-				bio: this.bio.getValue().trim(),
-				title: this.title.getValue()
+				bio: this.bio.getValue().trim()
 			};
+			const title = this.title.getValue();
+			if (title !== '') {
+				data.title = title;
+			}
 
 			this.setState({waiting: true});
 
@@ -83,8 +86,6 @@ const Select = require('../input/select2.jsx');
 						wrapperClassName="col-md-9"
 					/>
 					<Select
-						noDefault
-						defaultValue={this.title}
 						idAttribute="unlockId"
 						label="Title"
 						labelAttribute="title"

--- a/src/client/components/forms/profile.jsx
+++ b/src/client/components/forms/profile.jsx
@@ -56,59 +56,59 @@ const Select = require('../input/select2.jsx');
 			request.post('/editor/edit/handler')
 				.send(data).promise()
 				.then((res) => {
-					const editor = res.body.editor;
 					window.location.href = `/editor/${this.props.editor.id}`;
 				});
 		}
 
 		render() {
-		const loadingElement = this.state.waiting ? <LoadingSpinner/> : null;
-		const titles = this.props.titles.map(function(unlock) {
-			const title = unlock.title;
-			title.unlockId = unlock.id;
-			return title;
-		});
-		return (
-			<form
-				className="form-horizontal"
-				onSubmit={this.handleSubmit}
-			>
-				{loadingElement}
-				<Input
-					defaultValue={this.state.bio}
-					label="Bio"
-					labelClassName="col-md-3"
-					ref={(ref) => this.bio = ref}
-					type="textarea"
-					wrapperClassName="col-md-9"
+			const loadingElement =
+				this.state.waiting ? <LoadingSpinner/> : null;
+			const titles = this.props.titles.map((unlock) => {
+				const title = unlock.title;
+				title.unlockId = unlock.id;
+				return title;
+			});
+			return (
+				<form
+					className="form-horizontal"
+					onSubmit={this.handleSubmit}
+				>
+					{loadingElement}
+					<Input
+						defaultValue={this.state.bio}
+						label="Bio"
+						labelClassName="col-md-3"
+						ref={(ref) => this.bio = ref}
+						type="textarea"
+						wrapperClassName="col-md-9"
 					/>
-				<Select
-					noDefault
-					defaultValue={this.title}
-					idAttribute="unlockId"
-					label="Title"
-					labelAttribute="title"
-					labelClassName="col-md-4"
-					options={titles}
-					placeholder="Select title"
-					ref={(ref) => this.title = ref}
-					wrapperClassName="col-md-4"
-				/>
-				<div className="form-group">
-					<div className="col-md-4 col-md-offset-4">
-						<Button
-							block
-							bsSize="large"
-							bsStyle="primary"
-							type="submit"
-						>
-							Update!
-						</Button>
+					<Select
+						noDefault
+						defaultValue={this.title}
+						idAttribute="unlockId"
+						label="Title"
+						labelAttribute="title"
+						labelClassName="col-md-4"
+						options={titles}
+						placeholder="Select title"
+						ref={(ref) => this.title = ref}
+						wrapperClassName="col-md-4"
+					/>
+					<div className="form-group">
+						<div className="col-md-4 col-md-offset-4">
+							<Button
+								block
+								bsSize="large"
+								bsStyle="primary"
+								type="submit"
+							>
+								Update!
+							</Button>
+						</div>
 					</div>
-				</div>
-			</form>
-		);
-	}
+				</form>
+			);
+		}
 }
 
 	ProfileForm.displayName = 'ProfileForm';

--- a/src/client/components/forms/profile.jsx
+++ b/src/client/components/forms/profile.jsx
@@ -24,6 +24,7 @@ const Button = require('react-bootstrap').Button;
 const Input = require('react-bootstrap').Input;
 
 const LoadingSpinner = require('../loading-spinner.jsx');
+const Select = require('../input/select2.jsx');
 
 (() => {
 	'use strict';
@@ -44,80 +45,71 @@ const LoadingSpinner = require('../loading-spinner.jsx');
 
 		handleSubmit(evt) {
 			evt.preventDefault();
-
 			const data = {
 				id: this.props.editor.id,
 				bio: this.bio.getValue().trim(),
-				title: this.title.value
+				title: this.title.getValue()
 			};
-
+			console.log(data);
 			this.setState({waiting: true});
 
 			request.post('/editor/edit/handler')
 				.send(data).promise()
-				.then(() => {
+				.then((res) => {
+					const editor = res.body.editor;
 					window.location.href = `/editor/${this.props.editor.id}`;
 				});
 		}
 
 		render() {
-			const loadingElement =
-				this.state.waiting ? <LoadingSpinner/> : null;
-			const titles = this.props.titles.map((unlock) =>
-				(
-					<option
-						key={unlock.id}
-						value={unlock.id}
-					>
-						{unlock.title.title}
-					</option>
-				)
-			);
-
-			return (
-				<form
-					className="form-horizontal"
-					onSubmit={this.handleSubmit}
-				>
-					{loadingElement}
-					<Input
-						defaultValue={this.state.bio}
-						label="Bio"
-						labelClassName="col-md-3"
-						ref={(ref) => this.bio = ref}
-						type="textarea"
-						wrapperClassName="col-md-9"
+		const loadingElement = this.state.waiting ? <LoadingSpinner/> : null;
+		const titles = this.props.titles.map(function(unlock) {
+			const title = unlock.title;
+			title.unlockId = unlock.id;
+			return title;
+		});
+		return (
+			<form
+				className="form-horizontal"
+				onSubmit={this.handleSubmit}
+			>
+				{loadingElement}
+				<Input
+					defaultValue={this.state.bio}
+					label="Bio"
+					labelClassName="col-md-3"
+					ref={(ref) => this.bio = ref}
+					type="textarea"
+					wrapperClassName="col-md-9"
 					/>
-					<div className="form-group">
-						<div className="col-md-4 col-md-offset-4">
-							<label>Title</label>
-							<select
-								className="form-control"
-								name="title"
-								ref={(ref) => this.title = ref}
-								value={this.title}
-							>
-								<option value="none">none</option>
-								{titles}
-							</select>
-						</div>
+				<Select
+					noDefault
+					defaultValue={this.title}
+					idAttribute="unlockId"
+					label="Title"
+					labelAttribute="title"
+					labelClassName="col-md-4"
+					options={titles}
+					placeholder="Select title"
+					ref={(ref) => this.title = ref}
+					wrapperClassName="col-md-4"
+				/>
+				<div className="form-group">
+					<div className="col-md-4 col-md-offset-4">
+						<Button
+							block
+							bsSize="large"
+							bsStyle="primary"
+							type="submit"
+						>
+							Update!
+						</Button>
 					</div>
-					<div className="form-group">
-						<div className="col-md-4 col-md-offset-4">
-							<Button
-								block
-								bsSize="large"
-								bsStyle="primary"
-								type="submit"
-							>
-								Update!
-							</Button>
-						</div>
-					</div>
-				</form>
-			);
-		}
+				</div>
+			</form>
+		);
 	}
+}
 
 	ProfileForm.displayName = 'ProfileForm';
 	ProfileForm.propTypes = {

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -21,8 +21,14 @@
 const AchievementType = require('bookbrainz-data').AchievementType;
 const AchievementUnlock = require('bookbrainz-data').AchievementUnlock;
 const Editor = require('bookbrainz-data').Editor;
+const Revision = require('bookbrainz-data').Revision;
 const TitleType = require('bookbrainz-data').TitleType;
 const TitleUnlock = require('bookbrainz-data').TitleUnlock;
+const CreatorRevision = require('bookbrainz-data').CreatorRevision;
+const EditionRevision = require('bookbrainz-data').EditionRevision;
+const PublicationRevision = require('bookbrainz-data').PublicationRevision;
+const PublisherRevision = require('bookbrainz-data').PublisherRevision;
+const WorkRevision = require('bookbrainz-data').WorkRevision;
 
 const Promise = require('bluebird');
 const Bookshelf = require('bookbrainz-data').bookshelf;
@@ -309,6 +315,7 @@ function processPublisherCreator(editorId) {
 				{threshold: 10, name: 'Publisher Creator II'},
 				{threshold: 1, name: 'Publisher Creator I'}
 			];
+			return testTiers(rowCount, editorId, tiers);
 		});
 }
 
@@ -323,6 +330,7 @@ function processWorkerBee(editorId) {
 				{threshold: 10, name: 'Worker Bee II'},
 				{threshold: 1, name: 'Worker Bee I'}
 			];
+			return testTiers(rowCount, editorId, tiers);
 		});
 }
 
@@ -410,6 +418,8 @@ achievement.processEdit = (userid) =>
 		processCreatorCreator(userid),
 		processLimitedEdition(userid),
 		processPublisher(userid),
+		processPublisherCreator(userid),
+		processWorkerBee(userid),
 		processSprinter(userid),
 		processFunRunner(userid),
 		processMarathoner(userid),

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -262,10 +262,10 @@ function processRevisionist(editorId) {
 }
 
 function processCreatorCreator(editorId) {
-	return getTypeRevisions('creatorRevision', editorId)
+	return getTypeCreation(new CreatorRevision(), 'creator_revision', editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 100, name: 'Creator Creator III',
+				{threshold: 25, name: 'Creator Creator III',
 					titleName: 'Creator Creator'},
 				{threshold: 10, name: 'Creator Creator II'},
 				{threshold: 1, name: 'Creator Creator I'}
@@ -275,10 +275,10 @@ function processCreatorCreator(editorId) {
 }
 
 function processLimitedEdition(editorId) {
-	return getTypeRevisions('editionRevision', editorId)
+	return getTypeCreation(new EditionRevision(), 'edition_revision', editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 100, name: 'Limited Edition III',
+				{threshold: 25, name: 'Limited Edition III',
 					titleName: 'Limited Edition'},
 				{threshold: 10, name: 'Limited Edition II'},
 				{threshold: 1, name: 'Limited Edition I'}
@@ -288,10 +288,12 @@ function processLimitedEdition(editorId) {
 }
 
 function processPublisher(editorId) {
-	return getTypeRevisions('publisherRevision', editorId)
+	return getTypeCreation(new PublicationRevision(),
+		'publication_revision',
+		editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 100, name: 'Publisher III',
+				{threshold: 25, name: 'Publisher III',
 					titleName: 'Publisher'},
 				{threshold: 10, name: 'Publisher II'},
 				{threshold: 1, name: 'Publisher I'}

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -427,6 +427,8 @@ achievement.processEdit = (userid) =>
 		creatorCreator,
 		limitedEdition,
 		publisher,
+		publisherCreator,
+		workerBee,
 		sprinter,
 		funRunner,
 		marathoner) => {
@@ -436,6 +438,8 @@ achievement.processEdit = (userid) =>
 				achievementToUnlockId(creatorCreator),
 				achievementToUnlockId(limitedEdition),
 				achievementToUnlockId(publisher),
+				achievementToUnlockId(publisherCreator),
+				achievementToUnlockId(workerBee),
 				achievementToUnlockId(sprinter),
 				achievementToUnlockId(funRunner),
 				achievementToUnlockId(marathoner)
@@ -447,6 +451,8 @@ achievement.processEdit = (userid) =>
 				creatorCreator,
 				limitedEdition,
 				publisher,
+				publisherCreator,
+				workerBee,
 				sprinter,
 				funRunner,
 				marathoner,

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -302,6 +302,20 @@ function processPublisher(editorId) {
 		});
 }
 
+function processPublisherCreator(editorId) {
+	return getTypeCreation(new PublisherRevision(),
+		'publisher_revision',
+		editorId)
+		.then((rowCount) => {
+			const tiers = [
+				{threshold: 25, name: 'Publisher Creator III',
+					titleName: 'Publisher Creator'},
+				{threshold: 10, name: 'Publisher Creator II'},
+				{threshold: 1, name: 'Publisher Creator I'}
+			];
+		});
+}
+
 function processSprinter(editorId) {
 	const rawSql =
 		`SELECT * from bookbrainz.revision WHERE author_id=${editorId} \

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -316,6 +316,20 @@ function processPublisherCreator(editorId) {
 		});
 }
 
+function processWorkerBee(editorId) {
+	return getTypeCreation(new WorkRevision(),
+		'work_revision',
+		editorId)
+		.then((rowCount) => {
+			const tiers = [
+				{threshold: 25, name: 'Worker Bee III',
+					titleName: 'Worker Bee'},
+				{threshold: 10, name: 'Worker Bee II'},
+				{threshold: 1, name: 'Worker Bee I'}
+			];
+		});
+}
+
 function processSprinter(editorId) {
 	const rawSql =
 		`SELECT * from bookbrainz.revision WHERE author_id=${editorId} \

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -202,7 +202,7 @@ function testTiers(signal, editorId, tiers) {
  */
 function getTypeRevisions(revisionType, revisionString, editor) {
 	return revisionType
-		.query(function(qb) {
+		.query((qb) => {
 			qb.innerJoin('bookbrainz.revision',
 				'bookbrainz.revision.id',
 				`bookbrainz.${revisionString}.id`);
@@ -212,9 +212,7 @@ function getTypeRevisions(revisionType, revisionString, editor) {
 			qb.where('bookbrainz.revision.author_id', '=', editor);
 		})
 		.fetchAll()
-		.then((out) => {
-			return out.length;
-		})
+		.then((out) => out.length);
 }
 
 /**
@@ -227,23 +225,21 @@ function getTypeRevisions(revisionType, revisionString, editor) {
  */
 function getTypeCreation(revisionType, revisionString, editor) {
 	return revisionType
-		.query(function(qb) {
+		.query((qb) => {
 			qb.innerJoin('bookbrainz.revision',
 				'bookbrainz.revision.id',
 				`bookbrainz.${revisionString}.id`);
 			qb.groupBy(`${revisionString}.id`,
 				`${revisionString}.bbid`,
 				'revision.id');
-			qb.where('bookbrainz.revision.author_id', '=', editor)
+			qb.where('bookbrainz.revision.author_id', '=', editor);
 			qb.leftOuterJoin('bookbrainz.revision_parent',
 				'bookbrainz.revision_parent.child_id',
-				`bookbrainz.${revisionString}.id`)
+				`bookbrainz.${revisionString}.id`);
 			qb.whereNull('bookbrainz.revision_parent.parent_id');
 		})
 		.fetchAll()
-		.then((out) => {
-			return out.length;
-		});
+		.then((out) => out.length);
 }
 
 function processRevisionist(editorId) {

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -266,7 +266,7 @@ function processCreatorCreator(editorId) {
 	return getTypeCreation(new CreatorRevision(), 'creator_revision', editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 25, name: 'Creator Creator III',
+				{threshold: 100, name: 'Creator Creator III',
 					titleName: 'Creator Creator'},
 				{threshold: 10, name: 'Creator Creator II'},
 				{threshold: 1, name: 'Creator Creator I'}
@@ -279,7 +279,7 @@ function processLimitedEdition(editorId) {
 	return getTypeCreation(new EditionRevision(), 'edition_revision', editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 25, name: 'Limited Edition III',
+				{threshold: 100, name: 'Limited Edition III',
 					titleName: 'Limited Edition'},
 				{threshold: 10, name: 'Limited Edition II'},
 				{threshold: 1, name: 'Limited Edition I'}
@@ -294,7 +294,7 @@ function processPublisher(editorId) {
 		editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 25, name: 'Publisher III',
+				{threshold: 100, name: 'Publisher III',
 					titleName: 'Publisher'},
 				{threshold: 10, name: 'Publisher II'},
 				{threshold: 1, name: 'Publisher I'}
@@ -309,7 +309,7 @@ function processPublisherCreator(editorId) {
 		editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 25, name: 'Publisher Creator III',
+				{threshold: 100, name: 'Publisher Creator III',
 					titleName: 'Publisher Creator'},
 				{threshold: 10, name: 'Publisher Creator II'},
 				{threshold: 1, name: 'Publisher Creator I'}
@@ -324,7 +324,7 @@ function processWorkerBee(editorId) {
 		editorId)
 		.then((rowCount) => {
 			const tiers = [
-				{threshold: 25, name: 'Worker Bee III',
+				{threshold: 100, name: 'Worker Bee III',
 					titleName: 'Worker Bee'},
 				{threshold: 10, name: 'Worker Bee II'},
 				{threshold: 1, name: 'Worker Bee I'}

--- a/src/server/helpers/achievement.js
+++ b/src/server/helpers/achievement.js
@@ -33,7 +33,6 @@ const WorkRevision = require('bookbrainz-data').WorkRevision;
 const Promise = require('bluebird');
 const Bookshelf = require('bookbrainz-data').bookshelf;
 
-const _ = require('lodash');
 
 /**
  * Achievement Module

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -212,7 +212,9 @@ router.get('/:id/revisions', (req, res, next) => {
 				editorTitleJSON = Promise.resolve(editorJSON);
 			}
 			else {
-				editorTitleJSON = new TitleUnlock({id: editorJSON.titleUnlockId})
+				editorTitleJSON = new TitleUnlock({
+					id: editorJSON.titleUnlockId
+				})
 					.fetch({
 						withRelated: ['title']
 					})
@@ -263,7 +265,9 @@ router.get('/:id/achievements', (req, res, next) => {
 				editorTitleJSON = Promise.resolve(editorJSON);
 			}
 			else {
-				editorTitleJSON =  new TitleUnlock({id: editorJSON.titleUnlockId})
+				editorTitleJSON = new TitleUnlock({
+					id: editorJSON.titleUnlockId
+				})
 					.fetch({
 						withRelated: ['title']
 					})
@@ -286,29 +290,24 @@ router.get('/:id/achievements', (req, res, next) => {
 	const achievementJSONPromise = new AchievementUnlock()
 		.where('editor_id', userId)
 		.fetchAll()
-		.then((unlocks) => {
-			const unlocked = unlocks.map('attributes.achievementId');
-			/*for (let i = 0; i < unlocks.length; i++) {
-				unlocked[i] =
-					unlocks.models[i].attributes.achievementId;
-			}*/
-			return unlocked;
-		})
+		.then((unlocks) =>
+			unlocks.map('attributes.achievementId')
+		)
 		.then((unlocks) =>
 			new AchievementType()
 				.orderBy('id', 'ASC')
 				.fetchAll()
 				.then((achievements) => {
-					const model = achievements.map((achievement) => {
-						achievement = achievement.toJSON();
-						if (unlocks.indexOf(achievement.id) >= 0) {
-							achievement.unlocked = true;
+					const model = achievements.map((achievementType) => {
+						const achievementJSON = achievementType.toJSON();
+						if (unlocks.indexOf(achievementJSON.id) >= 0) {
+							achievementJSON.unlocked = true;
 						}
 						else {
-							achievement.unlocked = false;
+							achievementJSON.unlocked = false;
 						}
-						return achievement;
-					})
+						return achievementJSON;
+					});
 					const achievementsJSON = {
 						model
 					};

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -350,8 +350,8 @@ function rankUpdate(editorId, bodyRank, rank) {
 			let updatePromise;
 			if (bodyRank !== 'none') {
 				updatePromise = new AchievementUnlock({
-					achievement_id: parseInt(bodyRank, 10),
-					editor_id: parseInt(editorId, 10)
+					achievementId: parseInt(bodyRank, 10),
+					editorId: parseInt(editorId, 10)
 				})
 					.fetch({require: true})
 					.then((unlock) =>

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -53,7 +53,7 @@ router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 		.then((editor) => editor.toJSON());
 
 	const titleJSONPromise = new TitleUnlock()
-		.where({'editor_id': parseInt(req.user.id, 10)})
+		.where(_.snakeCase('editorId'), parseInt(req.user.id, 10))
 		.fetchAll({
 			withRelated: ['title']
 		})
@@ -171,7 +171,7 @@ router.get('/:id', (req, res, next) => {
 		.catch(next);
 
 	const achievementJSONPromise = new AchievementUnlock()
-		.where('editor_id', userId)
+		.where(_.snakeCase('editorId'), userId)
 		.where('profile_rank', '<=', '3')
 		.query((qb) => qb.limit(3))
 		.orderBy('profile_rank', 'ASC')

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -288,11 +288,11 @@ router.get('/:id/achievements', (req, res, next) => {
 		.where('editor_id', userId)
 		.fetchAll()
 		.then((unlocks) => {
-			const unlocked = [];
-			for (let i = 0; i < unlocks.length; i++) {
+			const unlocked = unlocks.map('attributes.achievementId');
+			/*for (let i = 0; i < unlocks.length; i++) {
 				unlocked[i] =
 					unlocks.models[i].attributes.achievementId;
-			}
+			}*/
 			return unlocked;
 		})
 		.then((unlocks) =>
@@ -300,18 +300,19 @@ router.get('/:id/achievements', (req, res, next) => {
 				.orderBy('id', 'ASC')
 				.fetchAll()
 				.then((achievements) => {
-					const achievementsJSON = {
-						model: achievements.toJSON()
-					};
-					for (let i = 0; i < achievementsJSON.model.length; i++) {
-						if (unlocks.indexOf(
-									achievementsJSON.model[i].id) >= 0) {
-							achievementsJSON.model[i].unlocked = true;
+					const model = achievements.map((achievement) => {
+						achievement = achievement.toJSON();
+						if (unlocks.indexOf(achievement.id) >= 0) {
+							achievement.unlocked = true;
 						}
 						else {
-							achievementsJSON.model[i].unlocked = false;
+							achievement.unlocked = false;
 						}
-					}
+						return achievement;
+					})
+					const achievementsJSON = {
+						model
+					};
 					return achievementsJSON;
 				}
 			)

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -111,7 +111,7 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 		)
 		.then((editor) => {
 			let editorTitleUnlock;
-			if (req.body.title === 'NULL' || req.body.title === '') {
+			if (!req.body.title) {
 				editorTitleUnlock = editor.set('titleUnlockId', null);
 			}
 			else {

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -213,7 +213,7 @@ router.get('/:id/revisions', (req, res, next) => {
 				editorTitleJSON = Promise.resolve(editorJSON);
 			}
 			else {
-				editorTitleJSON = new TitleUnlock({editorId: editorJSON.id})
+				editorTitleJSON = new TitleUnlock({id: editorJSON.titleUnlockId})
 					.fetch({
 						withRelated: ['title']
 					})
@@ -264,7 +264,7 @@ router.get('/:id/achievements', (req, res, next) => {
 				editorTitleJSON = Promise.resolve(editorJSON);
 			}
 			else {
-				editorTitleJSON = new TitleUnlock({editorId: userId})
+				editorTitleJSON =  new TitleUnlock({id: editorJSON.titleUnlockId})
 					.fetch({
 						withRelated: ['title']
 					})

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -50,9 +50,7 @@ const router = express.Router();
 router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 	const editorJSONPromise = new Editor({id: parseInt(req.user.id, 10)})
 		.fetch()
-		.then((editor) =>
-			editor.toJSON()
-		);
+		.then((editor) => editor.toJSON());
 
 	const titleJSONPromise = new TitleUnlock()
 		.where({'editor_id': parseInt(req.user.id, 10)})
@@ -85,7 +83,8 @@ router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 				},
 				markup
 			});
-		})
+		}
+	)
 		.catch(next);
 });
 
@@ -112,7 +111,7 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 		)
 		.then((editor) => {
 			let editorTitleUnlock;
-			if (req.body.title === '') {
+			if (req.body.title === 'NULL' || req.body.title === '') {
 				editorTitleUnlock = editor.set('titleUnlockId', null);
 			}
 			else {

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -112,7 +112,7 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 		)
 		.then((editor) => {
 			let editorTitleUnlock;
-			if (req.body.title === 'none') {
+			if (req.body.title === '') {
 				editorTitleUnlock = editor.set('titleUnlockId', null);
 			}
 			else {

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -239,6 +239,22 @@ router.get('/:id/revisions', (req, res, next) => {
 		.catch(next);
 });
 
+function setAchievementUnlockedField(achievements, unlockIds) {
+	const model = achievements.map((achievementType) => {
+		const achievementJSON = achievementType.toJSON();
+		if (unlockIds.indexOf(achievementJSON.id) >= 0) {
+			achievementJSON.unlocked = true;
+		}
+		else {
+			achievementJSON.unlocked = false;
+		}
+		return achievementJSON;
+	});
+	return {
+		model
+	};
+}
+
 router.get('/:id/achievements', (req, res, next) => {
 	const userId = parseInt(req.params.id, 10);
 	const editorJSONPromise = new Editor({id: userId})
@@ -286,7 +302,6 @@ router.get('/:id/achievements', (req, res, next) => {
 		})
 		.catch(next);
 
-
 	const achievementJSONPromise = new AchievementUnlock()
 		.where('editor_id', userId)
 		.fetchAll()
@@ -297,23 +312,9 @@ router.get('/:id/achievements', (req, res, next) => {
 			new AchievementType()
 				.orderBy('id', 'ASC')
 				.fetchAll()
-				.then((achievements) => {
-					const model = achievements.map((achievementType) => {
-						const achievementJSON = achievementType.toJSON();
-						if (unlocks.indexOf(achievementJSON.id) >= 0) {
-							achievementJSON.unlocked = true;
-						}
-						else {
-							achievementJSON.unlocked = false;
-						}
-						return achievementJSON;
-					});
-					const achievementsJSON = {
-						model
-					};
-					return achievementsJSON;
-				}
-			)
+				.then((achievements) =>
+					setAchievementUnlockedField(achievements, unlocks)
+				)
 		);
 
 	Promise.join(achievementJSONPromise, editorJSONPromise,

--- a/test/testAchievement.js
+++ b/test/testAchievement.js
@@ -36,6 +36,7 @@ const testMarathoner = require('./testMarathoner.js');
 const testPublisher = require('./testPublisher.js');
 const testRevisionist = require('./testRevisionist.js');
 const testSprinter = require('./testSprinter.js');
+const testWorkerBee = require('./testWorkerBee.js');
 
 function tests() {
 	describe('awardAchievement', () => {
@@ -153,6 +154,7 @@ function tests() {
 	describe('Publisher Achievement', testPublisher);
 	describe('Revisionist Achievement', testRevisionist);
 	describe('Sprinter Achievement', testSprinter);
+	describe('Worker Bee Achievement', testWorkerBee);
 }
 
 describe('achievement module', tests);

--- a/test/testAchievement.js
+++ b/test/testAchievement.js
@@ -34,6 +34,7 @@ const testFunRunner = require('./testFunRunner.js');
 const testLimitedEdition = require('./testLimitedEdition.js');
 const testMarathoner = require('./testMarathoner.js');
 const testPublisher = require('./testPublisher.js');
+const testPublisherCreator = require('./testPublisherCreator.js');
 const testRevisionist = require('./testRevisionist.js');
 const testSprinter = require('./testSprinter.js');
 const testWorkerBee = require('./testWorkerBee.js');
@@ -152,6 +153,7 @@ function tests() {
 	describe('Limited Edition Achievement', testLimitedEdition);
 	describe('Marathoner Achievement', testMarathoner);
 	describe('Publisher Achievement', testPublisher);
+	describe('Publisher Creator Achievement', testPublisherCreator);
 	describe('Revisionist Achievement', testRevisionist);
 	describe('Sprinter Achievement', testSprinter);
 	describe('Worker Bee Achievement', testWorkerBee);

--- a/test/testCreatorCreator.js
+++ b/test/testCreatorCreator.js
@@ -40,9 +40,9 @@ module.exports = function tests() {
 	it('I should be given to someone with a creator revision',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'creatorRevision', creatorCreatorIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'creator_revision', creatorCreatorIThreshold
 					)
 			});
 
@@ -68,9 +68,9 @@ module.exports = function tests() {
 	it('II should be given to someone with 10 creator revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'creatorRevision', creatorCreatorIIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'creator_revision', creatorCreatorIIThreshold
 					)
 			});
 			const achievementPromise = testData.createEditor()
@@ -94,9 +94,9 @@ module.exports = function tests() {
 	it('III should be given to someone with 100 creator revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'creatorRevision', creatorCreatorIIIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'creator_revision', creatorCreatorIIIThreshold
 					)
 			});
 			const achievementPromise = testData.createEditor()
@@ -126,9 +126,9 @@ module.exports = function tests() {
 	it('should not be given to someone with 0 creator revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'creatorRevision', 0
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'creator_revision', 0
 					)
 			});
 			const achievementPromise = testData.createEditor()

--- a/test/testCreatorCreator.js
+++ b/test/testCreatorCreator.js
@@ -37,7 +37,7 @@ module.exports = function tests() {
 
 	afterEach(testData.truncate);
 
-	it('I should be given to someone with a creator revision',
+	it('I should be given to someone with a creator creation',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -65,7 +65,7 @@ module.exports = function tests() {
 		}
 	);
 
-	it('II should be given to someone with 10 creator revisions',
+	it('II should be given to someone with 10 creator creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -91,7 +91,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('III should be given to someone with 100 creator revisions',
+	it('III should be given to someone with 100 creator creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -123,7 +123,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('should not be given to someone with 0 creator revisions',
+	it('should not be given to someone with 0 creator creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:

--- a/test/testLimitedEdition.js
+++ b/test/testLimitedEdition.js
@@ -36,7 +36,7 @@ module.exports = function tests() {
 
 	afterEach(testData.truncate);
 
-	it('I should given to someone with an edition revision',
+	it('I should given to someone with an edition creation',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -64,7 +64,7 @@ module.exports = function tests() {
 		}
 	);
 
-	it('II should be given to someone with 10 edition revisions',
+	it('II should be given to someone with 10 edition creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -90,7 +90,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('III should be given to someone with 100 edition revisions',
+	it('III should be given to someone with 100 edition creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -122,7 +122,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('should not given to someone with 0 edition revisions',
+	it('should not given to someone with 0 edition creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:

--- a/test/testLimitedEdition.js
+++ b/test/testLimitedEdition.js
@@ -39,9 +39,9 @@ module.exports = function tests() {
 	it('I should given to someone with an edition revision',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'editionRevision', limitedEditionIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'edition_revision', limitedEditionIThreshold
 					)
 			});
 
@@ -67,9 +67,9 @@ module.exports = function tests() {
 	it('II should be given to someone with 10 edition revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'editionRevision', limitedEditionIIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'edition_revision', limitedEditionIIThreshold
 					)
 			});
 			const achievementPromise = testData.createEditor()
@@ -93,9 +93,9 @@ module.exports = function tests() {
 	it('III should be given to someone with 100 edition revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'editionRevision', limitedEditionIIIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'edition_revision', limitedEditionIIIThreshold
 					)
 			});
 			const achievementPromise = testData.createEditor()
@@ -125,9 +125,9 @@ module.exports = function tests() {
 	it('should not given to someone with 0 edition revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'editionRevision', 0
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'edition_revision', 0
 					)
 			});
 			const achievementPromise = testData.createEditor()

--- a/test/testPublisher.js
+++ b/test/testPublisher.js
@@ -39,9 +39,9 @@ module.exports = function tests() {
 	it('I should be given to someone with a publisher revision',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'publisherRevision', publisherIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publication_revision', publisherIThreshold
 					)
 			});
 
@@ -67,9 +67,9 @@ module.exports = function tests() {
 	it('II should be given to someone with 10 publisher revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'publisherRevision', publisherIIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publication_revision', publisherIIThreshold
 					)
 			});
 			const achievementPromise = testData.createEditor()
@@ -93,9 +93,9 @@ module.exports = function tests() {
 	it('III should be given to someone with 100 edition revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'publisherRevision', publisherIIIThreshold
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publication_revision', publisherIIIThreshold
 					)
 			});
 			const achievementPromise = testData.createEditor()
@@ -125,9 +125,9 @@ module.exports = function tests() {
 	it('should not be given to someone with 0 publisher revisions',
 		() => {
 			Achievement.__set__({
-				getTypeRevisions:
-					testData.typeRevisionHelper(
-						'publisherRevision', 0
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publication_revision', 0
 					)
 			});
 			const achievementPromise = testData.createEditor()

--- a/test/testPublisher.js
+++ b/test/testPublisher.js
@@ -36,7 +36,7 @@ module.exports = function tests() {
 
 	afterEach(testData.truncate);
 
-	it('I should be given to someone with a publisher revision',
+	it('I should be given to someone with a publication creation',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -64,7 +64,7 @@ module.exports = function tests() {
 		}
 	);
 
-	it('II should be given to someone with 10 publisher revisions',
+	it('II should be given to someone with 10 publication creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -90,7 +90,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('III should be given to someone with 100 edition revisions',
+	it('III should be given to someone with 100 publication creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -122,7 +122,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('should not be given to someone with 0 publisher revisions',
+	it('should not be given to someone with 0 publication creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:

--- a/test/testPublisherCreator.js
+++ b/test/testPublisherCreator.js
@@ -128,7 +128,7 @@ module.exports = function tests() {
 			Achievement.__set__({
 				getTypeCreation:
 					testData.typeCreationHelper(
-						'creator_revision', 0
+						'publisher_revision', 0
 					)
 			});
 			const achievementPromise = testData.createEditor()

--- a/test/testPublisherCreator.js
+++ b/test/testPublisherCreator.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016  Max Prettyjohns
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+const rewire = require('rewire');
+const Promise = require('bluebird');
+const testData = require('../data/testData.js');
+const Achievement = rewire('../src/server/helpers/achievement.js');
+
+const publisherCreatorIThreshold = 1;
+const publisherCreatorIIThreshold = 10;
+const publisherCreatorIIIThreshold = 100;
+
+
+module.exports = function tests() {
+	beforeEach(() => testData.createPublisherCreator());
+
+	afterEach(testData.truncate);
+
+	it('I should be given to someone with a publisher creation',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publisher_revision', publisherCreatorIThreshold
+					)
+			});
+
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.publisherCreator['Publisher Creator I']
+				);
+
+			return Promise.all([
+				expect(achievementPromise).to.eventually.have
+				.property('editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have
+				.property('achievementId',
+					testData.publisherCreatorIAttribs.id)
+			]);
+		}
+	);
+
+	it('II should be given to someone with 10 creator creations',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publisher_revision', publisherCreatorIIThreshold
+					)
+			});
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.publisherCreator['Publisher Creator II']
+				);
+
+			return Promise.all([
+				expect(achievementPromise).to.eventually.have
+				.property('editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have
+				.property('achievementId',
+					testData.publisherCreatorIIAttribs.id)
+			]);
+		});
+
+	it('III should be given to someone with 100 creator creations',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'publisher_revision', publisherCreatorIIIThreshold
+					)
+			});
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.publisherCreator
+				);
+
+			return Promise.all([
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Publisher Creator III.editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Publisher Creator III.achievementId',
+					testData.publisherCreatorIIIAttribs.id),
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Publisher Creator.editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Publisher Creator.titleId',
+					testData.publisherCreatorAttribs.id)
+			]);
+		});
+
+	it('should not be given to someone with 0 creator creations',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'creator_revision', 0
+					)
+			});
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.publisherCreator['Publisher Creator I']
+				);
+
+			return expect(achievementPromise).to.eventually.equal(false);
+		});
+};
+

--- a/test/testPublisherCreator.js
+++ b/test/testPublisherCreator.js
@@ -65,7 +65,7 @@ module.exports = function tests() {
 		}
 	);
 
-	it('II should be given to someone with 10 creator creations',
+	it('II should be given to someone with 10 publisher creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -91,7 +91,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('III should be given to someone with 100 creator creations',
+	it('III should be given to someone with 100 publisher creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -123,7 +123,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('should not be given to someone with 0 creator creations',
+	it('should not be given to someone with 0 publisher creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:

--- a/test/testSprinter.js
+++ b/test/testSprinter.js
@@ -39,7 +39,7 @@ module.exports = () => {
 
 	afterEach(testData.truncate);
 
-	it('should give someone with 10 revisions in an hour Sprinter', () => {
+	it('should be given to someone with 10 revisions in an hour', () => {
 		const achievementPromise = testData.sprinterHelper(sprinterThreshold)
 			.then(() => new Editor({name: testData.editorAttribs.name})
 				.fetch()
@@ -60,7 +60,7 @@ module.exports = () => {
 	});
 
 
-	it('should not give someone with 9 revisions in an hour Sprinter', () => {
+	it('should not be given to someone with 9 revisions in an hour', () => {
 		const achievementPromise =
 			testData.sprinterHelper(sprinterThreshold - 1)
 			.then(() => new Editor({name: testData.editorAttribs.name})

--- a/test/testWorkerBee.js
+++ b/test/testWorkerBee.js
@@ -37,7 +37,7 @@ module.exports = function tests() {
 
 	afterEach(testData.truncate);
 
-	it('I should be given to someone with a Work creation',
+	it('I should be given to someone with a work creation',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:
@@ -123,7 +123,7 @@ module.exports = function tests() {
 			]);
 		});
 
-	it('should not be given to someone with 0 creator creations',
+	it('should not be given to someone with 0 work creations',
 		() => {
 			Achievement.__set__({
 				getTypeCreation:

--- a/test/testWorkerBee.js
+++ b/test/testWorkerBee.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2016  Max Prettyjohns
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+'use strict';
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+const rewire = require('rewire');
+const Promise = require('bluebird');
+const testData = require('../data/testData.js');
+const Achievement = rewire('../src/server/helpers/achievement.js');
+
+const workerBeeIThreshold = 1;
+const workerBeeIIThreshold = 10;
+const workerBeeIIIThreshold = 100;
+
+
+module.exports = function tests() {
+	beforeEach(() => testData.createWorkerBee());
+
+	afterEach(testData.truncate);
+
+	it('I should be given to someone with a Work creation',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'work_revision', workerBeeIThreshold
+					)
+			});
+
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.workerBee['Worker Bee I']
+				);
+
+			return Promise.all([
+				expect(achievementPromise).to.eventually.have
+				.property('editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have
+				.property('achievementId',
+					testData.workerBeeIAttribs.id)
+			]);
+		}
+	);
+
+	it('II should be given to someone with 10 work creations',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'work_revision', workerBeeIIThreshold
+					)
+			});
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.workerBee['Worker Bee II']
+				);
+
+			return Promise.all([
+				expect(achievementPromise).to.eventually.have
+				.property('editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have
+				.property('achievementId',
+					testData.workerBeeIIAttribs.id)
+			]);
+		});
+
+	it('III should be given to someone with 100 work creations',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'work_revision', workerBeeIIIThreshold
+					)
+			});
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.workerBee
+				);
+
+			return Promise.all([
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Worker Bee III.editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Worker Bee III.achievementId',
+					testData.workerBeeIIIAttribs.id),
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Worker Bee.editorId',
+					testData.editorAttribs.id),
+				expect(achievementPromise).to.eventually.have.deep
+				.property('Worker Bee.titleId',
+					testData.workerBeeAttribs.id)
+			]);
+		});
+
+	it('should not be given to someone with 0 creator creations',
+		() => {
+			Achievement.__set__({
+				getTypeCreation:
+					testData.typeCreationHelper(
+						'work_revision', 0
+					)
+			});
+			const achievementPromise = testData.createEditor()
+				.then((editor) =>
+					Achievement.processEdit(editor.id)
+				)
+				.then((edit) =>
+					edit.workerBee['Worker Bee I']
+				);
+
+			return expect(achievementPromise).to.eventually.equal(false);
+		});
+};


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Old achievements were based on number of revisions performed, this meant someone could simply revise the same entity multiple times to get the achievement.
Old version used Select component rather than Select2 component in edit profile

### Solution
<!-- What does this PR do to fix the problem? -->
Base the achievements on creation of entities
Add Worker bee and Publisher creator achievements
Convert edit profile to Select2 component

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Achievement module
Edit Profile form
Editor Route
Achievements tests

