### PR TITLE
refactor(tests): Deduplicate common test patterns

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -49,7 +49,7 @@ export function expectRevNamedIds(name, prop, rev) {
 	]);
 }
 
-export function expectIdsNested(name, prop, rev) {
+export function expectAllNamedIds(name, prop, rev) {
 	return (promise) => Promise.all([
 		expect(promise).to.eventually.have.nested
 			.property(`${name} ${rev}.editorId`,
@@ -84,12 +84,12 @@ export function generate(Achievement, orm, full) {
 	};
 }
 
-export function rewireAchievement(Achievement, rewiring) {
+export function rewire(Achievement, rewiring) {
 	return () => Achievement.__set__(rewiring);
 }
 
 export function rewireTypeCreation(Achievement, name, threshold) {
-	return rewireAchievement(Achievement, {
+	return rewire(Achievement, {
 		getTypeCreation:
 			testData.typeCreationHelper(
 				`${name}_revision`, threshold

--- a/test/common.js
+++ b/test/common.js
@@ -66,14 +66,14 @@ export function expectAllNamedIds(name, prop, rev) {
 	]);
 }
 
-export function generate(Achievement, orm, full) {
+export function getAttrPromise(Achievement, orm, full) {
 	return () => {
-		const editor = full ? testData.createEditor() :
+		const editorPromise = full ? testData.createEditor() :
 			new orm.Editor({name: testData.editorAttribs.name}).fetch();
-		return editor
-			.then((edit) => Achievement.processEdit(orm, edit.id))
-			.then((edit) => {
-				let value = edit;
+		return editorPromise
+			.then((editor) => Achievement.processEdit(orm, editor.id))
+			.then((editor) => {
+				let value = editor;
 
 				for (let index = 3; index < arguments.length; index++) {
 					value = value[arguments[index]];
@@ -97,10 +97,10 @@ export function rewireTypeCreation(Achievement, name, threshold) {
 	});
 }
 
-export function testAchievement(rewiring, generator, expectations) {
+export function testAchievement(rewiring, attrPromise, expectations) {
 	return () => {
 		rewiring();
-		const promise = generator();
+		const promise = attrPromise();
 		return expectations(promise);
 	};
 }

--- a/test/test-creator-creator.js
+++ b/test/test-creator-creator.js
@@ -32,12 +32,12 @@ function rewireTypeCreation(threshold) {
 	return common.rewireTypeCreation(Achievement, 'creator', threshold);
 }
 
-function generate() {
-	return common.generate(Achievement, orm, true, 'creatorCreator');
+function getAttrPromise() {
+	return common.getAttrPromise(Achievement, orm, true, 'creatorCreator');
 }
 
-function generateLabeled(rev) {
-	return common.generate(
+function getRevAttrPromise(rev) {
+	return common.getAttrPromise(
 		Achievement, orm, true, 'creatorCreator', `Creator Creator ${rev}`
 	);
 }
@@ -56,28 +56,28 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireTypeCreation(thresholdI),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		expectIds('I')
 	);
 	it('I should be given to someone with a creator creation', test1);
 
 	const test2 = common.testAchievement(
 		rewireTypeCreation(thresholdII),
-		generateLabeled('II'),
+		getRevAttrPromise('II'),
 		expectIds('II')
 	);
 	it('II should be given to someone with 10 creator creations', test2);
 
 	const test3 = common.testAchievement(
 		rewireTypeCreation(thresholdIII),
-		generate(),
+		getAttrPromise(),
 		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 creator creations', test3);
 
 	const test4 = common.testAchievement(
 		rewireTypeCreation(0),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		common.expectFalse()
 	);
 	it('should not be given to someone with 0 creator creations', test4);

--- a/test/test-creator-creator.js
+++ b/test/test-creator-creator.js
@@ -18,14 +18,9 @@
 
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
-
-chai.use(chaiAsPromised);
-const {expect} = chai;
 
 const Achievement = rewire('../lib/server/helpers/achievement.js');
 
@@ -33,60 +28,57 @@ const thresholdI = 1;
 const thresholdII = 10;
 const thresholdIII = 100;
 
+function rewireTypeCreation(threshold) {
+	return common.rewireAchievementTypeCreation(Achievement, 'creator', threshold);
+}
+
+function generate() {
+	return common.generate(Achievement, orm, true, 'creatorCreator');
+}
+
+function generateLabeled(rev) {
+	return common.generate(
+		Achievement, orm, true, 'creatorCreator', `Creator Creator ${rev}`
+	);
+}
+
+function expectIds(rev) {
+	return common.expectIds('creatorCreator', rev);
+}
+
+function expectAllNamedIds(rev) {
+	return common.expectIdsNested('Creator Creator', 'creatorCreator', rev);
+}
+
 export default function tests() {
 	beforeEach(() => testData.createCreatorCreator());
-
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'creator', thresholdI
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'creatorCreator', 'Creator Creator', 'I'
-		),
-		common.expectIds(
-			'creatorCreator', 'I'
-		)
+		rewireTypeCreation(thresholdI),
+		generateLabeled('I'),
+		expectIds('I')
 	);
 	it('I should be given to someone with a creator creation', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'creator', thresholdII
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'creatorCreator', 'Creator Creator', 'II'
-		),
-		common.expectIds(
-			'creatorCreator', 'II'
-		)
+		rewireTypeCreation(thresholdII),
+		generateLabeled('II'),
+		expectIds('II')
 	);
 	it('II should be given to someone with 10 creator creations', test2);
 
 	const test3 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'creator', thresholdIII
-		),
-		() => testData.createEditor()
-			.then((editor) => Achievement.processEdit(orm, editor.id))
-			.then((edit) => edit.creatorCreator),
-		common.expectIdsNested(
-			'Creator Creator',
-			'creatorCreator',
-			'III'
-		)
+		rewireTypeCreation(thresholdIII),
+		generate(),
+		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 creator creations', test3);
 
 	const test4 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'creator_revision', 0
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'creatorCreator', 'Creator Creator', 'I'
-		),
-		(promise) => expect(promise).to.eventually.equal(false)
+		rewireTypeCreation(0),
+		generateLabeled('I'),
+		common.expectFalse()
 	);
 	it('should not be given to someone with 0 creator creations', test4);
 }

--- a/test/test-creator-creator.js
+++ b/test/test-creator-creator.js
@@ -29,7 +29,7 @@ const thresholdII = 10;
 const thresholdIII = 100;
 
 function rewireTypeCreation(threshold) {
-	return common.rewireAchievementTypeCreation(Achievement, 'creator', threshold);
+	return common.rewireTypeCreation(Achievement, 'creator', threshold);
 }
 
 function generate() {
@@ -47,7 +47,7 @@ function expectIds(rev) {
 }
 
 function expectAllNamedIds(rev) {
-	return common.expectIdsNested('Creator Creator', 'creatorCreator', rev);
+	return common.expectAllNamedIds('Creator Creator', 'creatorCreator', rev);
 }
 
 export default function tests() {

--- a/test/test-explorer.js
+++ b/test/test-explorer.js
@@ -31,7 +31,7 @@ const thresholdII = 100;
 const thresholdIII = 1000;
 
 function rewireEntityVisits(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEntityVisits: () => Promise.resolve(threshold)
 	});
 }

--- a/test/test-explorer.js
+++ b/test/test-explorer.js
@@ -18,14 +18,10 @@
 
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
 
-chai.use(chaiAsPromised);
-const {expect} = chai;
 const {Editor} = orm;
 
 const Achievement = rewire('../lib/server/helpers/achievement.js');
@@ -34,73 +30,54 @@ const thresholdI = 10;
 const thresholdII = 100;
 const thresholdIII = 1000;
 
-export default function tests() {
-	beforeEach(
-		() => testData.createEditor()
-			.then(() => testData.createExplorer())
-	);
+function rewireEntityVisits(threshold) {
+	return common.rewireAchievement(Achievement, {
+		getEntityVisits: () => Promise.resolve(threshold)
+	});
+}
 
+function generatePageVisit(rev) {
+	return () => new Editor({name: testData.editorAttribs.name})
+		.fetch()
+		.then((editor) => Achievement.processPageVisit(orm, editor.id))
+		.then((edit) => edit.explorer[`Explorer ${rev}`]);
+}
+
+function expectIds(rev) {
+	return common.expectIds('explorer', rev);
+}
+
+export default function tests() {
+	beforeEach(() => testData.createEditor()
+		.then(() => testData.createExplorer())
+	);
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEntityVisits: () => Promise.resolve(thresholdI)
-		}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
-			.fetch()
-			.then((editor) => Achievement.processPageVisit(orm, editor.id))
-			.then((edit) => edit.explorer['Explorer I']),
-		common.expectIds(
-			'explorer', 'I'
-		)
+		rewireEntityVisits(thresholdI),
+		generatePageVisit('I'),
+		expectIds('I')
 	);
 	it('I should be given to someone with 10 entity views', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEntityVisits: () => Promise.resolve(thresholdII)
-		}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
-			.fetch()
-			.then((editor) => Achievement.processPageVisit(orm, editor.id))
-			.then((edit) => edit.explorer['Explorer II']),
-		common.expectIds(
-			'explorer', 'II'
-		)
+		rewireEntityVisits(thresholdII),
+		generatePageVisit('II'),
+		expectIds('II')
 	);
 	it('II should be given to someone with 100 entity views', test2);
 
 	const test3 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEntityVisits: () => Promise.resolve(thresholdIII)
-		}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
-			.fetch()
-			.then((editor) => Achievement.processPageVisit(orm, editor.id))
-			.then((edit) => edit.explorer['Explorer III']),
-		common.expectIds(
-			'explorer', 'III'
-		)
+		rewireEntityVisits(thresholdIII),
+		generatePageVisit('III'),
+		expectIds('III')
 	);
 	it('III should be given to someone with 1000 entity views', test3);
 
 	const test4 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEntityVisits: () => Promise.resolve(thresholdI - 1)
-		}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
-			.fetch()
-			.then((editor) => Achievement.processPageVisit(orm, editor.id))
-			.then((edit) => edit.explorer['Explorer I']),
-		(promise) => expect(promise).to.eventually.equal(false)
+		rewireEntityVisits(thresholdI - 1),
+		generatePageVisit('I'),
+		common.expectFalse()
 	);
 	it('I should not be given to someone with 9 entity views', test4);
 }

--- a/test/test-explorer.js
+++ b/test/test-explorer.js
@@ -36,7 +36,7 @@ function rewireEntityVisits(threshold) {
 	});
 }
 
-function generatePageVisit(rev) {
+function getPageVisitAttrPromise(rev) {
 	return () => new Editor({name: testData.editorAttribs.name})
 		.fetch()
 		.then((editor) => Achievement.processPageVisit(orm, editor.id))
@@ -55,28 +55,28 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireEntityVisits(thresholdI),
-		generatePageVisit('I'),
+		getPageVisitAttrPromise('I'),
 		expectIds('I')
 	);
 	it('I should be given to someone with 10 entity views', test1);
 
 	const test2 = common.testAchievement(
 		rewireEntityVisits(thresholdII),
-		generatePageVisit('II'),
+		getPageVisitAttrPromise('II'),
 		expectIds('II')
 	);
 	it('II should be given to someone with 100 entity views', test2);
 
 	const test3 = common.testAchievement(
 		rewireEntityVisits(thresholdIII),
-		generatePageVisit('III'),
+		getPageVisitAttrPromise('III'),
 		expectIds('III')
 	);
 	it('III should be given to someone with 1000 entity views', test3);
 
 	const test4 = common.testAchievement(
 		rewireEntityVisits(thresholdI - 1),
-		generatePageVisit('I'),
+		getPageVisitAttrPromise('I'),
 		common.expectFalse()
 	);
 	it('I should not be given to someone with 9 entity views', test4);

--- a/test/test-fun-runner.js
+++ b/test/test-fun-runner.js
@@ -18,67 +18,70 @@
 
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
-
-chai.use(chaiAsPromised);
-const {expect} = chai;
 
 const Achievement = rewire('../lib/server/helpers/achievement.js');
 
 const funRunnerThreshold = 7;
 const funRunnerDays = 6;
 
-export default function tests() {
-	beforeEach(
-		() => testData.createEditor()
-			.then(() => testData.createFunRunner())
-	);
+function rewireEditsInDaysTwo(threshold) {
+	return common.rewireAchievement(Achievement, {
+		getEditsInDays: (editorId, days) => {
+			let editPromise;
+			if (days === funRunnerDays) {
+				editPromise = Promise.resolve(threshold);
+			}
+			else {
+				editPromise = Promise.resolve(0);
+			}
+			return editPromise;
+		}
+	});
+}
 
+function rewireEditsInDaysThree(threshold) {
+	return common.rewireAchievement(Achievement, {
+		getEditsInDays: (_orm, editorId, days) => {
+			let editPromise;
+			if (days === funRunnerDays) {
+				editPromise = Promise.resolve(threshold);
+			}
+			else {
+				editPromise = Promise.resolve(0);
+			}
+			return editPromise;
+		}
+	});
+}
+
+function generateLabeled() {
+	return common.generate(Achievement, orm, false, 'funRunner', 'Fun Runner');
+}
+
+function expectIds(rev) {
+	return common.expectIds('funRunner', rev);
+}
+
+export default function tests() {
+	beforeEach(() => testData.createEditor()
+		.then(() => testData.createFunRunner())
+	);
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEditsInDays: (_orm, editorId, days) => {
-				let editPromise;
-				if (days === funRunnerDays) {
-					editPromise = Promise.resolve(funRunnerThreshold);
-				}
-				else {
-					editPromise = Promise.resolve(0);
-				}
-				return editPromise;
-			}
-		}),
-		common.generateProcessEditNamed(
-			Achievement, orm, 'funRunner', 'Fun Runner'
-		),
-		common.expectIds(
-			'funRunner', ''
-		)
+		rewireEditsInDaysThree(funRunnerThreshold),
+		generateLabeled(),
+		expectIds('')
 	);
 	it('should be given to someone with a revision a day for a week', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEditsInDays: (editorId, days) => {
-				let editPromise;
-				if (days === funRunnerDays) {
-					editPromise = Promise.resolve(funRunnerThreshold - 1);
-				}
-				else {
-					editPromise = Promise.resolve(0);
-				}
-				return editPromise;
-			}
-		}),
-		common.generateProcessEditNamed(
-			Achievement, orm, 'funRunner', 'Fun Runner'
-		),
-		(promise) => expect(promise).to.eventually.equal(false)
+		rewireEditsInDaysTwo(funRunnerThreshold - 1),
+		generateLabeled(),
+		common.expectFalse()
 	);
 	it('shouldn\'t be given to someone without a revision a day for a week',
 		test2);

--- a/test/test-fun-runner.js
+++ b/test/test-fun-runner.js
@@ -57,8 +57,8 @@ function rewireEditsInDaysThree(threshold) {
 	});
 }
 
-function generateLabeled() {
-	return common.generate(Achievement, orm, false, 'funRunner', 'Fun Runner');
+function getRevAttrPromise() {
+	return common.getAttrPromise(Achievement, orm, false, 'funRunner', 'Fun Runner');
 }
 
 function expectIds(rev) {
@@ -73,14 +73,14 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireEditsInDaysThree(funRunnerThreshold),
-		generateLabeled(),
+		getRevAttrPromise(),
 		expectIds('')
 	);
 	it('should be given to someone with a revision a day for a week', test1);
 
 	const test2 = common.testAchievement(
 		rewireEditsInDaysTwo(funRunnerThreshold - 1),
-		generateLabeled(),
+		getRevAttrPromise(),
 		common.expectFalse()
 	);
 	it('shouldn\'t be given to someone without a revision a day for a week',

--- a/test/test-fun-runner.js
+++ b/test/test-fun-runner.js
@@ -28,7 +28,7 @@ const funRunnerThreshold = 7;
 const funRunnerDays = 6;
 
 function rewireEditsInDaysTwo(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEditsInDays: (editorId, days) => {
 			let editPromise;
 			if (days === funRunnerDays) {
@@ -43,7 +43,7 @@ function rewireEditsInDaysTwo(threshold) {
 }
 
 function rewireEditsInDaysThree(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEditsInDays: (_orm, editorId, days) => {
 			let editPromise;
 			if (days === funRunnerDays) {

--- a/test/test-hot-off-the-press.js
+++ b/test/test-hot-off-the-press.js
@@ -27,7 +27,7 @@ const Achievement = rewire('../lib/server/helpers/achievement.js');
 const hotOffThePressThreshold = -7;
 
 function rewireEditionDateDifference(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEditionDateDifference: () =>
 			Promise.resolve(threshold)
 	});

--- a/test/test-hot-off-the-press.js
+++ b/test/test-hot-off-the-press.js
@@ -33,8 +33,8 @@ function rewireEditionDateDifference(threshold) {
 	});
 }
 
-function generateLabeled() {
-	return common.generate(
+function getRevAttrPromise() {
+	return common.getAttrPromise(
 		Achievement, orm, false, 'hotOffThePress', 'Hot Off the Press'
 	);
 }
@@ -51,7 +51,7 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireEditionDateDifference(hotOffThePressThreshold),
-		generateLabeled(),
+		getRevAttrPromise(),
 		expectIds('')
 	);
 	it('should be given to someone with edition revision released this week',
@@ -59,7 +59,7 @@ export default function tests() {
 
 	const test2 = common.testAchievement(
 		rewireEditionDateDifference(hotOffThePressThreshold - 1),
-		common.generate(
+		common.getAttrPromise(
 			Achievement, orm, false, 'timeTraveller', 'Time Traveller'
 		),
 		common.expectFalse()

--- a/test/test-limited-edition.js
+++ b/test/test-limited-edition.js
@@ -32,8 +32,8 @@ function rewireTypeCreation(threshold) {
 	return common.rewireTypeCreation(Achievement, 'edition', threshold);
 }
 
-function generateLabeled(rev) {
-	return common.generate(
+function getRevAttrPromise(rev) {
+	return common.getAttrPromise(
 		Achievement, orm, true, 'limitedEdition', `Limited Edition ${rev}`
 	);
 }
@@ -52,28 +52,28 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireTypeCreation(thresholdI),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		expectIds('I')
 	);
 	it('I should given to someone with an edition creation', test1);
 
 	const test2 = common.testAchievement(
 		rewireTypeCreation(thresholdII),
-		generateLabeled('II'),
+		getRevAttrPromise('II'),
 		expectIds('II')
 	);
 	it('II should be given to someone with 10 edition creations', test2);
 
 	const test3 = common.testAchievement(
 		rewireTypeCreation(thresholdIII),
-		common.generate(Achievement, orm, true, 'limitedEdition'),
+		common.getAttrPromise(Achievement, orm, true, 'limitedEdition'),
 		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 edition creations', test3);
 
 	const test4 = common.testAchievement(
 		rewireTypeCreation(0),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		common.expectFalse()
 	);
 	it('should not given to someone with 0 edition creations', test4);

--- a/test/test-limited-edition.js
+++ b/test/test-limited-edition.js
@@ -29,7 +29,7 @@ const thresholdII = 10;
 const thresholdIII = 100;
 
 function rewireTypeCreation(threshold) {
-	return common.rewireAchievementTypeCreation(Achievement, 'edition', threshold);
+	return common.rewireTypeCreation(Achievement, 'edition', threshold);
 }
 
 function generateLabeled(rev) {
@@ -43,7 +43,7 @@ function expectIds(rev) {
 }
 
 function expectAllNamedIds(rev) {
-	return common.expectIdsNested('Limited Edition', 'limitedEdition', rev);
+	return common.expectAllNamedIds('Limited Edition', 'limitedEdition', rev);
 }
 
 export default function tests() {

--- a/test/test-marathoner.js
+++ b/test/test-marathoner.js
@@ -28,7 +28,7 @@ const marathonerDays = 29;
 const marathonerThreshold = 30;
 
 function rewireEditsInDaysTwo(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEditsInDays: (editorId, days) => {
 			let editPromise;
 			if (days === marathonerDays) {
@@ -43,7 +43,7 @@ function rewireEditsInDaysTwo(threshold) {
 }
 
 function rewireEditsInDaysThree(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEditsInDays: (_orm, editorId, days) => {
 			let editPromise;
 			if (days === marathonerDays) {

--- a/test/test-marathoner.js
+++ b/test/test-marathoner.js
@@ -18,67 +18,70 @@
 
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
-
-chai.use(chaiAsPromised);
-const {expect} = chai;
 
 const Achievement = rewire('../lib/server/helpers/achievement.js');
 
 const marathonerDays = 29;
 const marathonerThreshold = 30;
 
-export default function tests() {
-	beforeEach(
-		() => testData.createEditor()
-			.then(() => testData.createMarathoner())
-	);
+function rewireEditsInDaysTwo(threshold) {
+	return common.rewireAchievement(Achievement, {
+		getEditsInDays: (editorId, days) => {
+			let editPromise;
+			if (days === marathonerDays) {
+				editPromise = Promise.resolve(threshold);
+			}
+			else {
+				editPromise = Promise.resolve(0);
+			}
+			return editPromise;
+		}
+	});
+}
 
+function rewireEditsInDaysThree(threshold) {
+	return common.rewireAchievement(Achievement, {
+		getEditsInDays: (_orm, editorId, days) => {
+			let editPromise;
+			if (days === marathonerDays) {
+				editPromise = Promise.resolve(threshold);
+			}
+			else {
+				editPromise = Promise.resolve(0);
+			}
+			return editPromise;
+		}
+	});
+}
+
+function generateLabeled() {
+	return common.generate(Achievement, orm, false, 'marathoner', 'Marathoner');
+}
+
+function expectIds(rev) {
+	return common.expectIds('marathoner', rev);
+}
+
+export default function tests() {
+	beforeEach(() => testData.createEditor()
+		.then(() => testData.createMarathoner())
+	);
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEditsInDays: (_orm, editorId, days) => {
-				let editPromise;
-				if (days === marathonerDays) {
-					editPromise = Promise.resolve(marathonerThreshold);
-				}
-				else {
-					editPromise = Promise.resolve(0);
-				}
-				return editPromise;
-			}
-		}),
-		common.generateProcessEditNamed(
-			Achievement, orm, 'marathoner', 'Marathoner'
-		),
-		common.expectIds(
-			'marathoner', ''
-		)
+		rewireEditsInDaysThree(marathonerThreshold),
+		generateLabeled(),
+		expectIds('')
 	);
 	it('should be given to someone with a revision a day for 30 days', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireAchievement(Achievement, {
-			getEditsInDays: (editorId, days) => {
-				let editPromise;
-				if (days === marathonerDays) {
-					editPromise = Promise.resolve(marathonerThreshold - 1);
-				}
-				else {
-					editPromise = Promise.resolve(0);
-				}
-				return editPromise;
-			}
-		}),
-		common.generateProcessEditNamed(
-			Achievement, orm, 'marathoner', 'Marathoner'
-		),
-		(promise) => expect(promise).to.eventually.equal(false)
+		rewireEditsInDaysTwo(marathonerThreshold - 1),
+		generateLabeled(),
+		common.expectFalse()
 	);
 	it('shouldn\'t be given to someone without a revision a day for 30 days',
 		test2);

--- a/test/test-marathoner.js
+++ b/test/test-marathoner.js
@@ -57,8 +57,8 @@ function rewireEditsInDaysThree(threshold) {
 	});
 }
 
-function generateLabeled() {
-	return common.generate(Achievement, orm, false, 'marathoner', 'Marathoner');
+function getRevAttrPromise() {
+	return common.getAttrPromise(Achievement, orm, false, 'marathoner', 'Marathoner');
 }
 
 function expectIds(rev) {
@@ -73,14 +73,14 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireEditsInDaysThree(marathonerThreshold),
-		generateLabeled(),
+		getRevAttrPromise(),
 		expectIds('')
 	);
 	it('should be given to someone with a revision a day for 30 days', test1);
 
 	const test2 = common.testAchievement(
 		rewireEditsInDaysTwo(marathonerThreshold - 1),
-		generateLabeled(),
+		getRevAttrPromise(),
 		common.expectFalse()
 	);
 	it('shouldn\'t be given to someone without a revision a day for 30 days',

--- a/test/test-publisher-creator.js
+++ b/test/test-publisher-creator.js
@@ -29,7 +29,7 @@ const thresholdII = 10;
 const thresholdIII = 100;
 
 function rewireTypeCreation(threshold) {
-	return common.rewireAchievementTypeCreation(Achievement, 'publisher', threshold);
+	return common.rewireTypeCreation(Achievement, 'publisher', threshold);
 }
 
 function generate() {
@@ -47,7 +47,7 @@ function expectIds(rev) {
 }
 
 function expectAllNamedIds(rev) {
-	return common.expectIdsNested(
+	return common.expectAllNamedIds(
 		'Publisher Creator', 'publisherCreator', rev
 	);
 }

--- a/test/test-publisher-creator.js
+++ b/test/test-publisher-creator.js
@@ -32,12 +32,12 @@ function rewireTypeCreation(threshold) {
 	return common.rewireTypeCreation(Achievement, 'publisher', threshold);
 }
 
-function generate() {
-	return common.generate(Achievement, orm, true, 'publisherCreator');
+function getAttrPromise() {
+	return common.getAttrPromise(Achievement, orm, true, 'publisherCreator');
 }
 
-function generateLabeled(rev) {
-	return common.generate(
+function getRevAttrPromise(rev) {
+	return common.getAttrPromise(
 		Achievement, orm, true, 'publisherCreator', `Publisher Creator ${rev}`
 	);
 }
@@ -58,28 +58,28 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireTypeCreation(thresholdI),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		expectIds('I')
 	);
 	it('I should be given to someone with a publisher creation', test1);
 
 	const test2 = common.testAchievement(
 		rewireTypeCreation(thresholdII),
-		generateLabeled('II'),
+		getRevAttrPromise('II'),
 		expectIds('II')
 	);
 	it('II should be given to someone with 10 publisher creations', test2);
 
 	const test3 = common.testAchievement(
 		rewireTypeCreation(thresholdIII),
-		generate(),
+		getAttrPromise(),
 		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 publisher creations', test3);
 
 	const test4 = common.testAchievement(
 		rewireTypeCreation(0),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		common.expectFalse()
 	);
 	it('should not be given to someone with 0 publisher creations', test4);

--- a/test/test-publisher-creator.js
+++ b/test/test-publisher-creator.js
@@ -18,14 +18,9 @@
 
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
-
-chai.use(chaiAsPromised);
-const {expect} = chai;
 
 const Achievement = rewire('../lib/server/helpers/achievement.js');
 
@@ -33,61 +28,59 @@ const thresholdI = 1;
 const thresholdII = 10;
 const thresholdIII = 100;
 
+function rewireTypeCreation(threshold) {
+	return common.rewireAchievementTypeCreation(Achievement, 'publisher', threshold);
+}
+
+function generate() {
+	return common.generate(Achievement, orm, true, 'publisherCreator');
+}
+
+function generateLabeled(rev) {
+	return common.generate(
+		Achievement, orm, true, 'publisherCreator', `Publisher Creator ${rev}`
+	);
+}
+
+function expectIds(rev) {
+	return common.expectIds('publisherCreator', rev);
+}
+
+function expectAllNamedIds(rev) {
+	return common.expectIdsNested(
+		'Publisher Creator', 'publisherCreator', rev
+	);
+}
 
 export default function tests() {
 	beforeEach(() => testData.createPublisherCreator());
-
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publisher', thresholdI
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'publisherCreator', 'Publisher Creator', 'I'
-		),
-		common.expectIds(
-			'publisherCreator', 'I'
-		)
+		rewireTypeCreation(thresholdI),
+		generateLabeled('I'),
+		expectIds('I')
 	);
 	it('I should be given to someone with a publisher creation', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publisher', thresholdII
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'publisherCreator', 'Publisher Creator', 'II'
-		),
-		common.expectIds(
-			'publisherCreator', 'II'
-		)
+		rewireTypeCreation(thresholdII),
+		generateLabeled('II'),
+		expectIds('II')
 	);
 	it('II should be given to someone with 10 publisher creations', test2);
 
 	const test3 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publisher', thresholdIII
-		),
-		() => testData.createEditor()
-			.then((editor) => Achievement.processEdit(orm, editor.id))
-			.then((edit) => edit.publisherCreator),
-		common.expectIdsNested(
-			'Publisher Creator',
-			'publisherCreator',
-			'III'
-		)
+		rewireTypeCreation(thresholdIII),
+		generate(),
+		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 publisher creations', test3);
 
 	const test4 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publisher', 0
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'publisherCreator', 'Publisher Creator', 'I'
-		),
-		(promise) => expect(promise).to.eventually.equal(false)
+		rewireTypeCreation(0),
+		generateLabeled('I'),
+		common.expectFalse()
 	);
 	it('should not be given to someone with 0 publisher creations', test4);
 }

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -29,7 +29,7 @@ const thresholdII = 10;
 const thresholdIII = 100;
 
 function rewireTypeCreation(threshold) {
-	return common.rewireAchievementTypeCreation(Achievement, 'publication', threshold);
+	return common.rewireTypeCreation(Achievement, 'publication', threshold);
 }
 
 function generate() {
@@ -47,7 +47,7 @@ function expectIds(rev) {
 }
 
 function expectAllNamedIds(rev) {
-	return common.expectIdsNested('Publisher', 'publisher', rev);
+	return common.expectAllNamedIds('Publisher', 'publisher', rev);
 }
 
 export default function tests() {

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -18,14 +18,9 @@
 
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
-
-chai.use(chaiAsPromised);
-const {expect} = chai;
 
 const Achievement = rewire('../src/server/helpers/achievement.js');
 
@@ -33,60 +28,57 @@ const thresholdI = 1;
 const thresholdII = 10;
 const thresholdIII = 100;
 
+function rewireTypeCreation(threshold) {
+	return common.rewireAchievementTypeCreation(Achievement, 'publication', threshold);
+}
+
+function generate() {
+	return common.generate(Achievement, orm, true, 'publisher');
+}
+
+function generateLabeled(rev) {
+	return common.generate(
+		Achievement, orm, true, 'publisher', `Publisher ${rev}`
+	);
+}
+
+function expectIds(rev) {
+	return common.expectIds('publisher', rev);
+}
+
+function expectAllNamedIds(rev) {
+	return common.expectIdsNested('Publisher', 'publisher', rev);
+}
+
 export default function tests() {
 	beforeEach(() => testData.createPublisher());
-
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publication', thresholdI
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'publisher', 'Publisher', 'I'
-		),
-		common.expectIds(
-			'publisher', 'I'
-		)
+		rewireTypeCreation(thresholdI),
+		generateLabeled('I'),
+		expectIds('I')
 	);
 	it('I should be given to someone with a publication creation', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publication', thresholdII
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'publisher', 'Publisher', 'II'
-		),
-		common.expectIds(
-			'publisher', 'II'
-		)
+		rewireTypeCreation(thresholdII),
+		generateLabeled('II'),
+		expectIds('II')
 	);
 	it('II should be given to someone with 10 publication creations', test2);
 
 	const test3 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publication', thresholdIII
-		),
-		() => testData.createEditor()
-			.then((editor) => Achievement.processEdit(orm, editor.id))
-			.then((edit) => edit.publisher),
-		common.expectIdsNested(
-			'Publisher',
-			'publisher',
-			'III'
-		)
+		rewireTypeCreation(thresholdIII),
+		generate(),
+		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 publication creations', test3);
 
 	const test4 = common.testAchievement(
-		common.rewireTypeCreation(
-			Achievement, 'publication', 0
-		),
-		common.generateProcessEdit(
-			Achievement, orm, 'publisher', 'Publisher', 'I'
-		),
-		(promise) => expect(promise).to.eventually.equal(false)
+		rewireTypeCreation(0),
+		generateLabeled('I'),
+		common.expectFalse()
 	);
 	it('should not be given to someone with 0 publication creations', test4);
 }

--- a/test/test-publisher.js
+++ b/test/test-publisher.js
@@ -32,12 +32,12 @@ function rewireTypeCreation(threshold) {
 	return common.rewireTypeCreation(Achievement, 'publication', threshold);
 }
 
-function generate() {
-	return common.generate(Achievement, orm, true, 'publisher');
+function getAttrPromise() {
+	return common.getAttrPromise(Achievement, orm, true, 'publisher');
 }
 
-function generateLabeled(rev) {
-	return common.generate(
+function getRevAttrPromise(rev) {
+	return common.getAttrPromise(
 		Achievement, orm, true, 'publisher', `Publisher ${rev}`
 	);
 }
@@ -56,28 +56,28 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireTypeCreation(thresholdI),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		expectIds('I')
 	);
 	it('I should be given to someone with a publication creation', test1);
 
 	const test2 = common.testAchievement(
 		rewireTypeCreation(thresholdII),
-		generateLabeled('II'),
+		getRevAttrPromise('II'),
 		expectIds('II')
 	);
 	it('II should be given to someone with 10 publication creations', test2);
 
 	const test3 = common.testAchievement(
 		rewireTypeCreation(thresholdIII),
-		generate(),
+		getAttrPromise(),
 		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 publication creations', test3);
 
 	const test4 = common.testAchievement(
 		rewireTypeCreation(0),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		common.expectFalse()
 	);
 	it('should not be given to someone with 0 publication creations', test4);

--- a/test/test-revisionist.js
+++ b/test/test-revisionist.js
@@ -28,7 +28,7 @@ const {Editor} = orm;
 const Achievement = rewire('../lib/server/helpers/achievement.js');
 
 function rewireNothing() {
-	return common.rewireAchievement(Achievement, {});
+	return common.rewire(Achievement, {});
 }
 
 function expectIds(rev) {
@@ -40,7 +40,7 @@ function expectRevNamedIds(rev) {
 }
 
 function expectAllNamedIds(rev) {
-	return common.expectIdsNested('Revisionist', 'revisionist', rev);
+	return common.expectAllNamedIds('Revisionist', 'revisionist', rev);
 }
 
 export default function tests() {

--- a/test/test-revisionist.js
+++ b/test/test-revisionist.js
@@ -19,86 +19,76 @@
 import * as achievement from '../lib/server/helpers/achievement';
 import * as common from './common';
 import * as testData from '../data/test-data.js';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
 import rewire from 'rewire';
 
 
-chai.use(chaiAsPromised);
-const {expect} = chai;
 const {Editor} = orm;
 
 const Achievement = rewire('../lib/server/helpers/achievement.js');
 
-export default function tests() {
-	beforeEach(
-		() => testData.createEditor()
-			.then(() => testData.createRevisionist())
-	);
+function rewireNothing() {
+	return common.rewireAchievement(Achievement, {});
+}
 
+function expectIds(rev) {
+	return common.expectIds('revisionist', rev);
+}
+
+function expectRevNamedIds(rev) {
+	return common.expectRevNamedIds('Revisionist', 'revisionist', rev);
+}
+
+function expectAllNamedIds(rev) {
+	return common.expectIdsNested('Revisionist', 'revisionist', rev);
+}
+
+export default function tests() {
+	beforeEach(() => testData.createEditor()
+		.then(() => testData.createRevisionist())
+	);
 	afterEach(testData.truncate);
 
 	const test1 = common.testAchievement(
-		common.rewireAchievement(Achievement, {}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
+		rewireNothing(),
+		() => new Editor({name: testData.editorAttribs.name})
 			.fetch()
 			.then((editor) => editor.set({revisionsApplied: 1}).save())
 			.then((editor) => achievement.processEdit(orm, editor.id))
 			.then((edit) => edit.revisionist['Revisionist I']),
-		common.expectIds(
-			'revisionist', 'I'
-		)
+		expectIds('I')
 	);
 	it('I should be given to someone with a revision', test1);
 
 	const test2 = common.testAchievement(
-		common.rewireAchievement(Achievement, {}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
+		rewireNothing(),
+		() => new Editor({name: testData.editorAttribs.name})
 			.fetch()
 			.then((editor) => editor.set({revisionsApplied: 50}).save())
 			.then((editor) => achievement.processEdit(orm, editor.id))
 			.then((edit) => edit.revisionist),
-		(promise) => Promise.all([
-			expect(promise).to.eventually.have.nested
-				.property('Revisionist II.editorId', testData.editorAttribs.id),
-			expect(promise).to.eventually.have.nested
-				.property('Revisionist II.achievementId',
-					testData.revisionistIIAttribs.id)
-		])
+		expectRevNamedIds('II')
 	);
 	it('II should be given to someone with 50 revisions', test2);
 
 	const test3 = common.testAchievement(
-		common.rewireAchievement(Achievement, {}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
+		rewireNothing(),
+		() => new Editor({name: testData.editorAttribs.name})
 			.fetch()
 			.then((editor) => editor.set({revisionsApplied: 250}).save())
 			.then((editor) => achievement.processEdit(orm, editor.id))
 			.then((edit) => edit.revisionist),
-		common.expectIdsNested(
-			'Revisionist',
-			'revisionist',
-			'III'
-		)
+		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 250 revisions', test3);
 
 	const test4 = common.testAchievement(
-		common.rewireAchievement(Achievement, {}),
-		() => new Editor({
-			name: testData.editorAttribs.name
-		})
+		rewireNothing(),
+		() => new Editor({name: testData.editorAttribs.name})
 			.fetch()
 			.then((editor) => achievement.processEdit(orm, editor.id))
 			.then((edit) => edit.revisionist['Revisionist I']),
-		(promise) => expect(promise).to.eventually.equal(false)
+		common.expectFalse()
 	);
 	it('should not be given to someone without a revision', test4);
 }

--- a/test/test-sprinter.js
+++ b/test/test-sprinter.js
@@ -30,7 +30,7 @@ const Achievement = rewire('../lib/server/helpers/achievement.js');
 const sprinterThreshold = 10;
 
 function rewireNothing() {
-	return common.rewireAchievement(Achievement, {});
+	return common.rewire(Achievement, {});
 }
 
 function expectIds(rev) {

--- a/test/test-time-traveller.js
+++ b/test/test-time-traveller.js
@@ -30,7 +30,7 @@ const processTimeTraveller = Achievement.__get__('processTimeTraveller');
 const timeTravellerThreshold = 0;
 
 function rewireEditionDateDifference(threshold) {
-	return common.rewireAchievement(Achievement, {
+	return common.rewire(Achievement, {
 		getEditionDateDifference: () =>
 			Promise.resolve(threshold)
 	});

--- a/test/test-worker-bee.js
+++ b/test/test-worker-bee.js
@@ -32,12 +32,12 @@ function rewireTypeCreation(threshold) {
 	return common.rewireTypeCreation(Achievement, 'work', threshold);
 }
 
-function generate() {
-	return common.generate(Achievement, orm, true, 'workerBee');
+function getAttrPromise() {
+	return common.getAttrPromise(Achievement, orm, true, 'workerBee');
 }
 
-function generateLabeled(rev) {
-	return common.generate(
+function getRevAttrPromise(rev) {
+	return common.getAttrPromise(
 		Achievement, orm, true, 'workerBee', `Worker Bee ${rev}`
 	);
 }
@@ -56,28 +56,28 @@ export default function tests() {
 
 	const test1 = common.testAchievement(
 		rewireTypeCreation(thresholdI),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		expectIds('I')
 	);
 	it('I should be given to someone with a work creation', test1);
 
 	const test2 = common.testAchievement(
 		rewireTypeCreation(thresholdII),
-		generateLabeled('II'),
+		getRevAttrPromise('II'),
 		expectIds('II')
 	);
 	it('II should be given to someone with 10 work creations', test2);
 
 	const test3 = common.testAchievement(
 		rewireTypeCreation(thresholdIII),
-		generate(),
+		getAttrPromise(),
 		expectAllNamedIds('III')
 	);
 	it('III should be given to someone with 100 work creations', test3);
 
 	const test4 = common.testAchievement(
 		rewireTypeCreation(0),
-		generateLabeled('I'),
+		getRevAttrPromise('I'),
 		common.expectFalse()
 	);
 	it('should not be given to someone with 0 work creations', test4);

--- a/test/test-worker-bee.js
+++ b/test/test-worker-bee.js
@@ -29,7 +29,7 @@ const thresholdII = 10;
 const thresholdIII = 100;
 
 function rewireTypeCreation(threshold) {
-	return common.rewireAchievementTypeCreation(Achievement, 'work', threshold);
+	return common.rewireTypeCreation(Achievement, 'work', threshold);
 }
 
 function generate() {
@@ -47,7 +47,7 @@ function expectIds(rev) {
 }
 
 function expectAllNamedIds(rev) {
-	return common.expectIdsNested('Worker Bee', 'workerBee', rev);
+	return common.expectAllNamedIds('Worker Bee', 'workerBee', rev);
 }
 
 export default function tests() {


### PR DESCRIPTION
### Problem
Reduce the amount of code that needs to be maintained for testing.

### Solution
Deduplicate common test patterns

### Areas of Impact
This affects most `.js` files directly in the `test/` directory and doesn't change any behaviour.