### PR TITLE
Entity revisions conversion - GCI

### DIFF
--- a/src/client/components/pages/entity-revisions.js
+++ b/src/client/components/pages/entity-revisions.js
@@ -78,7 +78,11 @@ class EntityRevisions extends React.Component {
 							key={`${revision.revision.author.id}${revision.id}`}
 						>
 							{header}
-							{revision.revision.note}
+							{revision.revision.notes.length > 0 &&
+								<p className="list-group-item-text">
+									{revision.revision.notes[0].content}
+								</p>
+							}
 						</ListGroupItem>
 					);
 				})}

--- a/src/client/components/pages/entity-revisions.js
+++ b/src/client/components/pages/entity-revisions.js
@@ -29,7 +29,7 @@ class EntityRevisions extends React.Component {
 	constructor(props) {
 		super(props);
 		this.renderHeader = this.renderHeader.bind(this);
-		this.renderRevisions = this.renderRevisions.bind(this);
+		this.renderRevision = this.renderRevision.bind(this);
 	}
 
 	renderHeader() {
@@ -54,48 +54,45 @@ class EntityRevisions extends React.Component {
 		);
 	}
 
-	renderRevisions() {
-		const {revisions} = this.props;
+	renderRevision(revision) {
+		const createdDate = new Date(revision.revision.createdAt);
+		const dateLabel = (Date.now() - createdDate < 86400000) ?
+			createdDate.toLocaleTimeString() :
+			createdDate.toLocaleDateString();
+		const header = (
+			<h4 className="list-group-item-heading">
+				<small className="pull-right">
+				{`${revision.revision.author.name}, ${dateLabel}`}
+				</small>
+				{`r${revision.id}`}
+			</h4>
+		);
 
 		return (
-			<ListGroup>
-				{revisions.map((revision) => {
-					const createdDate = new Date(revision.revision.createdAt);
-					const dateLabel = Date.now() - createdDate < 86400000 ?
-						createdDate.toLocaleTimeString() :
-						createdDate.toLocaleDateString();
-					const header = (
-						<h4 className="list-group-item-heading">
-							<small className="pull-right">
-							{`${revision.revision.author.name}, ${dateLabel}`}
-							</small>
-							{`r${revision.id}`}
-						</h4>
-					);
-					return (
-						<ListGroupItem
-							href={`/revision/${revision.id}`}
-							key={`${revision.revision.author.id}${revision.id}`}
-						>
-							{header}
-							{revision.revision.notes.length > 0 &&
-								<p className="list-group-item-text">
-									{revision.revision.notes[0].content}
-								</p>
-							}
-						</ListGroupItem>
-					);
-				})}
-			</ListGroup>
+			<ListGroupItem
+				href={`/revision/${revision.id}`}
+				key={`${revision.revision.author.id}${revision.id}`}
+			>
+				{header}
+				{revision.revision.notes.length > 0 &&
+					<p className="list-group-item-text">
+						{revision.revision.notes[0].content}
+					</p>
+				}
+			</ListGroupItem>
 		);
 	}
 
 	render() {
+		const {revisions} = this.props;
+
 		return (
 			<div>
 				{this.renderHeader()}
 				<h2>Revision History</h2>
-				{this.renderRevisions()}
+				<ListGroup>
+					{revisions.map(this.renderRevision)}
+				</ListGroup>
 			</div>
 		);
 	}

--- a/src/client/components/pages/entity-revisions.js
+++ b/src/client/components/pages/entity-revisions.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2016  Daniel Hsing
+ * 				 2016  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+const React = require('React');
+const bootstrap = require('react-bootstrap');
+
+const Row = bootstrap.Row;
+const Col = bootstrap.Col;
+const ListGroup = bootstrap.ListGroup;
+const ListGroupItem = bootstrap.ListGroupItem;
+
+class EntityRevisions extends React.Component {
+
+	constructor(props) {
+		super(props);
+		this.renderHeader = this.renderHeader.bind(this);
+		this.renderRevisions = this.renderRevisions.bind(this);
+	}
+
+	renderHeader() {
+		const {entity} = this.props;
+
+		return (
+			<Row>
+				<Col md={12}>
+					<h1>
+						{entity.defaultAlias &&
+							`${entity.defaultAlias.name} `
+						}
+						{entity.disambiguation &&
+							<small>
+								{`(${entity.disambiguation.comment})`}
+							</small>
+						}
+					</h1>
+					<hr/>
+				</Col>
+			</Row>
+		);
+	}
+
+	renderRevisions() {
+		const {revisions} = this.props;
+
+		return (
+			<ListGroup>
+				{revisions.map((revision) => {
+					const createdDate = new Date(revision.revision.createdAt);
+					const dateLabel = Date.now() - createdDate < 86400000 ?
+						createdDate.toLocaleTimeString() :
+						createdDate.toLocaleDateString();
+					const header = (
+						<h4 className="list-group-item-heading">
+							<small className="pull-right">
+							{`${revision.revision.author.name}, ${dateLabel}`}
+							</small>
+							{`r${revision.id}`}
+						</h4>
+					);
+					return (
+						<ListGroupItem
+							href={`/revision/${revision.id}`}
+							key={`${revision.revision.author.id}${revision.id}`}
+						>
+							{header}
+							{revision.revision.note}
+						</ListGroupItem>
+					);
+				})}
+			</ListGroup>
+		);
+	}
+
+	render() {
+		return (
+			<div>
+				{this.renderHeader()}
+				<h2>Revision History</h2>
+				{this.renderRevisions()}
+			</div>
+		);
+	}
+}
+EntityRevisions.displayName = 'EntityRevisions';
+EntityRevisions.propTypes = {
+	entity: React.PropTypes.shape({
+		defaultAlias: React.PropTypes.object,
+		disambiguation: React.PropTypes.object
+	}),
+	revisions: React.PropTypes.array
+};
+
+module.exports = EntityRevisions;
+

--- a/src/client/components/pages/entity-revisions.js
+++ b/src/client/components/pages/entity-revisions.js
@@ -16,7 +16,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-const React = require('React');
+const React = require('react');
 const bootstrap = require('react-bootstrap');
 
 const Row = bootstrap.Row;

--- a/src/client/components/pages/entity-revisions.js
+++ b/src/client/components/pages/entity-revisions.js
@@ -110,4 +110,3 @@ EntityRevisions.propTypes = {
 };
 
 module.exports = EntityRevisions;
-

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -146,11 +146,13 @@ module.exports.displayRevisions = (req, res, next, RevisionModel) => {
 
 	return new RevisionModel()
 		.where({bbid})
-		.fetchAll({withRelated: ['revision', 'revision.author']})
+		.fetchAll({
+			withRelated: ['revision', 'revision.author', 'revision.notes']
+		})
 		.then((collection) => {
 			const revisions = collection.toJSON();
 			const props = Object.assign({}, req.app.locals, res.locals, {
-				revisions,
+				revisions
 			});
 			const markup = ReactDOMServer.renderToString(
 				<Layout {...props}>

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -41,6 +41,9 @@ const search = require('../../helpers/search');
 const utils = require('../../helpers/utils');
 const achievement = require('../../helpers/achievement');
 
+const Layout = require('../../../client/containers/layout');
+const EntityRevisions =
+	require('../../../client/components/pages/entity-revisions');
 const DeletionForm = React.createFactory(
 	require('../../../client/components/forms/deletion')
 );
@@ -146,7 +149,15 @@ module.exports.displayRevisions = (req, res, next, RevisionModel) => {
 		.fetchAll({withRelated: ['revision', 'revision.author']})
 		.then((collection) => {
 			const revisions = collection.toJSON();
-			return res.render('entity/revisions', {revisions});
+			const props = Object.assign({}, req.app.locals, res.locals, {
+				revisions,
+			});
+			const markup = ReactDOMServer.renderToString(
+				<Layout {...props}>
+					<EntityRevisions/>
+				</Layout>
+			);
+			return res.render('target', {markup});
 		})
 		.catch(next);
 };


### PR DESCRIPTION
### Problem
Entity revision display is being rendered with pug instead of React.

### Solution
Created a React component for displaying entity revisions. Updated server code to render the newly created component instead of the old template. Also included 'revision.notes' in the relations being fetched to the client.

### Areas of Impact
Updates the displayRevisions render function and adds a new component to the client folder.
