### PR TITLE
Generate search index automatically on server boot

### DIFF
--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -55,7 +55,7 @@ search.init = (options) => {
 
 	// Automatically index on app startup if we haven't already
 	_client.indices.exists({index: _index})
-		.then((mainIndexExists) {
+		.then((mainIndexExists) => {
 			if (mainIndexExists) {
 				return null;
 			}

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -52,6 +52,16 @@ search.init = (options) => {
 	}, options);
 
 	_client = ElasticSearch.Client(config);
+
+	// Automatically index on app startup if we haven't already
+	_client.indices.exists({index: _index})
+		.then((mainIndexExists) {
+			if (mainIndexExists) {
+				return null;
+			}
+
+			return search.generateIndex();
+		});
 };
 
 function _fetchEntityModelsForESResults(results) {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->
### Problem

<!-- What are you trying to solve? -->

Bringing up a new instance of BookBrainz currently requires the administrator to manually hit `/search/reindex`.
### Solution

<!-- What does this PR do to fix the problem? -->

When starting the BB instance, verify that the search index exists. If not, generate it.
### Areas of Impact

<!-- What parts of the codebase and which behaviors are affected? -->

Server boot, search index generation.
