### PR TITLE
Added JSDoc annotations - GCI

### DIFF
--- a/src/client/components/forms/publication.js
+++ b/src/client/components/forms/publication.js
@@ -16,7 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
+/* eslint valid-jsdoc: "warn" */
 const Icon = require('react-fontawesome');
 const React = require('react');
 const request = require('superagent-bluebird-promise');
@@ -56,12 +56,10 @@ class PublicationForm extends React.Component {
 	}
 
 	/**
-	 * Sets 'tab' state variable to the first parameter and checks if
-	 * alias form is valid, storing the result as a boolean 'aliasesValid' in
-	 * state
+	 * Changes the current tab to the one specified and checks
+	 * if the alias form is valid.
 	 *
 	 * @param {number} tab - Indicates the current tab
-	 * @returns {undefined}
 	 */
 	handleTabSelect(tab) {
 		this.setState({
@@ -71,29 +69,26 @@ class PublicationForm extends React.Component {
 	}
 
 	/**
-	 * Decrements 'tab' state variable and moves to previous tab form
+	 * Event handler that moves user to previous tab
 	 *
-	 * @returns {undefined}
 	 */
 	handleBackClick() {
 		this.handleTabSelect(this.state.tab - 1);
 	}
 
 	/**
-	 * Increments 'tab' state variable and moves to following tab form
+	 * Event handler that moves user to following tab
 	 *
-	 * @returns {undefined}
 	 */
 	handleNextClick() {
 		this.handleTabSelect(this.state.tab + 1);
 	}
 
 	/**
-	 * Extracts user input from forms, formats the changes to publisher,
-	 * and submits it to the server.
+	 * Extracts user revisions to publications and sends it to the server
+	 * to be saved
 	 *
 	 * @param {object} evt - Event object passed in by event dispatcher
-	 * @returns {undefined}
 	 */
 	handleSubmit(evt) {
 		evt.preventDefault();
@@ -140,7 +135,7 @@ class PublicationForm extends React.Component {
 	/**
 	 * Renders the component: Includes a top nav bar, 3 forms that change
 	 * visibility based the 'tab' state variable, and a loading spinner that
-	 * appears when the 'waiting' state variable is true.
+	 * appears for certain async operations
 	 *
 	 * @returns {object} - JSX to render
 	 */

--- a/src/client/components/forms/publication.js
+++ b/src/client/components/forms/publication.js
@@ -16,7 +16,8 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-/* eslint valid-jsdoc: "warn" */
+/* eslint valid-jsdoc: ["error", { "requireReturn": false }] */
+
 const Icon = require('react-fontawesome');
 const React = require('react');
 const request = require('superagent-bluebird-promise');
@@ -56,10 +57,10 @@ class PublicationForm extends React.Component {
 	}
 
 	/**
-	 * Changes the current tab to the one specified and checks
-	 * if the alias form is valid.
+	 * Changes the selected tab and refreshes validity
+	 * of aliases form into state
 	 *
-	 * @param {number} tab - Indicates the current tab
+	 * @param {number} tab - Indicates the selected tab
 	 */
 	handleTabSelect(tab) {
 		this.setState({

--- a/src/client/components/forms/publication.js
+++ b/src/client/components/forms/publication.js
@@ -30,6 +30,14 @@ const PublicationData = require('./parts/publication-data');
 const RevisionNote = require('./parts/revision-note');
 
 class PublicationForm extends React.Component {
+
+	/**
+	 * Initializes component state to default values and binds class
+	 * methods to proper context so that they can be directly invoked
+	 * without explicit binding
+	 *
+	 * @param {object} props - Properties object passed down from parents
+	 */
 	constructor(props) {
 		super(props);
 
@@ -47,21 +55,46 @@ class PublicationForm extends React.Component {
 		this.handleSubmit = this.handleSubmit.bind(this);
 	}
 
+	/**
+	 * Sets 'tab' state variable to the first parameter and checks if
+	 * alias form is valid, storing the result as a boolean 'aliasesValid' in
+	 * state
+	 *
+	 * @param {number} tab - Indicates the current tab
+	 * @returns {undefined}
+	 */
 	handleTabSelect(tab) {
 		this.setState({
 			tab,
-			aliasesValid: this.aliases.valid(),
-			dataValid: this.data.valid()
+			aliasesValid: this.aliases.valid()
 		});
 	}
+
+	/**
+	 * Decrements 'tab' state variable and moves to previous tab form
+	 *
+	 * @returns {undefined}
+	 */
 	handleBackClick() {
 		this.handleTabSelect(this.state.tab - 1);
 	}
 
+	/**
+	 * Increments 'tab' state variable and moves to following tab form
+	 *
+	 * @returns {undefined}
+	 */
 	handleNextClick() {
 		this.handleTabSelect(this.state.tab + 1);
 	}
 
+	/**
+	 * Extracts user input from forms, formats the changes to publisher,
+	 * and submits it to the server.
+	 *
+	 * @param {object} evt - Event object passed in by event dispatcher
+	 * @returns {undefined}
+	 */
 	handleSubmit(evt) {
 		evt.preventDefault();
 
@@ -104,6 +137,13 @@ class PublicationForm extends React.Component {
 			});
 	}
 
+	/**
+	 * Renders the component: Includes a top nav bar, 3 forms that change
+	 * visibility based the 'tab' state variable, and a loading spinner that
+	 * appears when the 'waiting' state variable is true.
+	 *
+	 * @returns {object} - JSX to render
+	 */
 	render() {
 		let aliases = null;
 		const prefillData = this.props.publication;

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -16,7 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-/* eslint valid-jsdoc: "warn" */
+/* eslint valid-jsdoc: ["error", { "requireReturn": false }], max-len: "warn" */
 'use strict';
 
 const Creator = require('bookbrainz-data').Creator;
@@ -28,7 +28,7 @@ const Work = require('bookbrainz-data').Work;
 const Promise = require('bluebird');
 
 /**
- * Returns an API path for interacting with the given entity object
+ * Returns an API path for interacting with the given Bookshelf entity model
  *
  * @param {object} entity - Entity object
  * @returns {string} - URL path to interact with entity
@@ -39,7 +39,7 @@ function getEntityLink(entity) {
 }
 
 /**
- * Returns all entity models defined with the Bookshelf ORM
+ * Returns all entity models defined in bookbrainz-data-js
  *
  * @returns {object} - Object mapping model name to the entity model
  */
@@ -54,7 +54,7 @@ function getEntityModels() {
 }
 
 /**
- * Retrieves a Bookshelf ORM model given the model name
+ * Retrieves the Bookshelf entity model with the given the model name
  *
  * @param {string} type - Name or type of model
  * @throws {Error} Throws a custom error if the param 'type' does not
@@ -73,7 +73,7 @@ function getEntityModelByType(type) {
 }
 
 /**
- * Regular expression for valid BookBrainz IDs
+ * Regular expression for valid BookBrainz UUIDs (bbid)
  *
  * @type {RegExp}
  * @private
@@ -82,19 +82,22 @@ const _bbidRegex =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 /**
- * Tests if a BookBrainz ID is valid
+ * Tests if a BookBrainz UUID is valid
  *
- * @param {string} bbid - BookBrainz ID to validate
- * @returns {boolean} - Returns true if BookBrainz ID is valid
+ * @param {string} bbid - BookBrainz UUID to validate
+ * @returns {boolean} - Returns true if BookBrainz UUID is valid
  */
 function isValidBBID(bbid) {
 	return _bbidRegex.test(bbid);
 }
 
 /**
- * Helper function that allows the values of an object that
+ * Helper-function / template-tag that allows the values of an object that
  * is passed in at a later time to be interpolated into a
- * string
+ * string.
+ *
+ * Cribbed from MDN documentation on template literals:
+ * https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals
  *
  * @param {string[]} strings - Array of string literals from template
  * @returns {function(*)} - Takes an object/array as an argument.
@@ -102,7 +105,6 @@ function isValidBBID(bbid) {
  * the tagged template literal replaced with their corresponding values
  * from the newly passed in object.
  */
-// Cribbed from MDN documentation on template literals
 function template(strings) {
 	const keys = Array.prototype.slice.call(arguments, 1);
 
@@ -118,7 +120,7 @@ function template(strings) {
 }
 
 /**
- * Generates a page title for an entity object
+ * Generates a page title for an entity row
  *
  * @param {object} entity - Entity object
  * @param {string} titleForUnnamed - Fallback title in case entity has no name
@@ -144,10 +146,11 @@ function createEntityPageTitle(entity, titleForUnnamed, templateForNamed) {
 }
 
 /**
- * Adds to the edit count of the specified editor
+ * Adds 1 to the edit count of the specified editor
  *
- * @param {string} id - ID of editor object/row
- * @param {object} transacting - Bookshelf transaction object
+ * @param {string} id - row ID of editor to be updated
+ * @param {object} transacting - Bookshelf transaction object (must be in
+ * progress)
  * @returns {Promise} - Resolves to the updated editor model
  */
 function incrementEditorEditCountById(id, transacting) {

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -16,7 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
+/* eslint valid-jsdoc: "warn" */
 'use strict';
 
 const Creator = require('bookbrainz-data').Creator;
@@ -29,6 +29,7 @@ const Promise = require('bluebird');
 
 /**
  * Returns an API path for interacting with the given entity object
+ *
  * @param {object} entity - Entity object
  * @returns {string} - URL path to interact with entity
  */
@@ -39,6 +40,7 @@ function getEntityLink(entity) {
 
 /**
  * Returns all entity models defined with the Bookshelf ORM
+ *
  * @returns {object} - Object mapping model name to the entity model
  */
 function getEntityModels() {
@@ -53,6 +55,7 @@ function getEntityModels() {
 
 /**
  * Retrieves a Bookshelf ORM model given the model name
+ *
  * @param {string} type - Name or type of model
  * @throws {Error} Throws a custom error if the param 'type' does not
  * map to a model
@@ -71,6 +74,7 @@ function getEntityModelByType(type) {
 
 /**
  * Regular expression for valid BookBrainz IDs
+ *
  * @type {RegExp}
  * @private
  */
@@ -79,6 +83,7 @@ const _bbidRegex =
 
 /**
  * Tests if a BookBrainz ID is valid
+ *
  * @param {string} bbid - BookBrainz ID to validate
  * @returns {boolean} - Returns true if BookBrainz ID is valid
  */
@@ -87,8 +92,10 @@ function isValidBBID(bbid) {
 }
 
 /**
- * Curried template literal tag where data object is passed in as
- * latter argument and object keys are used as template values.
+ * Helper function that allows the values of an object that
+ * is passed in at a later time to be interpolated into a
+ * string
+ *
  * @param {string[]} strings - Array of string literals from template
  * @returns {function(*)} - Takes an object/array as an argument.
  * When invoked, it will return a string with all the key names from
@@ -112,6 +119,7 @@ function template(strings) {
 
 /**
  * Generates a page title for an entity object
+ *
  * @param {object} entity - Entity object
  * @param {string} titleForUnnamed - Fallback title in case entity has no name
  * @param {function} templateForNamed - Accepts an object with a name field and
@@ -136,8 +144,8 @@ function createEntityPageTitle(entity, titleForUnnamed, templateForNamed) {
 }
 
 /**
- * Increments totalRevisions and revisionsApplied fields on the
- * bookshelf editor object/row with the specified id
+ * Adds to the edit count of the specified editor
+ *
  * @param {string} id - ID of editor object/row
  * @param {object} transacting - Bookshelf transaction object
  * @returns {Promise} - Resolves to the updated editor model
@@ -153,9 +161,9 @@ function incrementEditorEditCountById(id, transacting) {
 
 /**
  * Removes all rows from a selection of database tables
+ *
  * @param {object} Bookshelf - Bookshelf instance connected to database
  * @param {string[]} tables - List of tables to truncate
- * @returns {undefined}
  */
 function truncateTables(Bookshelf, tables) {
 	Promise.each(tables,

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -27,11 +27,20 @@ const Publisher = require('bookbrainz-data').Publisher;
 const Work = require('bookbrainz-data').Work;
 const Promise = require('bluebird');
 
+/**
+ * Returns an API path for interacting with the given entity object
+ * @param {object} entity - Entity object
+ * @returns {string} - URL path to interact with entity
+ */
 function getEntityLink(entity) {
 	const bbid = entity.bbid;
 	return `/${entity.type.toLowerCase()}/${bbid}`;
 }
 
+/**
+ * Returns all entity models defined with the Bookshelf ORM
+ * @returns {object} - Object mapping model name to the entity model
+ */
 function getEntityModels() {
 	return {
 		Creator,
@@ -42,6 +51,14 @@ function getEntityModels() {
 	};
 }
 
+/**
+ * Retrieves a Bookshelf ORM model given the model name
+ * @param {string} type - Name or type of model
+ * @throws {Error} Throws a custom error if the param 'type' does not
+ * map to a model
+ * @returns {object} - Bookshelf model object with the type specified in the
+ * single param
+ */
 function getEntityModelByType(type) {
 	const entityModels = getEntityModels();
 
@@ -52,13 +69,32 @@ function getEntityModelByType(type) {
 	return entityModels[type];
 }
 
+/**
+ * Regular expression for valid BookBrainz IDs
+ * @type {RegExp}
+ * @private
+ */
 const _bbidRegex =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
+/**
+ * Tests if a BookBrainz ID is valid
+ * @param {string} bbid - BookBrainz ID to validate
+ * @returns {boolean} - Returns true if BookBrainz ID is valid
+ */
 function isValidBBID(bbid) {
 	return _bbidRegex.test(bbid);
 }
 
+/**
+ * Curried template literal tag where data object is passed in as
+ * latter argument and object keys are used as template values.
+ * @param {string[]} strings - Array of string literals from template
+ * @returns {function(*)} - Takes an object/array as an argument.
+ * When invoked, it will return a string with all the key names from
+ * the tagged template literal replaced with their corresponding values
+ * from the newly passed in object.
+ */
 // Cribbed from MDN documentation on template literals
 function template(strings) {
 	const keys = Array.prototype.slice.call(arguments, 1);
@@ -74,6 +110,14 @@ function template(strings) {
 	};
 }
 
+/**
+ * Generates a page title for an entity object
+ * @param {object} entity - Entity object
+ * @param {string} titleForUnnamed - Fallback title in case entity has no name
+ * @param {function} templateForNamed - Accepts an object with a name field and
+ * uses it to generate a title string
+ * @returns {string} - Title string
+ */
 function createEntityPageTitle(entity, titleForUnnamed, templateForNamed) {
 	/**
 	 * User-visible strings should _never_ be created by concatenation; when we
@@ -91,6 +135,13 @@ function createEntityPageTitle(entity, titleForUnnamed, templateForNamed) {
 	return title;
 }
 
+/**
+ * Increments totalRevisions and revisionsApplied fields on the
+ * bookshelf editor object/row with the specified id
+ * @param {string} id - ID of editor object/row
+ * @param {object} transacting - Bookshelf transaction object
+ * @returns {Promise} - Resolves to the updated editor model
+ */
 function incrementEditorEditCountById(id, transacting) {
 	return new Editor({id})
 		.fetch({transacting})
@@ -100,6 +151,12 @@ function incrementEditorEditCountById(id, transacting) {
 		});
 }
 
+/**
+ * Removes all rows from a selection of database tables
+ * @param {object} Bookshelf - Bookshelf instance connected to database
+ * @param {string[]} tables - List of tables to truncate
+ * @returns {undefined}
+ */
 function truncateTables(Bookshelf, tables) {
 	Promise.each(tables,
 		(table) => Bookshelf.knex.raw(`TRUNCATE ${table} CASCADE`)


### PR DESCRIPTION
### Problem
Lack of documentation makes maintaining the project harder and puts a higher bar of entry for new developers.

### Solution
Adds JSDoc style annotations to a few files in the codebase, outlining the purpose, params, and return values.

### Areas of Impact
Annotations should not alter the behaviour of any existing code.
