### PR TITLE
fix: separate server-only prop helpers from isomorphic prop helpers

### DIFF
--- a/src/client/components/pages/entity/creator.js
+++ b/src/client/components/pages/entity/creator.js
@@ -21,14 +21,13 @@
 /* eslint strict: 0 */
 
 import * as entityHelper from '../../../helpers/entity';
-import * as propsHelper from '../../../../server/helpers/props';
 import AttributeList from '../parts/attribute-list';
 import EntityPage from '../../../containers/entity';
 import React from 'react';
+import {extractEntityProps} from '../../../helpers/props';
 
 
 const {extractAttribute, getDateAttributes, getTypeAttribute} = entityHelper;
-const {extractEntityProps} = propsHelper;
 
 function CreatorPage(props) {
 	const {entity} = props;

--- a/src/client/components/pages/entity/edition.js
+++ b/src/client/components/pages/entity/edition.js
@@ -20,15 +20,14 @@
 /* eslint strict: 0 */
 
 import * as entityHelper from '../../../helpers/entity';
-import * as propsHelper from '../../../../server/helpers/props';
 import AttributeList from '../parts/attribute-list';
 import EntityPage from '../../../containers/entity';
 import FontAwesome from 'react-fontawesome';
 import React from 'react';
+import {extractEntityProps} from '../../../helpers/props';
 
 
 const {extractAttribute, getLanguageAttribute} = entityHelper;
-const {extractEntityProps} = propsHelper;
 
 function EditionPage(props) {
 	const {entity} = props;

--- a/src/client/components/pages/entity/publication.js
+++ b/src/client/components/pages/entity/publication.js
@@ -21,14 +21,13 @@
 /* eslint strict: 0 */
 
 import * as entityHelper from '../../../helpers/entity';
-import * as propsHelper from '../../../../server/helpers/props';
 import AttributeList from '../parts/attribute-list';
 import EntityPage from '../../../containers/entity';
 import React from 'react';
+import {extractEntityProps} from '../../../helpers/props';
 
 
 const {getTypeAttribute, showEntityEditions} = entityHelper;
-const {extractEntityProps} = propsHelper;
 
 function PublicationPage(props) {
 	const {entity} = props;

--- a/src/client/components/pages/entity/publisher.js
+++ b/src/client/components/pages/entity/publisher.js
@@ -21,16 +21,15 @@
 /* eslint strict: 0 */
 
 import * as entityHelper from '../../../helpers/entity';
-import * as propsHelper from '../../../../server/helpers/props';
 import AttributeList from '../parts/attribute-list';
 import EntityPage from '../../../containers/entity';
 import React from 'react';
+import {extractEntityProps} from '../../../helpers/props';
 
 
 const {
 	extractAttribute, getTypeAttribute, getDateAttributes, showEntityEditions
 } = entityHelper;
-const {extractEntityProps} = propsHelper;
 
 function PublisherPage(props) {
 	const {entity} = props;

--- a/src/client/components/pages/entity/work.js
+++ b/src/client/components/pages/entity/work.js
@@ -21,14 +21,13 @@
 /* eslint strict: 0 */
 
 import * as entityHelper from '../../../helpers/entity';
-import * as propsHelper from '../../../../server/helpers/props';
 import AttributeList from '../parts/attribute-list';
 import EntityPage from '../../../containers/entity';
 import React from 'react';
+import {extractEntityProps} from '../../../helpers/props';
 
 
 const {getLanguageAttribute, getTypeAttribute} = entityHelper;
-const {extractEntityProps} = propsHelper;
 
 function WorkPage(props) {
 	const {entity} = props;

--- a/src/client/controllers/deletion.js
+++ b/src/client/controllers/deletion.js
@@ -16,18 +16,18 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../server/helpers/props';
 import DeletionForm from '../components/forms/deletion';
 import Layout from '../containers/layout';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {extractLayoutProps} from '../helpers/props';
 
 
 const propsTarget = document.getElementById('props');
 const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
 
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(props)}>
+	<Layout {...extractLayoutProps(props)}>
 		<DeletionForm entity={props.entity}/>
 	</Layout>
 );

--- a/src/client/controllers/editor/achievement.js
+++ b/src/client/controllers/editor/achievement.js
@@ -18,7 +18,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../../server/helpers/props';
+import {
+	extractEditorProps,
+	extractLayoutProps
+} from '../../helpers/props';
 import AchievementsTab from '../../components/pages/parts/editor-achievements';
 import EditorContainer from '../../containers/editor';
 import Layout from '../../containers/layout';
@@ -30,9 +33,9 @@ const propsTarget = document.getElementById('props');
 const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
 
 ReactDOM.render(
-	<Layout {...propHelpers.extractLayoutProps(props)}>
+	<Layout {...extractLayoutProps(props)}>
 		<EditorContainer
-			{...propHelpers.extractEditorProps(props)}
+			{...extractEditorProps(props)}
 		>
 			<AchievementsTab
 				achievement={props.achievement}

--- a/src/client/controllers/editor/edit.js
+++ b/src/client/controllers/editor/edit.js
@@ -17,18 +17,18 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../../server/helpers/props';
 import Layout from '../../containers/layout';
 import ProfileForm from '../../components/forms/profile';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {extractLayoutProps} from '../../helpers/props';
 
 
 const propsTarget = document.getElementById('props');
 const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
 
 ReactDOM.render(
-	<Layout {...propHelpers.extractLayoutProps(props)}>
+	<Layout {...extractLayoutProps(props)}>
 		<ProfileForm
 			editor={props.editor}
 			genders={props.genders}

--- a/src/client/controllers/editor/editor.js
+++ b/src/client/controllers/editor/editor.js
@@ -17,7 +17,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../../server/helpers/props';
+import {
+	extractChildProps,
+	extractEditorProps,
+	extractLayoutProps
+} from '../../helpers/props';
 import EditorContainer from '../../containers/editor';
 import Layout from '../../containers/layout';
 import ProfileTab from '../../components/pages/parts/editor-profile';
@@ -41,15 +45,15 @@ else {
 	tab = (
 		<ProfileTab
 			user={props.user}
-			{...propHelpers.extractChildProps(props)}
+			{...extractChildProps(props)}
 		/>
 	);
 }
 
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(props)} >
+	<Layout {...extractLayoutProps(props)} >
 		<EditorContainer
-			{...propHelpers.extractEditorProps(props)}
+			{...extractEditorProps(props)}
 		>
 			{tab}
 		</EditorContainer>

--- a/src/client/controllers/entity/entity.js
+++ b/src/client/controllers/entity/entity.js
@@ -16,7 +16,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../../server/helpers/props';
+import {
+	extractEntityProps,
+	extractLayoutProps
+} from '../../helpers/props';
 import CreatorPage from '../../components/pages/entities/creator';
 import EditionPage from '../../components/pages/entities/edition';
 import EntityRevisions from '../../components/pages/entity-revisions';
@@ -47,7 +50,7 @@ const Child = entityComponents[page] || CreatorPage;
 let markup = null;
 if (page === 'revisions') {
 	markup = (
-		<Layout {...propHelpers.extractLayoutProps(props)}>
+		<Layout {...extractLayoutProps(props)}>
 			<EntityRevisions
 				entity={props.entity}
 				revisions={props.revisions}
@@ -57,8 +60,8 @@ if (page === 'revisions') {
 }
 else {
 	markup = (
-		<Layout {...propHelpers.extractLayoutProps(props)}>
-			<Child {...propHelpers.extractEntityProps(props)}/>
+		<Layout {...extractLayoutProps(props)}>
+			<Child {...extractEntityProps(props)}/>
 		</Layout>
 	);
 }

--- a/src/client/controllers/index.js
+++ b/src/client/controllers/index.js
@@ -16,7 +16,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../server/helpers/props';
+import {
+	extractChildProps,
+	extractLayoutProps
+} from '../helpers/props';
 import AboutPage from '../../client/components/pages/about';
 import ContributePage from '../../client/components/pages/contribute';
 import DevelopPage from '../../client/components/pages/develop';
@@ -46,8 +49,8 @@ const pageMap = {
 const Child = pageMap[page] || Index;
 
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(props)}>
-		<Child {...propHelpers.extractChildProps(props)}/>
+	<Layout {...extractLayoutProps(props)}>
+		<Child {...extractChildProps(props)}/>
 	</Layout>
 );
 

--- a/src/client/controllers/registrationDetails.js
+++ b/src/client/controllers/registrationDetails.js
@@ -17,18 +17,18 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../server/helpers/props';
 import Layout from '../containers/layout';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import RegistrationForm from '../components/forms/registration-details';
+import {extractLayoutProps} from '../helpers/props';
 
 
 const propsTarget = document.getElementById('props');
 const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
 
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(props)}>
+	<Layout {...extractLayoutProps(props)}>
 		<RegistrationForm
 			gender={props.gender}
 			genders={props.genders}

--- a/src/client/controllers/revision.js
+++ b/src/client/controllers/revision.js
@@ -16,17 +16,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../server/helpers/props';
 import Layout from '../containers/layout';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import RevisionPage from '../components/pages/revision';
+import {extractLayoutProps} from '../helpers/props';
 
 
 const propsTarget = document.getElementById('props');
 const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(props)}>
+	<Layout {...extractLayoutProps(props)}>
 		<RevisionPage
 			diffs={props.diffs}
 			revision={props.revision}

--- a/src/client/controllers/search.js
+++ b/src/client/controllers/search.js
@@ -16,18 +16,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../../server/helpers/props';
 import Layout from '../containers/layout';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import SearchPage from '../components/pages/search';
-
+import {extractLayoutProps} from '../helpers/props';
 
 const propsTarget = document.getElementById('props');
 const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
 
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(props)}>
+	<Layout {...extractLayoutProps(props)}>
 		<SearchPage initialResults={props.initialResults}/>
 	</Layout>
 );

--- a/src/client/entity-editor/controller.js
+++ b/src/client/entity-editor/controller.js
@@ -21,8 +21,11 @@
  */
 
 import * as helpers from './helpers';
-import * as propHelpers from '../../server/helpers/props';
 import {applyMiddleware, compose, createStore} from 'redux';
+import {
+	extractChildProps,
+	extractLayoutProps
+} from '../helpers/props';
 import EntityEditor from './entity-editor';
 import Immutable from 'immutable';
 import Layout from '../containers/layout';
@@ -58,11 +61,11 @@ const store = createStore(
 );
 
 const markup = (
-	<Layout {...propHelpers.extractLayoutProps(rest)}>
+	<Layout {...extractLayoutProps(rest)}>
 		<Provider store={store}>
 			<EntityEditor
 				validate={getValidator(props.entityType)}
-				{...propHelpers.extractChildProps(rest)}
+				{...extractChildProps(rest)}
 			>
 				<EntitySection/>
 			</EntityEditor>

--- a/src/client/helpers/props.js
+++ b/src/client/helpers/props.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016  Daniel Hsing
+ * Copyright (C) 2017  Daniel Hsing
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,16 +16,38 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import jsesc from 'jsesc';
+import {omit, pick} from 'lodash';
 
-// JSON.stringify that escapes characters in string output
-export function escapeProps(props) {
-	return jsesc(props, {
-		isScriptContext: true,
-		json: true
-	});
+const LAYOUT_PROPS = [
+	'hideSearch',
+	'homepage',
+	'repositoryUrl',
+	'requiresJS',
+	'siteRevision',
+	'user'
+];
+
+const EDITOR_PROPS = [
+	'editor',
+	'tabActive'
+];
+
+export function extractLayoutProps(props) {
+	return pick(props, LAYOUT_PROPS);
 }
 
-export function generateProps(req, res, props) {
-	return Object.assign({}, req.app.locals, res.locals, props);
+export function extractEditorProps(props) {
+	return pick(props, EDITOR_PROPS);
+}
+
+export function extractChildProps(props) {
+	return omit(props, LAYOUT_PROPS);
+}
+
+export function extractEntityProps(props) {
+	return {
+		alert: props.alert,
+		entity: props.entity,
+		identifierTypes: props.identifierTypes
+	};
 }

--- a/src/server/helpers/error.js
+++ b/src/server/helpers/error.js
@@ -16,13 +16,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from './props';
+import * as propHelpers from '../../client/helpers/props';
 import ErrorPage from '../../client/components/pages/error';
 import Layout from '../../client/containers/layout';
 import Log from 'log';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import config from './config';
+import {generateProps} from './props';
 import status from 'http-status';
 
 
@@ -139,7 +140,7 @@ function _getErrorToSend(err) {
 
 export function renderError(req, res, err) {
 	const errorToSend = _getErrorToSend(err);
-	const props = propHelpers.generateProps(req, res, {
+	const props = generateProps(req, res, {
 		error: errorToSend
 	});
 	const markup = ReactDOMServer.renderToString(

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -20,7 +20,8 @@
 import * as auth from '../helpers/auth';
 import * as error from '../helpers/error';
 import * as handler from '../helpers/handler';
-import * as propHelpers from '../helpers/props';
+import * as propHelpers from '../../client/helpers/props';
+import {escapeProps, generateProps} from '../helpers/props';
 import AchievementsTab from
 	'../../client/components/pages/parts/editor-achievements';
 import EditorContainer from '../../client/containers/editor';
@@ -70,7 +71,7 @@ router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 
 	Promise.join(editorJSONPromise, titleJSONPromise, genderJSONPromise,
 		(editorJSON, titleJSON, genderJSON) => {
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				editor: editorJSON,
 				genders: genderJSON,
 				titles: titleJSON
@@ -87,7 +88,7 @@ router.get('/edit', auth.isAuthenticated, (req, res, next) => {
 			);
 			res.render('target', {
 				markup,
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script
 			});
 		}
@@ -202,7 +203,7 @@ router.get('/:id', (req, res, next) => {
 
 	Promise.join(achievementJSONPromise, editorJSONPromise,
 		(achievementJSON, editorJSON) => {
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				achievement: achievementJSON,
 				editor: editorJSON,
 				tabActive: 0
@@ -222,7 +223,7 @@ router.get('/:id', (req, res, next) => {
 			res.render('target', {
 				markup,
 				page: 'profile',
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script: '/js/editor/editor.js'
 			});
 		}
@@ -264,7 +265,7 @@ router.get('/:id/revisions', (req, res, next) => {
 			return editorTitleJSON;
 		})
 		.then((editorJSON) => {
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				editor: editorJSON,
 				tabActive: 1
 			});
@@ -282,7 +283,7 @@ router.get('/:id/revisions', (req, res, next) => {
 			res.render('target', {
 				markup,
 				page: 'revisions',
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script: '/js/editor/editor.js'
 			});
 		})
@@ -375,7 +376,7 @@ router.get('/:id/achievements', (req, res, next) => {
 
 	Promise.join(achievementJSONPromise, editorJSONPromise,
 		(achievementJSON, editorJSON) => {
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				achievement: achievementJSON,
 				editor: editorJSON,
 				tabActive: 2
@@ -395,7 +396,7 @@ router.get('/:id/achievements', (req, res, next) => {
 			const script = '/js/editor/achievement.js';
 			res.render('target', {
 				markup,
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script
 			});
 		}

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -22,8 +22,9 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../helpers/props';
+import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
+import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -87,7 +88,7 @@ router.get('/:bbid/revisions', (req, res, next) => {
 router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders,	middleware.loadLanguages,
 	middleware.loadCreatorTypes, (req, res) => {
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			creatorTypes: res.locals.creatorTypes,
 			entityType: 'creator',
 			genderOptions: res.locals.genders,
@@ -128,7 +129,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Creator'
 		});
@@ -220,7 +221,7 @@ router.get(
 	(req, res) => {
 		const creator = res.locals.entity;
 
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			creator,
 			creatorTypes: res.locals.creatorTypes,
 			entityType: 'creator',
@@ -262,7 +263,7 @@ router.get(
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Edit Creator'
 		});

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -22,8 +22,9 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../helpers/props';
+import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
+import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -110,7 +111,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages,
 	(req, res, next) => {
 		const {Publication, Publisher} = req.app.locals.orm;
-		const propsPromise = propHelpers.generateProps(req, res, {
+		const propsPromise = generateProps(req, res, {
 			editionFormats: res.locals.editionFormats,
 			editionStatuses: res.locals.editionStatuses,
 			entityType: 'edition',
@@ -178,7 +179,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 			return res.render('target', {
 				markup,
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script: '/js/entity-editor.js',
 				title: 'Add Edition'
 			});
@@ -283,7 +284,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	(req, res) => {
 		const edition = res.locals.entity;
 
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			editionFormats: res.locals.editionFormats,
 			editionStatuses: res.locals.editionStatuses,
 			entityType: 'edition',
@@ -324,7 +325,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Edit Edition'
 		});

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -19,9 +19,10 @@
 
 import * as achievement from '../../helpers/achievement';
 import * as handler from '../../helpers/handler';
-import * as propHelpers from '../../helpers/props';
+import * as propHelpers from '../../../client/helpers/props';
 import * as search from '../../helpers/search';
 import * as utils from '../../helpers/utils';
+import {escapeProps, generateProps} from '../../helpers/props';
 import CreatorPage from '../../../client/components/pages/entities/creator';
 import DeletionForm from '../../../client/components/forms/deletion';
 import EditionPage from '../../../client/components/pages/entities/edition';
@@ -126,7 +127,7 @@ export function displayEntity(req, res) {
 		const entityName = entity.type.toLowerCase();
 		const EntityComponent = entityComponents[entityName];
 		if (EntityComponent) {
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				alert,
 				identifierTypes
 			});
@@ -140,7 +141,7 @@ export function displayEntity(req, res) {
 			res.render('target', {
 				markup,
 				page: entityName,
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script: '/js/entity/entity.js'
 			});
 		}
@@ -153,7 +154,7 @@ export function displayEntity(req, res) {
 }
 
 export function displayDeleteEntity(req, res) {
-	const props = propHelpers.generateProps(req, res);
+	const props = generateProps(req, res);
 
 	const markup = ReactDOMServer.renderToString(
 		<Layout {...propHelpers.extractLayoutProps(props)}>
@@ -163,7 +164,7 @@ export function displayDeleteEntity(req, res) {
 
 	res.render('target', {
 		markup,
-		props: propHelpers.escapeProps(props),
+		props: escapeProps(props),
 		script: '/js/deletion.js'
 	});
 }
@@ -178,7 +179,7 @@ export function displayRevisions(req, res, next, RevisionModel) {
 		})
 		.then((collection) => {
 			const revisions = collection.toJSON();
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				revisions
 			});
 			const markup = ReactDOMServer.renderToString(
@@ -192,7 +193,7 @@ export function displayRevisions(req, res, next, RevisionModel) {
 			return res.render('target', {
 				markup,
 				page: 'revisions',
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script: '/js/entity/entity.js'
 			});
 		})

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -22,8 +22,9 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../helpers/props';
+import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
+import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -92,7 +93,7 @@ router.get('/:bbid/revisions', (req, res, next) => {
 
 router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublicationTypes, (req, res) => {
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			entityType: 'publication',
 			heading: 'Create Publication',
 			identifierTypes: res.locals.identifierTypes,
@@ -132,7 +133,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Publisher'
 		});
@@ -200,7 +201,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublicationTypes, middleware.loadLanguages, (req, res) => {
 		const publication = res.locals.entity;
 
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			entityType: 'publication',
 			heading: 'Edit Publication',
 			identifierTypes: res.locals.identifierTypes,
@@ -240,7 +241,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Edit Publication'
 		});

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -22,8 +22,9 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../helpers/props';
+import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
+import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -102,7 +103,7 @@ router.get('/:bbid/revisions', (req, res, next) => {
 router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
 	(req, res) => {
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			entityType: 'publisher',
 			heading: 'Create Publisher',
 			identifierTypes: res.locals.identifierTypes,
@@ -142,7 +143,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Publisher'
 		});
@@ -230,7 +231,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	(req, res) => {
 		const publisher = res.locals.entity;
 
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			entityType: 'publisher',
 			heading: 'Edit Publisher',
 			identifierTypes: res.locals.identifierTypes,
@@ -270,7 +271,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Publisher'
 		});

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -22,8 +22,9 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../helpers/props';
+import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
+import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -88,7 +89,7 @@ router.get('/:bbid/revisions', (req, res, next) => {
 router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadWorkTypes,
 	(req, res) => {
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			entityType: 'work',
 			heading: 'Create Work',
 			identifierTypes: res.locals.identifierTypes,
@@ -128,7 +129,7 @@ router.get('/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Work'
 		});
@@ -201,7 +202,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		workToFormState(work);
 
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			entityType: 'work',
 			heading: 'Edit Work',
 			identifierTypes: res.locals.identifierTypes,
@@ -241,7 +242,7 @@ router.get('/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 
 		return res.render('target', {
 			markup,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/entity-editor.js',
 			title: 'Add Work'
 		});

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -18,8 +18,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as propHelpers from '../helpers/props';
+import * as propHelpers from '../../client/helpers/props';
 import * as utils from '../helpers/utils';
+import {escapeProps, generateProps} from '../helpers/props';
 import AboutPage from '../../client/components/pages/about';
 import ContributePage from '../../client/components/pages/contribute';
 import DevelopPage from '../../client/components/pages/develop';
@@ -41,7 +42,7 @@ router.get('/', async (req, res, next) => {
 	const numRevisionsOnHomepage = 9;
 
 	function render(entities) {
-		const props = propHelpers.generateProps(req, res, {
+		const props = generateProps(req, res, {
 			homepage: true,
 			recent: _.take(entities, numRevisionsOnHomepage),
 			requireJS: Boolean(res.locals.user)
@@ -60,7 +61,7 @@ router.get('/', async (req, res, next) => {
 		res.render('target', {
 			markup,
 			page: 'Index',
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/index.js'
 		});
 	}
@@ -110,7 +111,7 @@ router.get('/', async (req, res, next) => {
 // Helper function to create pages that don't require custom logic
 function _createStaticRoute(route, title, PageComponent) {
 	router.get(route, (req, res) => {
-		const props = propHelpers.generateProps(req, res);
+		const props = generateProps(req, res);
 
 		const markup = ReactDOMServer.renderToString(
 			<Layout {...propHelpers.extractLayoutProps(props)}>
@@ -121,7 +122,7 @@ function _createStaticRoute(route, title, PageComponent) {
 		res.render('target', {
 			markup,
 			page: title,
-			props: propHelpers.escapeProps(props),
+			props: escapeProps(props),
 			script: '/js/index.js',
 			title
 		});

--- a/src/server/routes/register.js
+++ b/src/server/routes/register.js
@@ -21,7 +21,8 @@
 import * as error from '../helpers/error';
 import * as handler from '../helpers/handler';
 import * as middleware from '../helpers/middleware';
-import * as propHelpers from '../helpers/props';
+import * as propHelpers from '../../client/helpers/props';
+import {escapeProps, generateProps} from '../helpers/props';
 import Layout from '../../client/containers/layout';
 import Log from 'log';
 import React from 'react';
@@ -43,7 +44,7 @@ router.get('/', (req, res) => {
 		return res.redirect(`/editor/${req.user.id}`);
 	}
 
-	const props = propHelpers.generateProps(req, res);
+	const props = generateProps(req, res);
 
 	const markup = ReactDOMServer.renderToString(
 		<Layout {...propHelpers.extractLayoutProps(props)}>
@@ -68,7 +69,7 @@ router.get('/details', middleware.loadGenders, (req, res) => {
 		name: _.capitalize(req.session.mbProfile.gender)
 	});
 
-	const props = propHelpers.generateProps(req, res, {
+	const props = generateProps(req, res, {
 		gender,
 		genders: res.locals.genders,
 		name: req.session.mbProfile.sub
@@ -86,7 +87,7 @@ router.get('/details', middleware.loadGenders, (req, res) => {
 
 	return res.render('target', {
 		markup,
-		props: propHelpers.escapeProps(props),
+		props: escapeProps(props),
 		script: '/js/registrationDetails.js',
 		title: 'Register'
 	});

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -21,10 +21,11 @@ import * as baseFormatter from '../helpers/diffFormatters/base';
 import * as entityFormatter from '../helpers/diffFormatters/entity';
 import * as entityRoutes from './entity/entity';
 import * as languageSetFormatter from '../helpers/diffFormatters/languageSet';
-import * as propHelpers from '../helpers/props';
+import * as propHelpers from '../../client/helpers/props';
 import * as publisherSetFormatter from '../helpers/diffFormatters/publisherSet';
 import * as releaseEventSetFormatter from
 	'../helpers/diffFormatters/releaseEventSet';
+import {escapeProps, generateProps} from '../helpers/props';
 import Layout from '../../client/containers/layout';
 import Promise from 'bluebird';
 import React from 'react';
@@ -232,7 +233,7 @@ router.get('/:id', (req, res, next) => {
 					formatWorkChange
 				)
 			);
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				diffs,
 				revision: revision.toJSON(),
 				title: 'RevisionPage'
@@ -249,7 +250,7 @@ router.get('/:id', (req, res, next) => {
 			const script = '/js/revision.js';
 			res.render('target', {
 				markup,
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script
 			});
 		}

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -20,8 +20,9 @@
 import * as auth from '../helpers/auth';
 import * as error from '../helpers/error';
 import * as handler from '../helpers/handler';
-import * as propHelpers from '../helpers/props';
+import * as propHelpers from '../../client/helpers/props';
 import * as search from '../helpers/search';
+import {escapeProps, generateProps} from '../helpers/props';
 import Layout from '../../client/containers/layout';
 import Promise from 'bluebird';
 import React from 'react';
@@ -47,7 +48,7 @@ router.get('/', (req, res, next) => {
 			query
 		}))
 		.then((searchResults) => {
-			const props = propHelpers.generateProps(req, res, {
+			const props = generateProps(req, res, {
 				hideSearch: true,
 				...searchResults
 			});
@@ -60,7 +61,7 @@ router.get('/', (req, res, next) => {
 
 			res.render('target', {
 				markup,
-				props: propHelpers.escapeProps(props),
+				props: escapeProps(props),
 				script: '/js/search.js',
 				title: 'Search Results'
 			});


### PR DESCRIPTION
server-side dependencies such as `jsesc` were previously being pulled into the client bundle and not being transpiled properly. This patch should prevent this from happening. 