### PR TITLE
Added area information to UI

### DIFF
--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -81,6 +81,8 @@ class EditorProfileTab extends React.Component {
 					<dd>
 					{musicbrainzAccount}
 					</dd>
+					<dt>Area</dt>
+					<dd>{editor.area ? editor.area.name : '?'}</dd>
 					<dt>Type</dt>
 					<dd>{editor.type.label}</dd>
 					<dt>Reputation</dt>

--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -76,3 +76,12 @@ function formatScalarChange(change, label) {
 	return formatChange(change, label, (side) => side && [side]);
 }
 module.exports.formatScalarChange = formatScalarChange;
+
+function formatAreaChange(change, label) {
+	return formatChange(
+		change,
+		label || 'Area',
+		(side) => typeof side === 'string' ? [side] : side && [side.name]
+	);
+}
+module.exports.formatAreaChange = formatAreaChange;

--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -81,6 +81,7 @@ function formatAreaChange(change, label) {
 	return formatChange(
 		change,
 		label || 'Area',
+		// eslint-disable-next-line
 		(side) => typeof side === 'string' ? [side] : side && [side.name]
 	);
 }

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -69,6 +69,16 @@ function formatCreatorChange(change) {
 		return baseFormatter.formatTypeChange(change, 'Creator Type');
 	}
 
+	if (_.isEqual(change.path, ['beginArea']) ||
+			_.isEqual(change.path, ['beginArea', 'name'])) {
+		return baseFormatter.formatAreaChange(change, 'Begin Area');
+	}
+
+	if (_.isEqual(change.path, ['endArea'] ||
+			_.isEqual(change.path, ['beginArea']))) {
+		return baseFormatter.formatAreaChange(change, 'End Area');
+	}
+
 	return null;
 }
 
@@ -128,6 +138,11 @@ function formatPublisherChange(change) {
 
 	if (_.isEqual(change.path, ['type'])) {
 		return baseFormatter.formatTypeChange(change, 'Publisher Type');
+	}
+
+	if (_.isEqual(change.path, ['area']) ||
+			_.isEqual(change.path, ['area', 'name'])) {
+		return baseFormatter.formatAreaChange(change);
 	}
 
 	return null;

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -74,8 +74,8 @@ function formatCreatorChange(change) {
 		return baseFormatter.formatAreaChange(change, 'Begin Area');
 	}
 
-	if (_.isEqual(change.path, ['endArea'] ||
-			_.isEqual(change.path, ['beginArea']))) {
+	if (_.isEqual(change.path, ['endArea']) ||
+			_.isEqual(change.path, ['endArea', 'name'])) {
 		return baseFormatter.formatAreaChange(change, 'End Area');
 	}
 

--- a/templates/editor/editor.jade
+++ b/templates/editor/editor.jade
@@ -37,6 +37,8 @@ block body
 							|Link My MusicBrainz Account
 					else
 						|No Linked MusicBrainz Account
+				dt Area
+				dd=(editor.area ? editor.area.name : '?')
 				dt Type
 				dd=editor.type.label
 				dt Reputation

--- a/templates/entity/view/creator.jade
+++ b/templates/entity/view/creator.jade
@@ -11,5 +11,8 @@ block attributes
 
 	dt Gender
 	dd=(entity.gender ? entity.gender.name : '?')
-
+	dt Begin Area
+	dd=(entity.beginArea ? entity.beginArea.name : '?')
+	dt End Area
+	dd=(entity.endArea ? entity.endArea.name : '?')
 	+begin_end

--- a/templates/entity/view/publisher.jade
+++ b/templates/entity/view/publisher.jade
@@ -8,7 +8,8 @@ block picture
 
 block attributes
 	+type(entity.publisherType)
-
+	dt Area
+	dd=(entity.area ? entity.area.name : '?')
 	+begin_end
 
 block content


### PR DESCRIPTION
### Problem
Area information for Creator and Publisher entities and the editor are not being displayed on the site.

### Solution
Adds area attributes to entity pages and profile pages of editors. Also updated server + model code in https://github.com/bookbrainz/bookbrainz-data-js to include area changes in entity revisions.

### Areas of Impact
Minimal impact on Creator, Publisher, and Editor templates. Adds new cases to server-side revision code that is used to format changes for the client.
