### PR TITLE
update init function to address requestTimeOut Failure on reindexing

### DIFF
--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -294,6 +294,8 @@ export function searchByName(orm, name, collection) {
 }
 
 export async function init(orm, options) {
+	// Default requestTimeOut is 30000ms which become short for reindexing now
+	options.requestTimeOut = 60000;
 	const config = _.extend({
 		defer() {
 			const defer = {};


### PR DESCRIPTION

### Problem
When reindexing the data in elasticsearch it is giving error request timeout.


### Solution
Increase the value of requestTimeOut.


### Areas of Impact
When we build the project and we have to reindex the data in the elasticsearch. The default requestTimeOut is 30000ms which is become short for indexing current dumped database.


