### PR TITLE
refactor(tests): Eliminate some code duplication

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017  Robin Richtsfeld
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+export function expectAchievementIds(promise, editorId, achievementId) {
+	return Promise.all([
+		expect(promise).to.eventually.have
+			.property('editorId', editorId),
+		expect(promise).to.eventually.have
+			.property('achievementId', achievementId)
+	]);
+}
+
+export function expectAchievementIdsNested(promise, name,
+	editorId, achievementId, titleId) {
+	return Promise.all([
+		expect(promise).to.eventually.have.nested
+			.property(`${name} III.editorId`, editorId),
+		expect(promise).to.eventually.have.nested
+			.property(`${name} III.achievementId`, achievementId),
+		expect(promise).to.eventually.have.nested
+			.property(`${name}.editorId`, editorId),
+		expect(promise).to.eventually.have.nested
+			.property(`${name}.titleId`, titleId)
+	]);
+}

--- a/test/test-creator-creator.js
+++ b/test/test-creator-creator.js
@@ -17,6 +17,7 @@
  */
 
 import * as testData from '../data/test-data.js';
+import {expectAchievementIds, expectAchievementIdsNested} from './common';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -55,14 +56,11 @@ export default function tests() {
 					edit.creatorCreator['Creator Creator I']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.creatorCreatorIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.creatorCreatorIAttribs.id
+			);
 		}
 	);
 
@@ -82,14 +80,11 @@ export default function tests() {
 					edit.creatorCreator['Creator Creator II']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.creatorCreatorIIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.creatorCreatorIIAttribs.id
+			);
 		});
 
 	it('III should be given to someone with 100 creator creations',
@@ -108,20 +103,13 @@ export default function tests() {
 					edit.creatorCreator
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Creator Creator III.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Creator Creator III.achievementId',
-						testData.creatorCreatorIIIAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Creator Creator.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Creator Creator.titleId',
-						testData.creatorCreatorAttribs.id)
-			]);
+			return expectAchievementIdsNested(
+				achievementPromise,
+				'Creator Creator',
+				testData.editorAttribs.id,
+				testData.creatorCreatorIIIAttribs.id,
+				testData.creatorCreatorAttribs.id,
+			);
 		});
 
 	it('should not be given to someone with 0 creator creations',

--- a/test/test-explorer.js
+++ b/test/test-explorer.js
@@ -20,6 +20,7 @@ import * as testData from '../data/test-data.js';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import {expectAchievementIds} from './common';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
@@ -59,13 +60,11 @@ export default function tests() {
 				edit.explorer['Explorer I']
 			);
 
-		return Promise.all([
-			expect(achievementPromise).to.eventually.have
-				.property('editorId', testData.editorAttribs.id),
-			expect(achievementPromise).to.eventually.have
-				.property('achievementId',
-					testData.explorerIAttribs.id)
-		]);
+		return expectAchievementIds(
+			achievementPromise,
+			testData.editorAttribs.id,
+			testData.explorerIAttribs.id
+		);
 	});
 
 	it('II should be given to someone with 100 entity views', () => {
@@ -84,13 +83,11 @@ export default function tests() {
 				edit.explorer['Explorer II']
 			);
 
-		return Promise.all([
-			expect(achievementPromise).to.eventually.have
-				.property('editorId', testData.editorAttribs.id),
-			expect(achievementPromise).to.eventually.have
-				.property('achievementId',
-					testData.explorerIIAttribs.id)
-		]);
+		return expectAchievementIds(
+			achievementPromise,
+			testData.editorAttribs.id,
+			testData.explorerIIAttribs.id
+		);
 	});
 
 	it('III should be given to someone with 1000 entity views',
@@ -110,13 +107,11 @@ export default function tests() {
 					edit.explorer['Explorer III']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId', testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.explorerIIIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.explorerIIIAttribs.id
+			);
 		});
 
 	it('I should not be given to someone with 9 entity views', () => {

--- a/test/test-fun-runner.js
+++ b/test/test-fun-runner.js
@@ -20,6 +20,7 @@ import * as testData from '../data/test-data.js';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import {expectAchievementIds} from './common';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
@@ -67,12 +68,11 @@ export default function tests() {
 					edit.funRunner['Fun Runner']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId', testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId', testData.funRunnerAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.funRunnerAttribs.id
+			);
 		});
 
 	it('shouldn\'t be given to someone without a revision a day for a week',

--- a/test/test-hot-off-the-press.js
+++ b/test/test-hot-off-the-press.js
@@ -20,6 +20,7 @@ import * as testData from '../data/test-data.js';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import {expectAchievementIds} from './common';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
@@ -58,13 +59,11 @@ export default function tests() {
 						edit.hotOffThePress['Hot Off the Press']
 					);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId', testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.hotOffThePressAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.hotOffThePressAttribs.id
+			);
 		}
 	);
 

--- a/test/test-limited-edition.js
+++ b/test/test-limited-edition.js
@@ -17,6 +17,7 @@
  */
 
 import * as testData from '../data/test-data.js';
+import {expectAchievementIds, expectAchievementIdsNested} from './common';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -55,14 +56,11 @@ export default function tests() {
 					edit.limitedEdition['Limited Edition I']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.limitedEditionIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.limitedEditionIAttribs.id
+			);
 		}
 	);
 
@@ -82,14 +80,11 @@ export default function tests() {
 					edit.limitedEdition['Limited Edition II']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.limitedEditionIIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.limitedEditionIIAttribs.id
+			);
 		});
 
 	it('III should be given to someone with 100 edition creations',
@@ -108,20 +103,13 @@ export default function tests() {
 					edit.limitedEdition
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Limited Edition III.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Limited Edition III.achievementId',
-						testData.limitedEditionIIIAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Limited Edition.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Limited Edition.titleId',
-						testData.limitedEditionAttribs.id)
-			]);
+			return expectAchievementIdsNested(
+				achievementPromise,
+				'Limited Edition',
+				testData.editorAttribs.id,
+				testData.limitedEditionIIIAttribs.id,
+				testData.limitedEditionAttribs.id,
+			);
 		});
 
 	it('should not given to someone with 0 edition creations',

--- a/test/test-marathoner.js
+++ b/test/test-marathoner.js
@@ -20,6 +20,7 @@ import * as testData from '../data/test-data.js';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import {expectAchievementIds} from './common';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
@@ -67,12 +68,11 @@ export default function tests() {
 					edit.marathoner.Marathoner
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId', testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId', testData.marathonerAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.marathonerAttribs.id
+			);
 		});
 
 	it('shouldn\'t be given to someone without a revision a day for 30 days',

--- a/test/test-publisher-creator.js
+++ b/test/test-publisher-creator.js
@@ -17,6 +17,7 @@
  */
 
 import * as testData from '../data/test-data.js';
+import {expectAchievementIds, expectAchievementIdsNested} from './common';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -56,14 +57,11 @@ export default function tests() {
 					edit.publisherCreator['Publisher Creator I']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.publisherCreatorIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.publisherCreatorIAttribs.id
+			);
 		}
 	);
 
@@ -83,14 +81,11 @@ export default function tests() {
 					edit.publisherCreator['Publisher Creator II']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.publisherCreatorIIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.publisherCreatorIIAttribs.id
+			);
 		});
 
 	it('III should be given to someone with 100 publisher creations',
@@ -109,20 +104,13 @@ export default function tests() {
 					edit.publisherCreator
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher Creator III.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher Creator III.achievementId',
-						testData.publisherCreatorIIIAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher Creator.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher Creator.titleId',
-						testData.publisherCreatorAttribs.id)
-			]);
+			return expectAchievementIdsNested(
+				achievementPromise,
+				'Publisher Creator',
+				testData.editorAttribs.id,
+				testData.publisherCreatorIIIAttribs.id,
+				testData.publisherCreatorAttribs.id,
+			);
 		});
 
 	it('should not be given to someone with 0 publisher creations',

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -17,6 +17,7 @@
  */
 
 import * as testData from '../data/test-data.js';
+import {expectAchievementIds, expectAchievementIdsNested} from './common';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -55,14 +56,11 @@ export default function tests() {
 					edit.publisher['Publisher I']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.publisherIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.publisherIAttribs.id
+			);
 		}
 	);
 
@@ -82,14 +80,11 @@ export default function tests() {
 					edit.publisher['Publisher II']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.publisherIIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.publisherIIAttribs.id
+			);
 		});
 
 	it('III should be given to someone with 100 publication creations',
@@ -108,20 +103,13 @@ export default function tests() {
 					edit.publisher
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher III.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher III.achievementId',
-						testData.publisherIIIAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Publisher.titleId',
-						testData.publisherAttribs.id)
-			]);
+			return expectAchievementIdsNested(
+				achievementPromise,
+				'Publisher',
+				testData.editorAttribs.id,
+				testData.publisherIIIAttribs.id,
+				testData.publisherAttribs.id,
+			);
 		});
 
 	it('should not be given to someone with 0 publication creations',

--- a/test/test-revisionist.js
+++ b/test/test-revisionist.js
@@ -18,6 +18,7 @@
 
 import * as achievement from '../lib/server/helpers/achievement';
 import * as testData from '../data/test-data.js';
+import {expectAchievementIds, expectAchievementIdsNested} from './common';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -53,13 +54,11 @@ export default function tests() {
 				edit.revisionist['Revisionist I']
 			);
 
-		return Promise.all([
-			expect(achievementPromise).to.eventually.have
-				.property('editorId', testData.editorAttribs.id),
-			expect(achievementPromise).to.eventually.have
-				.property('achievementId',
-					testData.revisionistIAttribs.id)
-		]);
+		return expectAchievementIds(
+			achievementPromise,
+			testData.editorAttribs.id,
+			testData.revisionistIAttribs.id
+		);
 	});
 
 	it('II should be given to someone with 50 revisions', () => {
@@ -106,20 +105,13 @@ export default function tests() {
 					edit.revisionist
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Revisionist III.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Revisionist III.achievementId',
-						testData.revisionistIIIAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Revisionist.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Revisionist.titleId',
-						testData.revisionistAttribs.id)
-			]);
+			return expectAchievementIdsNested(
+				achievementPromise,
+				'Revisionist',
+				testData.editorAttribs.id,
+				testData.revisionistIIIAttribs.id,
+				testData.revisionistAttribs.id,
+			);
 		});
 
 	it('should not be given to someone without a revision', () => {

--- a/test/test-sprinter.js
+++ b/test/test-sprinter.js
@@ -21,6 +21,7 @@ import * as testData from '../data/test-data.js';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import {expectAchievementIds} from './common';
 import orm from './bookbrainz-data';
 
 
@@ -51,12 +52,11 @@ export default function tests() {
 				edit.sprinter.Sprinter
 			);
 
-		return Promise.all([
-			expect(achievementPromise).to.eventually.have
-				.property('editorId', testData.editorAttribs.id),
-			expect(achievementPromise).to.eventually.have
-				.property('achievementId', testData.sprinterAttribs.id)
-		]);
+		return expectAchievementIds(
+			achievementPromise,
+			testData.editorAttribs.id,
+			testData.sprinterAttribs.id
+		);
 	});
 
 

--- a/test/test-time-traveller.js
+++ b/test/test-time-traveller.js
@@ -20,6 +20,7 @@ import * as testData from '../data/test-data.js';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import {expectAchievementIds} from './common';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
@@ -60,12 +61,11 @@ export default function tests() {
 						edit['Time Traveller']
 					);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId', testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId', testData.timeTravellerAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.timeTravellerAttribs.id
+			);
 		}
 	);
 

--- a/test/test-worker-bee.js
+++ b/test/test-worker-bee.js
@@ -17,6 +17,7 @@
  */
 
 import * as testData from '../data/test-data.js';
+import {expectAchievementIds, expectAchievementIdsNested} from './common';
 import Promise from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -56,14 +57,11 @@ export default function tests() {
 					edit.workerBee['Worker Bee I']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.workerBeeIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.workerBeeIAttribs.id
+			);
 		}
 	);
 
@@ -83,14 +81,11 @@ export default function tests() {
 					edit.workerBee['Worker Bee II']
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have
-					.property('editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have
-					.property('achievementId',
-						testData.workerBeeIIAttribs.id)
-			]);
+			return expectAchievementIds(
+				achievementPromise,
+				testData.editorAttribs.id,
+				testData.workerBeeIIAttribs.id
+			);
 		});
 
 	it('III should be given to someone with 100 work creations',
@@ -109,20 +104,13 @@ export default function tests() {
 					edit.workerBee
 				);
 
-			return Promise.all([
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Worker Bee III.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Worker Bee III.achievementId',
-						testData.workerBeeIIIAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Worker Bee.editorId',
-						testData.editorAttribs.id),
-				expect(achievementPromise).to.eventually.have.nested
-					.property('Worker Bee.titleId',
-						testData.workerBeeAttribs.id)
-			]);
+			return expectAchievementIdsNested(
+				achievementPromise,
+				'Worker Bee',
+				testData.editorAttribs.id,
+				testData.workerBeeIIIAttribs.id,
+				testData.workerBeeAttribs.id,
+			);
 		});
 
 	it('should not be given to someone with 0 work creations',


### PR DESCRIPTION
### Problem
Reduce the amount of code that needs to be maintained for testing.

### Solution
Factor out common assertion pattern applied to `achievementPromise`.

### Areas of Impact
This affects most `.js` files directly in the `test/` directory and doesn't change any behaviour.