### PR TITLE
Fix(Duplicate Alias):Added check if Alias is duplicated

### DIFF
--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -180,7 +180,18 @@ export function makeEntityCreateOrEditHandler(
 			const err = new error.FormSubmissionError();
 			error.sendErrorAsJSON(res, err);
 		}
-
+		if (req.body.aliasEditor !== null) {
+			for (const alias in req.body.aliasEditor) {
+				 req.app.locals.orm['Alias']
+					 .forge({name: req.body.aliasEditor[alias].name})
+					 .fetch().then((results) => {
+					 if (results !== null) {
+						 const err = new error.AliasDuplicateError();
+						 error.sendErrorAsJSON(res, err);
+					 }
+				 });
+			}
+		}
 		req.body = transformNewForm(req.body);
 
 		const entityFunction = action === 'create' ?

--- a/src/server/helpers/error.js
+++ b/src/server/helpers/error.js
@@ -83,6 +83,17 @@ export class FormSubmissionError extends SiteError {
 	}
 }
 
+// When Alias Already exists
+export class AliasDuplicateError extends SiteError {
+	static get defaultMessage() {
+		return 'Duplicate Alias';
+	}
+
+	static get status() {
+		return status.BAD_REQUEST;
+	}
+}
+
 export class NotAuthenticatedError extends _AuthenticationError {
 	static get defaultMessage() {
 		return 'You are not currently authenticated';


### PR DESCRIPTION
Fixes: Duplicate Aliases problem.

Error is thrown at time of form submission if alias is duplicated.

A check function is added to check if added alias is already present in AliasSet.

