### PR TITLE
Add eslint precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,14 @@
     "test-cov": "nyc --reporter=text npm run test",
     "test-ci": "nyc --reporter=lcovonly --reporter=text-summary npm run test",
     "jsdoc": "node_modules/.bin/jsdoc -r src",
-    "flow": "flow"
+    "flow": "flow",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint",
+      "git add"
+    ]
   },
   "engines": {
     "node": ">=6.0"
@@ -103,13 +110,15 @@
     "babel-register": "^6.24.1",
     "chai": "^4.0.2",
     "chai-as-promised": "^7.0.0",
-    "eslint": "^4.13.0",
+    "eslint": "^4.13.1",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.5.1",
     "flow-bin": "^0.54.0",
+    "husky": "^0.14.3",
     "jsdoc": "^3.4.0",
+    "lint-staged": "^6.0.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.12.5",
     "nyc": "^11.4.0",


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Linter errors aren't being caught when committing.


### Solution
<!-- What does this PR do to fix the problem? -->
Adds a pre-commit hook that runs `eslint` on all staged `*.js` files, and does
not allow you to commit until errors are fixed.


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Only the `package.json` (and of course the `package-lock.json`) is affected.

By the way, the branch is named `precommit-eshansingh` because my GCI username is Eshan Singh, as it's forced to be my real name, but my GH username is different.