### PR TITLE
Fix bug tracker link

### DIFF
--- a/src/client/components/footer.js
+++ b/src/client/components/footer.js
@@ -69,7 +69,7 @@ function Footer(props) {
 						Alpha Software —{' '}
 						<a href={`${repositoryUrl}commit/${siteRevision}`}>
 							{siteRevision}
-						</a> — <a href="#">Report a Bug</a>
+						</a> — <a href="https://tickets.metabrainz.org/projects/BB/issues/">Report a Bug</a>
 					</small>
 				</Row>
 			</Grid>

--- a/templates/footer.jade
+++ b/templates/footer.jade
@@ -20,5 +20,5 @@ footer.footer
         ='Alpha Software — '
         a(href=`${repositoryUrl}commit/${siteRevision}`)=siteRevision
         =' — '
-        a(href="#") Report a Bug
+        a(href="https://tickets.metabrainz.org/projects/BB/issues/") Report a Bug
 


### PR DESCRIPTION
### Problem

Currently, "Report a Bug" button in the footer doesn't link to MeB's bug tracker.

### Solution

The fix was mostly simple, adding a link to the Jira Bug Tracker.

### Areas of Impact

All webpages should now link to the bug tracker
