### PR TITLE
Fixed typo in README about checking successful database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ At this point, the database is set up, and the following command should give
 you a list of usernames of BookBrainz editors (after entering the password from
 earlier):
 
-    sudo -u postgres bookbrainz -c "SELECT name FROM bookbrainz.editor"
+    sudo -u postgres psql bookbrainz -c "SELECT name FROM bookbrainz.editor"
 
 ### Cloning
 


### PR DESCRIPTION


### Problem
There was a typo in the server setup code in the README. The code snippet read:

```  sudo -u postgres  bookbrainz -c "SELECT name FROM bookbrainz.editor" ```

However typing this command into my terminal gave me 

```sudo: bookbrainz: command not found```.



### Solution
This PR adds the command ```psql``` in front of ```bookbrainz``` so it will actually try to access the database.


### Areas of Impact
New dev experience?
