### PR TITLE
Updated forms and server to support area editing

### DIFF
--- a/src/client/components/forms/creator.js
+++ b/src/client/components/forms/creator.js
@@ -75,9 +75,9 @@ class CreatorForm extends React.Component {
 		const revisionNote = this.revision.note.getValue();
 		const data = {
 			aliases: aliasData.slice(0, -1),
-			beginArea: creatorData.beginArea,
+			beginAreaId: parseInt(creatorData.beginArea, 10),
 			beginDate: creatorData.beginDate,
-			endArea: creatorData.endArea,
+			endAreaId: parseInt(creatorData.endArea, 10),
 			endDate: creatorData.endDate,
 			ended: creatorData.ended,
 			genderId: parseInt(creatorData.gender, 10),
@@ -87,6 +87,7 @@ class CreatorForm extends React.Component {
 			identifiers: creatorData.identifiers,
 			note: revisionNote
 		};
+		console.log(data);
 
 		this.setState({waiting: true});
 

--- a/src/client/components/forms/creator.js
+++ b/src/client/components/forms/creator.js
@@ -87,7 +87,6 @@ class CreatorForm extends React.Component {
 			identifiers: creatorData.identifiers,
 			note: revisionNote
 		};
-		console.log(data);
 
 		this.setState({waiting: true});
 

--- a/src/client/components/forms/creator.js
+++ b/src/client/components/forms/creator.js
@@ -75,7 +75,9 @@ class CreatorForm extends React.Component {
 		const revisionNote = this.revision.note.getValue();
 		const data = {
 			aliases: aliasData.slice(0, -1),
+			beginArea: creatorData.beginArea,
 			beginDate: creatorData.beginDate,
+			endArea: creatorData.endArea,
 			endDate: creatorData.endDate,
 			ended: creatorData.ended,
 			genderId: parseInt(creatorData.gender, 10),

--- a/src/client/components/forms/parts/creator-data.js
+++ b/src/client/components/forms/parts/creator-data.js
@@ -16,6 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+/* eslint no-return-assign: 0 */
 
 const Icon = require('react-fontawesome');
 const React = require('react');
@@ -25,6 +26,7 @@ const Input = require('react-bootstrap').Input;
 const Identifiers = require('./identifier-list');
 const PartialDate = require('../../input/partial-date');
 const Select = require('../../input/select2');
+const SearchSelect = require('../../input/entity-search');
 
 const validators = require('../../../helpers/react-validators');
 
@@ -42,7 +44,9 @@ class CreatorData extends React.Component {
 
 	getValue() {
 		return {
+			beginArea: this.beginArea.getValue(),
 			beginDate: this.begin.getValue(),
+			endArea: this.endArea.getValue(),
 			endDate: this.ended.getChecked() ? this.end.getValue() : '',
 			ended: this.ended.getChecked(),
 			gender: this.gender.getValue(),
@@ -64,8 +68,10 @@ class CreatorData extends React.Component {
 	}
 
 	render() {
+		let initialBeginArea = null;
 		let initialBeginDate = null;
 		let initialEndDate = null;
+		let initialEndArea = null;
 		let initialGender = null;
 		let initialCreatorType = null;
 		let initialDisambiguation = null;
@@ -74,7 +80,9 @@ class CreatorData extends React.Component {
 
 		const prefillData = this.props.creator;
 		if (prefillData) {
+			initialBeginArea = prefillData.beginArea;
 			initialBeginDate = prefillData.beginDate;
+			initialEndArea = prefillData.endArea;
 			initialEndDate = prefillData.endDate;
 			initialGender = prefillData.gender ?
 				prefillData.gender.id : null;
@@ -153,6 +161,28 @@ class CreatorData extends React.Component {
 						options={this.props.creatorTypes}
 						placeholder="Select creator type…"
 						ref={(ref) => this.creatorType = ref}
+						select2Options={select2Options}
+						wrapperClassName="col-md-4"
+					/>
+					<SearchSelect
+						noDefault
+						collection="area"
+						defaultValue={initialBeginArea}
+						label="Begin Area"
+						labelClassName="col-md-4"
+						placeholder="Select begin area..."
+						ref={(ref) => this.beginArea = ref}
+						select2Options={select2Options}
+						wrapperClassName="col-md-4"
+					/>
+					<SearchSelect
+						noDefault
+						collection="area"
+						defaultValue={initialEndArea}
+						label="End Area"
+						labelClassName="col-md-4"
+						placeholder="Select end area..."
+						ref={(ref) => this.endArea = ref}
 						select2Options={select2Options}
 						wrapperClassName="col-md-4"
 					/>

--- a/src/client/components/forms/parts/creator-data.js
+++ b/src/client/components/forms/parts/creator-data.js
@@ -80,9 +80,11 @@ class CreatorData extends React.Component {
 
 		const prefillData = this.props.creator;
 		if (prefillData) {
-			initialBeginArea = prefillData.beginArea;
+			initialBeginArea = prefillData.beginArea ?
+				prefillData.beginArea.id : null;
 			initialBeginDate = prefillData.beginDate;
-			initialEndArea = prefillData.endArea;
+			initialEndArea = prefillData.endArea ?
+				prefillData.endArea.id : null;
 			initialEndDate = prefillData.endDate;
 			initialGender = prefillData.gender ?
 				prefillData.gender.id : null;
@@ -246,7 +248,9 @@ class CreatorData extends React.Component {
 CreatorData.displayName = 'CreatorData';
 CreatorData.propTypes = {
 	creator: React.PropTypes.shape({
+		beginArea: validators.labeledProperty,
 		beginDate: React.PropTypes.string,
+		endArea: validators.labeledProperty,
 		endDate: React.PropTypes.string,
 		ended: React.PropTypes.bool,
 		gender: validators.namedProperty,

--- a/src/client/components/forms/parts/publisher-data.js
+++ b/src/client/components/forms/parts/publisher-data.js
@@ -16,6 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+/* eslint no-return-assign: 0 */
 
 const Icon = require('react-fontawesome');
 const React = require('react');
@@ -25,6 +26,7 @@ const Input = require('react-bootstrap').Input;
 const Identifiers = require('./identifier-list');
 const PartialDate = require('../../input/partial-date');
 const Select = require('../../input/select2');
+const SearchSelect = require('../../input/entity-search');
 
 const validators = require('../../../helpers/react-validators');
 
@@ -42,6 +44,7 @@ class PublisherData extends React.Component {
 
 	getValue() {
 		return {
+			area: this.area.getValue(),
 			beginDate: this.begin.getValue(),
 			endDate: this.ended.getChecked() ? this.end.getValue() : '',
 			ended: this.ended.getChecked(),
@@ -63,6 +66,7 @@ class PublisherData extends React.Component {
 	}
 
 	render() {
+		let initialArea = null;
 		let initialBeginDate = null;
 		let initialEndDate = null;
 		let initialPublisherType = null;
@@ -72,6 +76,7 @@ class PublisherData extends React.Component {
 
 		const prefillData = this.props.publisher;
 		if (prefillData) {
+			initialArea = prefillData.area;
 			initialBeginDate = prefillData.beginDate;
 			initialEndDate = prefillData.endDate;
 			initialPublisherType = prefillData.publisherType ?
@@ -136,6 +141,17 @@ class PublisherData extends React.Component {
 						options={this.props.publisherTypes}
 						placeholder="Select publisher type…"
 						ref={(ref) => this.publisherType = ref}
+						select2Options={select2Options}
+						wrapperClassName="col-md-4"
+					/>
+					<SearchSelect
+						noDefault
+						collection="area"
+						defaultValue={initialArea}
+						label="Area"
+						labelClassName="col-md-4"
+						placeholder="Select area..."
+						ref={(ref) => this.area = ref}
 						select2Options={select2Options}
 						wrapperClassName="col-md-4"
 					/>

--- a/src/client/components/forms/parts/publisher-data.js
+++ b/src/client/components/forms/parts/publisher-data.js
@@ -76,7 +76,8 @@ class PublisherData extends React.Component {
 
 		const prefillData = this.props.publisher;
 		if (prefillData) {
-			initialArea = prefillData.area;
+			initialArea = prefillData.area ?
+				prefillData.area.id : null;
 			initialBeginDate = prefillData.beginDate;
 			initialEndDate = prefillData.endDate;
 			initialPublisherType = prefillData.publisherType ?
@@ -216,6 +217,7 @@ PublisherData.displayName = 'PublisherData';
 PublisherData.propTypes = {
 	identifierTypes: React.PropTypes.arrayOf(validators.labeledProperty),
 	publisher: React.PropTypes.shape({
+		area: validators.labeledProperty,
 		annotation: React.PropTypes.shape({
 			content: React.PropTypes.string
 		}),

--- a/src/client/components/forms/parts/relationship-row.js
+++ b/src/client/components/forms/parts/relationship-row.js
@@ -238,6 +238,7 @@ class RelationshipRow extends React.Component {
 			<SearchSelect
 				standalone
 				bsStyle={validationState}
+				collection={this.props.collection}
 				disabled={
 				this.disabled() || this.state.deleted ||
 				(targetEntity && targetEntity.bbid) ===
@@ -356,6 +357,7 @@ class RelationshipRow extends React.Component {
 
 RelationshipRow.displayName = 'RelationshipRow';
 RelationshipRow.propTypes = {
+	collection: React.PropTypes.string,
 	entity: React.PropTypes.shape({
 		bbid: React.PropTypes.string
 	}),

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -66,7 +66,6 @@ class ProfileForm extends React.Component {
 	}
 
 	render() {
-		console.log(this.props);
 		const loadingElement =
 			this.state.waiting ? <LoadingSpinner/> : null;
 		const titles = this.props.titles.map((unlock) => {

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -25,6 +25,7 @@ const Input = require('react-bootstrap').Input;
 
 const LoadingSpinner = require('../loading-spinner');
 const Select = require('../input/select2');
+const SearchSelect = require('../input/entity-search');
 
 class ProfileForm extends React.Component {
 	constructor(props) {
@@ -33,6 +34,7 @@ class ProfileForm extends React.Component {
 		this.state = {
 			bio: this.props.editor.bio,
 			title: toString(this.props.editor.titleUnlockId),
+			area: this.props.editor.area,
 			waiting: false
 		};
 
@@ -43,6 +45,7 @@ class ProfileForm extends React.Component {
 	handleSubmit(evt) {
 		evt.preventDefault();
 		const data = {
+			area: this.area.getValue(),
 			id: this.props.editor.id,
 			bio: this.bio.getValue().trim()
 		};
@@ -50,7 +53,6 @@ class ProfileForm extends React.Component {
 		if (title !== '') {
 			data.title = title;
 		}
-
 		this.setState({waiting: true});
 
 		request.post('/editor/edit/handler')
@@ -90,6 +92,16 @@ class ProfileForm extends React.Component {
 					options={titles}
 					placeholder="Select title"
 					ref={(ref) => this.title = ref}
+					wrapperClassName="col-md-4"
+				/>
+				<SearchSelect
+					noDefault
+					collection="area"
+					defaultValue={this.state.area}
+					label="Area"
+					labelClassName="col-md-4"
+					placeholder="Select area..."
+					ref={(ref) => this.area = ref}
 					wrapperClassName="col-md-4"
 				/>
 				<div className="form-group">

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -27,6 +27,8 @@ const LoadingSpinner = require('../loading-spinner');
 const Select = require('../input/select2');
 const SearchSelect = require('../input/entity-search');
 
+const validators = require('../../helpers/react-validators');
+
 class ProfileForm extends React.Component {
 	constructor(props) {
 		super(props);
@@ -34,7 +36,8 @@ class ProfileForm extends React.Component {
 		this.state = {
 			bio: this.props.editor.bio,
 			title: toString(this.props.editor.titleUnlockId),
-			area: this.props.editor.area,
+			area: this.props.editor.area ?
+				this.props.editor.area.id : null,
 			waiting: false
 		};
 
@@ -45,7 +48,7 @@ class ProfileForm extends React.Component {
 	handleSubmit(evt) {
 		evt.preventDefault();
 		const data = {
-			area: this.area.getValue(),
+			areaId: parseInt(this.area.getValue(), 10),
 			id: this.props.editor.id,
 			bio: this.bio.getValue().trim()
 		};
@@ -63,6 +66,7 @@ class ProfileForm extends React.Component {
 	}
 
 	render() {
+		console.log(this.props);
 		const loadingElement =
 			this.state.waiting ? <LoadingSpinner/> : null;
 		const titles = this.props.titles.map((unlock) => {
@@ -123,7 +127,12 @@ class ProfileForm extends React.Component {
 
 ProfileForm.displayName = 'ProfileForm';
 ProfileForm.propTypes = {
-	editor: React.PropTypes.object,
+	editor: React.PropTypes.shape({
+		id: React.PropTypes.number,
+		area: validators.labeledProperty,
+		bio: React.PropTypes.string,
+		titleUnlockId: React.PropTypes.number
+	}),
 	titles: React.PropTypes.array
 };
 

--- a/src/client/components/forms/publisher.js
+++ b/src/client/components/forms/publisher.js
@@ -74,7 +74,7 @@ class PublisherForm extends React.Component {
 		const publisherData = this.data.getValue();
 		const revisionNote = this.revision.note.getValue();
 		const data = {
-			area: publisherData.area,
+			areaId: parseInt(publisherData.area, 10),
 			aliases: aliasData.slice(0, -1),
 			beginDate: publisherData.beginDate,
 			endDate: publisherData.endDate,

--- a/src/client/components/forms/publisher.js
+++ b/src/client/components/forms/publisher.js
@@ -74,6 +74,7 @@ class PublisherForm extends React.Component {
 		const publisherData = this.data.getValue();
 		const revisionNote = this.revision.note.getValue();
 		const data = {
+			area: publisherData.area,
 			aliases: aliasData.slice(0, -1),
 			beginDate: publisherData.beginDate,
 			endDate: publisherData.endDate,

--- a/src/client/components/forms/relationship.js
+++ b/src/client/components/forms/relationship.js
@@ -295,6 +295,7 @@ class RelationshipEditor extends React.Component {
 
 RelationshipEditor.displayName = 'RelationshipEditor';
 RelationshipEditor.propTypes = {
+	collection: React.PropTypes.string,
 	entity: React.PropTypes.shape({
 		bbid: React.PropTypes.string
 	}),

--- a/src/client/components/input/entity-search.js
+++ b/src/client/components/input/entity-search.js
@@ -171,9 +171,11 @@ class EntitySearch extends React.Component {
 	}
 }
 
+
 EntitySearch.displayName = 'EntitySearch';
 EntitySearch.propTypes = {
 	bsStyle: React.PropTypes.string,
+	collection: React.PropTypes.string,
 	defaultValue: React.PropTypes.shape({
 		bbid: React.PropTypes.string
 	}),

--- a/src/client/components/input/entity-search.js
+++ b/src/client/components/input/entity-search.js
@@ -171,7 +171,6 @@ class EntitySearch extends React.Component {
 	}
 }
 
-
 EntitySearch.displayName = 'EntitySearch';
 EntitySearch.propTypes = {
 	bsStyle: React.PropTypes.string,

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -26,6 +26,7 @@ const _ = require('lodash');
 const Publication = require('bookbrainz-data').Publication;
 const Creator = require('bookbrainz-data').Creator;
 const Edition = require('bookbrainz-data').Edition;
+const Editor = require('bookbrainz-data').Editor;
 const Work = require('bookbrainz-data').Work;
 const Publisher = require('bookbrainz-data').Publisher;
 
@@ -129,6 +130,7 @@ search.indexEntity = (entity) =>
 		body: entity
 	});
 
+
 search.refreshIndex = () =>
 	_client.indices.refresh({index: _index});
 
@@ -207,6 +209,7 @@ search.generateIndex = () => {
 				throw err;
 			}
 		})
+		// GOTCHA: index creation is buggy
 		.then(() => _client.indices.create(
 			{index: _index, body: indexMappings}
 		))
@@ -218,7 +221,9 @@ search.generateIndex = () => {
 			];
 
 			const entityBehaviors = [
-				{model: Creator, relations: ['gender', 'creatorType']},
+				{model: Creator,
+					relations:
+						['gender', 'creatorType', 'beginArea', 'endArea']},
 				{
 					model: Edition,
 					relations: [
@@ -228,7 +233,7 @@ search.generateIndex = () => {
 					]
 				},
 				{model: Publication, relations: ['publicationType']},
-				{model: Publisher, relations: ['publisherType']},
+				{model: Publisher, relations: ['publisherType', 'area']},
 				{model: Work, relations: ['workType']}
 			];
 

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -26,7 +26,6 @@ const _ = require('lodash');
 const Publication = require('bookbrainz-data').Publication;
 const Creator = require('bookbrainz-data').Creator;
 const Edition = require('bookbrainz-data').Edition;
-const Editor = require('bookbrainz-data').Editor;
 const Work = require('bookbrainz-data').Work;
 const Publisher = require('bookbrainz-data').Publisher;
 
@@ -130,7 +129,6 @@ search.indexEntity = (entity) =>
 		body: entity
 	});
 
-
 search.refreshIndex = () =>
 	_client.indices.refresh({index: _index});
 
@@ -210,6 +208,7 @@ search.generateIndex = () => {
 			}
 		})
 		// GOTCHA: index creation is buggy
+		// https://tickets.metabrainz.org/browse/BB-205
 		.then(() => _client.indices.create(
 			{index: _index, body: indexMappings}
 		))

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -136,7 +136,7 @@ router.get('/:id', (req, res, next) => {
 	const editorJSONPromise = new Editor({id: userId})
 		.fetch({
 			require: true,
-			withRelated: ['type', 'gender']
+			withRelated: ['type', 'gender', 'area']
 		})
 		.then((editordata) => {
 			let editorJSON = editordata.toJSON();
@@ -264,7 +264,7 @@ router.get('/:id/achievements', (req, res, next) => {
 	const editorJSONPromise = new Editor({id: userId})
 		.fetch({
 			require: true,
-			withRelated: ['type', 'gender']
+			withRelated: ['type', 'gender', 'area']
 		})
 		.then((editordata) => {
 			let editorJSON = editordata.toJSON();
@@ -377,7 +377,7 @@ router.post('/:id/achievements/', auth.isAuthenticated, (req, res) => {
 	const editorPromise = new Editor({id: userId})
 		.fetch({
 			require: true,
-			withRelated: ['type', 'gender']
+			withRelated: ['type', 'gender', 'area']
 		})
 		.then((editordata) => {
 			let editorJSON;

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -120,6 +120,10 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 			return editorTitleUnlock.save();
 		})
 		.then((editor) =>
+			editor.set('areaId', req.body.areaId)
+				.save()
+		)
+		.then((editor) =>
 			editor.toJSON()
 		);
 

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -136,7 +136,8 @@ router.get('/:bbid/edit', auth.isAuthenticated, loadIdentifierTypes,
 );
 
 const additionalCreatorProps = [
-	'typeId', 'genderId', 'areaId', 'beginDate', 'endDate', 'ended'
+	'typeId', 'genderId', 'beginAreaId', 'beginDate', 'endDate', 'ended',
+	'endAreaId'
 ];
 
 router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) =>

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -54,7 +54,7 @@ router.param(
 	'bbid',
 	makeEntityLoader(
 		Creator,
-		['creatorType', 'gender'],
+		['creatorType', 'gender', 'beginArea', 'endArea'],
 		'Creator not found'
 	)
 );

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -54,7 +54,7 @@ router.param(
 	'bbid',
 	makeEntityLoader(
 		Publisher,
-		['publisherType'],
+		['publisherType', 'area'],
 		'Publisher not found'
 	)
 );


### PR DESCRIPTION
### Problem
The site does not include a way to modify location-based fields.

### Solution
- Allows EntitySearch component to have its search narrowed down to a particular collection
- Builds on top of the existing schema support for areas to add additional area input components into forms that require it. Also modifying the data sent up to the server to include the results from the new inputs.
- Modifies the server-side entity edit handlers to accept the new area fields
- Adds area relations into a few indexed entity models

### Areas of Impact
This PR affects a few client-side forms, server indexing code, and entity edit handlers.

### Gotchas
- Current indexing code is buggy
- Error is thrown when edit handler of Creator entity is requested without any of its data being changed (successfully replicated on live site).
    - **UPDATE**: is this intended behaviour? https://github.com/bookbrainz/bookbrainz-site/blob/master/src/server/routes/entity/entity.js#L724

