### PR TITLE
Escape invalid characters in injected prop string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -401,6 +401,13 @@
         "lodash": "4.17.4",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        }
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1657,6 +1664,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3416,6 +3424,795 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
     "ftp": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
@@ -4346,9 +5143,9 @@
       }
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -5244,6 +6041,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jade": "~1.11.0",
     "jquery": "^3.1.1",
     "jquery.mousewheel": "^3.1.9",
+    "jsesc": "^2.5.1",
     "less": "^2.7.1",
     "lodash": "^4.7.0",
     "log": "^1.4.0",

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -29,6 +29,7 @@ import SearchSelect from '../input/entity-search';
 import SelectWrapper from '../input/select-wrapper';
 import request from 'superagent-bluebird-promise';
 
+
 const {Button, Col, Grid, Row} = bootstrap;
 const {formatDate, injectDefaultAliasName} = utilsHelper;
 

--- a/src/client/components/input/select-wrapper.js
+++ b/src/client/components/input/select-wrapper.js
@@ -27,9 +27,9 @@ import classNames from 'classnames';
 function wangleID(value, idAttribute) {
 	if (_.isArray(value)) {
 		return value.map(
-			(aValue) => (
-				_.isObject(aValue) ? aValue[idAttribute] : aValue
-			)
+			(aValue) =>
+				(_.isObject(aValue) ? aValue[idAttribute] : aValue)
+
 		);
 	}
 

--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -26,6 +26,7 @@ import React from 'react';
 import _ from 'lodash';
 import request from 'superagent-bluebird-promise';
 
+
 const {Button, Col, ListGroup, ListGroupItem, Row} = bootstrap;
 const {formatDate} = utilsHelper;
 

--- a/src/client/entity-editor/common/language-field.js
+++ b/src/client/entity-editor/common/language-field.js
@@ -47,9 +47,9 @@ function LanguageField({
 	error,
 	...rest
 }: Props) {
-	const label = (
+	const label =
 		<ValidationLabel empty={empty} error={error}>Language</ValidationLabel>
-	);
+	;
 
 	return (
 		<CustomInput label={label}>

--- a/src/client/entity-editor/validators/work.js
+++ b/src/client/entity-editor/validators/work.js
@@ -27,6 +27,7 @@ import {
 import _ from 'lodash';
 import type {_IdentifierType} from '../../../types';
 
+
 export function validateWorkSectionType(value: ?any): boolean {
 	return validatePositiveInteger(value);
 }

--- a/src/server/helpers/props.js
+++ b/src/server/helpers/props.js
@@ -17,7 +17,7 @@
  */
 
 import _ from 'lodash';
-import jsesc from 'jsesc'
+import jsesc from 'jsesc';
 
 
 const LAYOUT_PROPS = [
@@ -37,9 +37,9 @@ const EDITOR_PROPS = [
 // JSON.stringify that escapes characters in string output
 export function escapeProps(props) {
 	return jsesc(props, {
-		json: true,
-		isScriptContext: true
-	})
+		isScriptContext: true,
+		json: true
+	});
 }
 
 export function generateProps(req, res, props) {

--- a/src/server/helpers/props.js
+++ b/src/server/helpers/props.js
@@ -17,6 +17,7 @@
  */
 
 import _ from 'lodash';
+import jsesc from 'jsesc'
 
 
 const LAYOUT_PROPS = [
@@ -32,6 +33,14 @@ const EDITOR_PROPS = [
 	'editor',
 	'tabActive'
 ];
+
+// JSON.stringify that escapes characters in string output
+export function escapeProps(props) {
+	return jsesc(props, {
+		json: true,
+		isScriptContext: true
+	})
+}
 
 export function generateProps(req, res, props) {
 	return Object.assign({}, req.app.locals, res.locals, props);

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -85,7 +85,11 @@ router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 					/>
 				</Layout>
 			);
-			res.render('target', {markup, props, script});
+			res.render('target', {
+				markup, 
+				props: propHelpers.escapeProps(props), 
+				script
+			});
 		}
 	)
 		.catch(next);
@@ -218,7 +222,7 @@ router.get('/:id', (req, res, next) => {
 			res.render('target', {
 				markup,
 				page: 'profile',
-				props,
+				props: propHelpers.escapeProps(props),
 				script: '/js/editor/editor.js'
 			});
 		}
@@ -278,7 +282,7 @@ router.get('/:id/revisions', (req, res, next) => {
 			res.render('target', {
 				markup,
 				page: 'revisions',
-				props,
+				props: propHelpers.escapeProps(props),
 				script: '/js/editor/editor.js'
 			});
 		})
@@ -389,7 +393,11 @@ router.get('/:id/achievements', (req, res, next) => {
 				</Layout>
 			);
 			const script = '/js/editor/achievement.js';
-			res.render('target', {markup, props, script});
+			res.render('target', {
+				markup, 
+				props: propHelpers.escapeProps(props), 
+				script
+			});
 		}
 	);
 });

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -86,8 +86,8 @@ router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 				</Layout>
 			);
 			res.render('target', {
-				markup, 
-				props: propHelpers.escapeProps(props), 
+				markup,
+				props: propHelpers.escapeProps(props),
 				script
 			});
 		}
@@ -394,8 +394,8 @@ router.get('/:id/achievements', (req, res, next) => {
 			);
 			const script = '/js/editor/achievement.js';
 			res.render('target', {
-				markup, 
-				props: propHelpers.escapeProps(props), 
+				markup,
+				props: propHelpers.escapeProps(props),
 				script
 			});
 		}

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -128,7 +128,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Creator'
 		});
@@ -262,7 +262,7 @@ router.get(
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Edit Creator'
 		});

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -178,7 +178,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 			return res.render('target', {
 				markup,
-				props,
+				props: propHelpers.escapeProps(props),
 				script: '/js/entity-editor.js',
 				title: 'Add Edition'
 			});
@@ -324,7 +324,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Edit Edition'
 		});

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -162,8 +162,8 @@ export function displayDeleteEntity(req, res) {
 	);
 
 	res.render('target', {
-		markup, 
-		props: propHelpers.escapeProps(props), 
+		markup,
+		props: propHelpers.escapeProps(props),
 		script: '/js/deletion.js'
 	});
 }

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -140,7 +140,7 @@ export function displayEntity(req, res) {
 			res.render('target', {
 				markup,
 				page: entityName,
-				props,
+				props: propHelpers.escapeProps(props),
 				script: '/js/entity/entity.js'
 			});
 		}
@@ -161,7 +161,11 @@ export function displayDeleteEntity(req, res) {
 		</Layout>
 	);
 
-	res.render('target', {markup, props, script: '/js/deletion.js'});
+	res.render('target', {
+		markup, 
+		props: propHelpers.escapeProps(props), 
+		script: '/js/deletion.js'
+	});
 }
 
 export function displayRevisions(req, res, next, RevisionModel) {
@@ -188,7 +192,7 @@ export function displayRevisions(req, res, next, RevisionModel) {
 			return res.render('target', {
 				markup,
 				page: 'revisions',
-				props,
+				props: propHelpers.escapeProps(props),
 				script: '/js/entity/entity.js'
 			});
 		})

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -132,7 +132,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Publisher'
 		});
@@ -240,7 +240,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Edit Publication'
 		});

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -142,7 +142,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Publisher'
 		});
@@ -270,7 +270,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Publisher'
 		});

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -128,7 +128,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Work'
 		});
@@ -241,7 +241,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Work'
 		});

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -60,7 +60,7 @@ router.get('/', async (req, res, next) => {
 		res.render('target', {
 			markup,
 			page: 'Index',
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/index.js'
 		});
 	}
@@ -121,7 +121,7 @@ function _createStaticRoute(route, title, PageComponent) {
 		res.render('target', {
 			markup,
 			page: title,
-			props,
+			props: propHelpers.escapeProps(props),
 			script: '/js/index.js',
 			title
 		});

--- a/src/server/routes/register.js
+++ b/src/server/routes/register.js
@@ -86,7 +86,7 @@ router.get('/details', middleware.loadGenders, (req, res) => {
 
 	return res.render('target', {
 		markup,
-		props,
+		props: propHelpers.escapeProps(props),
 		script: '/js/registrationDetails.js',
 		title: 'Register'
 	});

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -247,7 +247,11 @@ router.get('/:id', (req, res, next) => {
 				</Layout>
 			);
 			const script = '/js/revision.js';
-			res.render('target', {markup, props, script});
+			res.render('target', {
+				markup, 
+				props: propHelpers.escapeProps(props), 
+				script
+			});
 		}
 	)
 		.catch(next);

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -248,8 +248,8 @@ router.get('/:id', (req, res, next) => {
 			);
 			const script = '/js/revision.js';
 			res.render('target', {
-				markup, 
-				props: propHelpers.escapeProps(props), 
+				markup,
+				props: propHelpers.escapeProps(props),
 				script
 			});
 		}

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -59,7 +59,8 @@ router.get('/', (req, res, next) => {
 			);
 
 			res.render('target', {
-				markup, props,
+				markup, 
+				props: propHelpers.escapeProps(props),
 				script: '/js/search.js',
 				title: 'Search Results'
 			});

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -59,7 +59,7 @@ router.get('/', (req, res, next) => {
 			);
 
 			res.render('target', {
-				markup, 
+				markup,
 				props: propHelpers.escapeProps(props),
 				script: '/js/search.js',
 				title: 'Search Results'

--- a/templates/target.jade
+++ b/templates/target.jade
@@ -13,5 +13,5 @@ html
 		if page
 			script(type='application/json')#page!= page
 		if props && script
-			script(type='application/json')#props!= JSON.stringify(props)
+			script(type='application/json')#props!= props
 			script(src=script)


### PR DESCRIPTION
Server-generated props were not being escaped properly which allowed for script injection to occur. This issue has been resolved using the [jsesc](https://github.com/mathiasbynens/jsesc) library which converts JS objects to strings and escapes characters according to specified options. 

**note:** once Jade/Pug templates are replaced with html string templates, validation/escape logic can be moved directly into the template file so the boilerplate added from this PR is a temporary measure.