### PR TITLE
area-fixes-Daniel-Hsing

### DIFF
--- a/src/client/components/forms/parts/creator-data.js
+++ b/src/client/components/forms/parts/creator-data.js
@@ -47,7 +47,6 @@ class CreatorData extends React.Component {
 	getValue() {
 		const beginArea = this.beginArea.getValue();
 		const endArea = this.endArea.getValue();
-
 		return {
 			beginArea: beginArea ? beginArea.id : null,
 			beginDate: this.begin.getValue(),
@@ -84,7 +83,6 @@ class CreatorData extends React.Component {
 		let initialIdentifiers = [];
 
 		const prefillData = this.props.creator;
-
 		if (prefillData) {
 			if (prefillData.beginArea) {
 				initialBeginArea = prefillData.beginArea;
@@ -92,7 +90,6 @@ class CreatorData extends React.Component {
 			if (prefillData.endArea) {
 				initialEndArea = prefillData.endArea;
 			}
-
 			initialBeginDate = prefillData.beginDate;
 			initialEndDate = prefillData.endDate;
 			initialGender = prefillData.gender ?

--- a/src/client/components/forms/parts/creator-data.js
+++ b/src/client/components/forms/parts/creator-data.js
@@ -29,6 +29,8 @@ const Select = require('../../input/select2');
 const SearchSelect = require('../../input/entity-search');
 
 const validators = require('../../../helpers/react-validators');
+const injectDefaultAliasName =
+	require('../../../helpers/utils').injectDefaultAliasName;
 
 class CreatorData extends React.Component {
 	constructor(props) {
@@ -43,10 +45,13 @@ class CreatorData extends React.Component {
 	}
 
 	getValue() {
+		const beginArea = this.beginArea.getValue();
+		const endArea = this.endArea.getValue();
+
 		return {
-			beginArea: this.beginArea.getValue(),
+			beginArea: beginArea ? beginArea.id : null,
 			beginDate: this.begin.getValue(),
-			endArea: this.endArea.getValue(),
+			endArea: endArea ? endArea.id : null,
 			endDate: this.ended.getChecked() ? this.end.getValue() : '',
 			ended: this.ended.getChecked(),
 			gender: this.gender.getValue(),
@@ -79,12 +84,18 @@ class CreatorData extends React.Component {
 		let initialIdentifiers = [];
 
 		const prefillData = this.props.creator;
+
+		console.log(prefillData);
+
 		if (prefillData) {
-			initialBeginArea = prefillData.beginArea ?
-				prefillData.beginArea.id : null;
+			if (prefillData.beginArea) {
+				initialBeginArea = prefillData.beginArea;
+			}
+			if (prefillData.endArea) {
+				initialEndArea = prefillData.endArea;
+			}
+
 			initialBeginDate = prefillData.beginDate;
-			initialEndArea = prefillData.endArea ?
-				prefillData.endArea.id : null;
 			initialEndDate = prefillData.endDate;
 			initialGender = prefillData.gender ?
 				prefillData.gender.id : null;
@@ -169,7 +180,7 @@ class CreatorData extends React.Component {
 					<SearchSelect
 						noDefault
 						collection="area"
-						defaultValue={initialBeginArea}
+						defaultValue={injectDefaultAliasName(initialBeginArea)}
 						label="Begin Area"
 						labelClassName="col-md-4"
 						placeholder="Select begin area..."
@@ -180,7 +191,7 @@ class CreatorData extends React.Component {
 					<SearchSelect
 						noDefault
 						collection="area"
-						defaultValue={initialEndArea}
+						defaultValue={injectDefaultAliasName(initialEndArea)}
 						label="End Area"
 						labelClassName="col-md-4"
 						placeholder="Select end area..."

--- a/src/client/components/forms/parts/creator-data.js
+++ b/src/client/components/forms/parts/creator-data.js
@@ -85,8 +85,6 @@ class CreatorData extends React.Component {
 
 		const prefillData = this.props.creator;
 
-		console.log(prefillData);
-
 		if (prefillData) {
 			if (prefillData.beginArea) {
 				initialBeginArea = prefillData.beginArea;

--- a/src/client/components/forms/parts/publisher-data.js
+++ b/src/client/components/forms/parts/publisher-data.js
@@ -29,6 +29,8 @@ const Select = require('../../input/select2');
 const SearchSelect = require('../../input/entity-search');
 
 const validators = require('../../../helpers/react-validators');
+const injectDefaultAliasName =
+	require('../../../helpers/utils').injectDefaultAliasName;
 
 class PublisherData extends React.Component {
 	constructor(props) {
@@ -43,8 +45,10 @@ class PublisherData extends React.Component {
 	}
 
 	getValue() {
+		const area = this.area.getValue();
+
 		return {
-			area: this.area.getValue(),
+			area: area ? area.id : null,
 			beginDate: this.begin.getValue(),
 			endDate: this.ended.getChecked() ? this.end.getValue() : '',
 			ended: this.ended.getChecked(),
@@ -76,8 +80,10 @@ class PublisherData extends React.Component {
 
 		const prefillData = this.props.publisher;
 		if (prefillData) {
-			initialArea = prefillData.area ?
-				prefillData.area.id : null;
+			if (prefillData.area) {
+				initialArea = prefillData.area;
+			}
+
 			initialBeginDate = prefillData.beginDate;
 			initialEndDate = prefillData.endDate;
 			initialPublisherType = prefillData.publisherType ?
@@ -148,7 +154,7 @@ class PublisherData extends React.Component {
 					<SearchSelect
 						noDefault
 						collection="area"
-						defaultValue={initialArea}
+						defaultValue={injectDefaultAliasName(initialArea)}
 						label="Area"
 						labelClassName="col-md-4"
 						placeholder="Select area..."

--- a/src/client/components/forms/parts/publisher-data.js
+++ b/src/client/components/forms/parts/publisher-data.js
@@ -46,7 +46,6 @@ class PublisherData extends React.Component {
 
 	getValue() {
 		const area = this.area.getValue();
-
 		return {
 			area: area ? area.id : null,
 			beginDate: this.begin.getValue(),
@@ -83,7 +82,6 @@ class PublisherData extends React.Component {
 			if (prefillData.area) {
 				initialArea = prefillData.area;
 			}
-
 			initialBeginDate = prefillData.beginDate;
 			initialEndDate = prefillData.endDate;
 			initialPublisherType = prefillData.publisherType ?

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -28,6 +28,8 @@ const Select = require('../input/select2');
 const SearchSelect = require('../input/entity-search');
 
 const validators = require('../../helpers/react-validators');
+const injectDefaultAliasName =
+	require('../../helpers/utils').injectDefaultAliasName;
 
 class ProfileForm extends React.Component {
 	constructor(props) {
@@ -37,7 +39,7 @@ class ProfileForm extends React.Component {
 			bio: this.props.editor.bio,
 			title: toString(this.props.editor.titleUnlockId),
 			area: this.props.editor.area ?
-				this.props.editor.area.id : null,
+				this.props.editor.area : null,
 			waiting: false
 		};
 
@@ -47,8 +49,10 @@ class ProfileForm extends React.Component {
 
 	handleSubmit(evt) {
 		evt.preventDefault();
+		const area = this.area.getValue();
+
 		const data = {
-			areaId: parseInt(this.area.getValue(), 10),
+			areaId: area ? parseInt(area.id, 10) : null,
 			id: this.props.editor.id,
 			bio: this.bio.getValue().trim()
 		};
@@ -56,7 +60,6 @@ class ProfileForm extends React.Component {
 		if (title !== '') {
 			data.title = title;
 		}
-		this.setState({waiting: true});
 
 		request.post('/editor/edit/handler')
 			.send(data).promise()
@@ -73,6 +76,12 @@ class ProfileForm extends React.Component {
 			title.unlockId = unlock.id;
 			return title;
 		});
+		const select2Options = {
+			width: "100%",
+			allowClear: true
+		};
+
+
 		return (
 			<form
 				className="form-horizontal"
@@ -100,11 +109,12 @@ class ProfileForm extends React.Component {
 				<SearchSelect
 					noDefault
 					collection="area"
-					defaultValue={this.state.area}
+					defaultValue={injectDefaultAliasName(this.state.area)}
 					label="Area"
 					labelClassName="col-md-4"
 					placeholder="Select area..."
 					ref={(ref) => this.area = ref}
+					select2Options={select2Options}
 					wrapperClassName="col-md-4"
 				/>
 				<div className="form-group">

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -50,7 +50,6 @@ class ProfileForm extends React.Component {
 	handleSubmit(evt) {
 		evt.preventDefault();
 		const area = this.area.getValue();
-
 		const data = {
 			areaId: area ? parseInt(area.id, 10) : null,
 			id: this.props.editor.id,
@@ -80,8 +79,6 @@ class ProfileForm extends React.Component {
 			width: '100%',
 			allowClear: true
 		};
-
-
 		return (
 			<form
 				className="form-horizontal"

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -77,7 +77,7 @@ class ProfileForm extends React.Component {
 			return title;
 		});
 		const select2Options = {
-			width: "100%",
+			width: '100%',
 			allowClear: true
 		};
 

--- a/src/client/components/input/entity-search.js
+++ b/src/client/components/input/entity-search.js
@@ -105,7 +105,8 @@ class EntitySearch extends React.Component {
 					Edition: 'book',
 					Publication: 'th-list',
 					Publisher: 'university',
-					Work: 'file-text-o'
+					Work: 'file-text-o',
+					Area: 'globe'
 				};
 
 				/* eslint prefer-template: 0 */

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -33,20 +33,26 @@ function SearchResults(props) {
 		);
 	}
 
-	const results = props.results.map((result) => (
-		<tr key={result.bbid}>
-			<td>
-				<a href={`/${result.type.toLowerCase()}/${result.bbid}`}>
-					{result.defaultAlias ?
-						result.defaultAlias.name : '(unnamed)'
-					}
-				</a>
-			</td>
-			<td>
-				{result.type}
-			</td>
-		</tr>
-	));
+	const results = props.results.map((result) => {
+		// No redirect link for Area entity results
+		const name = result.defaultAlias ? result.defaultAlias.name :
+			'(unnamed)';
+		const alias = result.type === 'Area' ? name :
+			<a href={`/${result.type.toLowerCase()}/${result.bbid}`}>
+				{name}
+			</a>;
+
+		return (
+			<tr key={result.bbid}>
+				<td>
+					{alias}
+				</td>
+				<td>
+					{result.type}
+				</td>
+			</tr>
+		);
+	});
 
 	return (
 		<Table

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -37,15 +37,16 @@ function SearchResults(props) {
 		// No redirect link for Area entity results
 		const name = result.defaultAlias ? result.defaultAlias.name :
 			'(unnamed)';
-		const alias = result.type === 'Area' ? name :
-			<a href={`/${result.type.toLowerCase()}/${result.bbid}`}>
-				{name}
-			</a>;
+		const link = result.type === 'Area' ?
+			`//musicbrainz.org/area/${result.bbid}` :
+			`/${result.type.toLowerCase()}/${result.bbid}`;
 
 		return (
 			<tr key={result.bbid}>
 				<td>
-					{alias}
+					<a href={link}>
+						{name}
+					</a>
 				</td>
 				<td>
 					{result.type}

--- a/src/client/helpers/utils.js
+++ b/src/client/helpers/utils.js
@@ -1,13 +1,17 @@
-'use strict';
-
+/**
+ * Injects entity model object with a default alias name property.
+ *
+ * @param {object} instance - Entity object.
+ * @returns {object} - New object with injected properties.
+ */
 function injectDefaultAliasName(instance) {
+	'use strict';
 	if (instance && instance.name) {
-		const injectedObj = Object.assign({}, instance, {
+		return Object.assign({}, instance, {
 			defaultAlias: {
 				name: instance.name
 			}
 		});
-		return injectedObj;
 	}
 	return instance;
 }

--- a/src/client/helpers/utils.js
+++ b/src/client/helpers/utils.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function injectDefaultAliasName(instance) {
+	if (instance && instance.name) {
+		const injectedObj = Object.assign({}, instance, {
+			defaultAlias: {
+				name: instance.name
+			}
+		});
+		return injectedObj;
+	}
+	return instance;
+}
+
+exports.injectDefaultAliasName = injectDefaultAliasName;

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -23,6 +23,7 @@ const Promise = require('bluebird');
 const ElasticSearch = require('elasticsearch');
 const _ = require('lodash');
 
+const Area = require('bookbrainz-data').Area;
 const Publication = require('bookbrainz-data').Publication;
 const Creator = require('bookbrainz-data').Creator;
 const Edition = require('bookbrainz-data').Edition;
@@ -71,11 +72,26 @@ function _fetchEntityModelsForESResults(results) {
 
 	return Promise.map(results.hits, (hit) => {
 		const entityStub = hit._source;
-		const model = utils.getEntityModelByType(entityStub.type);
 
+		if (entityStub.type === 'Area') {
+			return Area.forge({bbid: entityStub.bbid})
+				.where({gid: entityStub.bbid})
+				.fetch()
+				.then((area) => {
+					const areaJSON = area.toJSON();
+					areaJSON.defaultAlias = {
+						name: areaJSON.name
+					};
+					areaJSON.type = 'Area';
+					return areaJSON;
+				});
+		}
+		const model = utils.getEntityModelByType(entityStub.type);
 		return model.forge({bbid: entityStub.bbid})
 			.fetch({withRelated: ['defaultAlias']})
 			.then((entity) => entity.toJSON());
+
+
 	});
 }
 
@@ -121,6 +137,20 @@ search.autocomplete = (query, collection) => {
 	return _searchForEntities(dslQuery);
 };
 
+search.indexArea = (area) =>
+	_client.index({
+		index: _index,
+		id: area.gid,
+		type: 'area',
+		body: {
+			defaultAlias: {
+				name: area.name
+			},
+			bbid: area.gid,
+			type: 'Area'
+		}
+	});
+
 search.indexEntity = (entity) =>
 	_client.index({
 		index: _index,
@@ -128,6 +158,7 @@ search.indexEntity = (entity) =>
 		type: entity.type.toLowerCase(),
 		body: entity
 	});
+
 
 search.refreshIndex = () =>
 	_client.indices.refresh({index: _index});
@@ -246,6 +277,14 @@ search.generateIndex = () => {
 					.map(search.indexEntity)
 			);
 		})
+		.then(() =>
+			 Promise.all(Area.forge()
+				 // countries only
+				.where({type: 1})
+				.fetchAll()
+				.then((collection) => collection.toJSON())
+				.map(search.indexArea)
+		))
 		.then(search.refreshIndex);
 };
 

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -157,7 +157,6 @@ search.indexEntity = (entity) =>
 		body: entity
 	});
 
-
 search.refreshIndex = () =>
 	_client.indices.refresh({index: _index});
 

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -90,8 +90,6 @@ function _fetchEntityModelsForESResults(results) {
 		return model.forge({bbid: entityStub.bbid})
 			.fetch({withRelated: ['defaultAlias']})
 			.then((entity) => entity.toJSON());
-
-
 	});
 }
 

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -74,8 +74,7 @@ function _fetchEntityModelsForESResults(results) {
 		const entityStub = hit._source;
 
 		if (entityStub.type === 'Area') {
-			return Area.forge({bbid: entityStub.bbid})
-				.where({gid: entityStub.bbid})
+			return Area.forge({gid: entityStub.bbid})
 				.fetch()
 				.then((area) => {
 					const areaJSON = area.toJSON();
@@ -275,13 +274,14 @@ search.generateIndex = () => {
 			);
 		})
 		.then(() =>
-			 Promise.all(Area.forge()
-				 // countries only
+			Area.forge()
+				// countries only
 				.where({type: 1})
 				.fetchAll()
 				.then((collection) => collection.toJSON())
 				.map(search.indexArea)
-		))
+
+		)
 		.then(search.refreshIndex);
 };
 

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -19,6 +19,7 @@
 /* eslint valid-jsdoc: ["error", { "requireReturn": false }], max-len: "warn" */
 'use strict';
 
+const Area = require('bookbrainz-data').Area;
 const Creator = require('bookbrainz-data').Creator;
 const Edition = require('bookbrainz-data').Edition;
 const Editor = require('bookbrainz-data').Editor;

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -49,7 +49,9 @@ const router = express.Router();
 
 router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 	const editorJSONPromise = new Editor({id: parseInt(req.user.id, 10)})
-		.fetch()
+		.fetch({
+			withRelated: ['area']
+		})
 		.then((editor) => editor.toJSON());
 
 	const titleJSONPromise = new TitleUnlock()


### PR DESCRIPTION
### Problem
Area entities are not being indexed; hence EntitySearch components included in #114 have no way of providing any area options to user. The Area entity is different from the other indexed entities so some special cases need to be made. There are also some issues with data retrieval and insertion in the EntitySearch component.

### Solution
Indexes the Area entity, patches data handling issues in EntitySearch, and adds special cases in search for dealing with Area entities. Also introduces a few styling touches such as disabling area links in the SearchPage results and a globe icon for area entities.

### Areas of Impact
Impacts the indexing and some search functions, Creator, Publisher and Profile edit forms, SearchResults component.
