### PR TITLE
fix: added compression middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "catw": "^1.0.1",
     "classnames": "^2.2.5",
     "co": "^4.6.0",
+    "compression": "^1.7.1",
     "connect-redis": "^3.0.1",
     "cross-env": "^5.0.1",
     "debug": "^2.2.0",

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -36,7 +36,7 @@ import redis from 'connect-redis';
 import routes from './routes';
 import session from 'express-session';
 import staticCache from 'express-static-cache';
-
+import compression from 'compression';
 
 Promise.config({
 	longStackTraces: true,
@@ -66,6 +66,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
 	extended: false
 }));
+app.use(compression());
 
 // Set up serving of static assets
 app.use(staticCache(path.join(rootDir, 'static/js'), {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -25,6 +25,7 @@ import BookBrainzData from 'bookbrainz-data';
 import Debug from 'debug';
 import Promise from 'bluebird';
 import bodyParser from 'body-parser';
+import compression from 'compression';
 import config from './helpers/config';
 import express from 'express';
 import favicon from 'serve-favicon';
@@ -36,7 +37,6 @@ import redis from 'connect-redis';
 import routes from './routes';
 import session from 'express-session';
 import staticCache from 'express-static-cache';
-import compression from 'compression';
 
 Promise.config({
 	longStackTraces: true,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Server responses can be slow for people with low bandwidth. 


### Solution
Adding the node "compression" module to compress all incoming responses. 