### PR TITLE
fix: add spread props before named props in select-wrapper component

### DIFF
--- a/src/client/components/input/select-wrapper.js
+++ b/src/client/components/input/select-wrapper.js
@@ -94,13 +94,13 @@ class SelectWrapper extends React.Component {
 				}
 				<div className={wrapperClassName}>
 					<Child
+						{...props}
 						labelKey={labelAttribute}
 						multi={multiple}
 						ref={(ref) => this.select = ref}
 						value={childValue}
 						valueKey={idAttribute}
 						onChange={this.handleChange}
-						{...props}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
Previously, some props being passed to the base select component (such as the critical `onChange` prop) were being overridden by null values from the component's `defaultProps` property. As a result, some select components on the site (i.e. the gender select input) were not functional. This change fixes this behavior by ensuring that the named props always overrides the default ones. 

Another way of addressing this issue would have been to remove unnecessary `defaultProps` values.