### PR TITLE
Filter identifier types by entity type

### DIFF
--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2015  Ben Ockmore
- *               2015  Sean Burke
+ * Copyright (C) 2015       Ben Ockmore
+ *               2015-2017  Sean Burke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,11 +16,8 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-/* eslint max-len: "warn" */
 
-/* eslint prefer-rest-params: 1, prefer-reflect: 1 */
-
-import Promise from 'bluebird';
+// @flow
 
 /**
  * Returns an API path for interacting with the given Bookshelf entity model
@@ -28,7 +25,7 @@ import Promise from 'bluebird';
  * @param {object} entity - Entity object
  * @returns {string} - URL path to interact with entity
  */
-export function getEntityLink(entity) {
+export function getEntityLink(entity: Object): string {
 	return `/${entity.type.toLowerCase()}/${entity.bbid}`;
 }
 
@@ -38,7 +35,7 @@ export function getEntityLink(entity) {
  * @param {object} orm - the BookBrainz ORM, initialized during app setup
  * @returns {object} - Object mapping model name to the entity model
  */
-export function getEntityModels(orm) {
+export function getEntityModels(orm: Object): Object {
 	const {Creator, Edition, Publication, Publisher, Work} = orm;
 	return {
 		Creator,
@@ -59,7 +56,7 @@ export function getEntityModels(orm) {
  * @returns {object} - Bookshelf model object with the type specified in the
  * single param
  */
-export function getEntityModelByType(orm, type) {
+export function getEntityModelByType(orm: Object, type: string): Object {
 	const entityModels = getEntityModels(orm);
 
 	if (!entityModels[type]) {
@@ -84,7 +81,7 @@ const _bbidRegex =
  * @param {string} bbid - BookBrainz UUID to validate
  * @returns {boolean} - Returns true if BookBrainz UUID is valid
  */
-export function isValidBBID(bbid) {
+export function isValidBBID(bbid: string): boolean {
 	return _bbidRegex.test(bbid);
 }
 
@@ -102,11 +99,11 @@ export function isValidBBID(bbid) {
  * the tagged template literal replaced with their corresponding values
  * from the newly passed in object.
  */
-export function template(strings) {
+export function template(strings: Array<string>): Function {
 	// eslint-disable-next-line prefer-reflect, prefer-rest-params
 	const keys = Array.prototype.slice.call(arguments, 1);
 
-	return (values) => {
+	return (values): string => {
 		const result = [strings[0]];
 
 		keys.forEach((key, i) => {
@@ -127,10 +124,10 @@ export function template(strings) {
  * @returns {string} - Title string
  */
 export function createEntityPageTitle(
-	entity,
-	titleForUnnamed,
-	templateForNamed
-) {
+	entity: Object,
+	titleForUnnamed: string,
+	templateForNamed: Function
+): string {
 	/**
 	 * User-visible strings should _never_ be created by concatenation; when we
 	 * start to implement localization, it will create problems for users of
@@ -156,7 +153,11 @@ export function createEntityPageTitle(
  * progress)
  * @returns {Promise} - Resolves to the updated editor model
  */
-export function incrementEditorEditCountById(orm, id, transacting) {
+export function incrementEditorEditCountById(
+	orm: Object,
+	id: string,
+	transacting: Object
+): Promise<Object> {
 	const {Editor} = orm;
 	return new Editor({id})
 		.fetch({transacting})
@@ -174,8 +175,7 @@ export function incrementEditorEditCountById(orm, id, transacting) {
  * @returns {Promise} a promise which will be fulfilled when the operation to
  *                    truncate tables completes
  */
-export function truncateTables(Bookshelf, tables) {
-	return Promise.each(
-		tables, (table) => Bookshelf.knex.raw(`TRUNCATE ${table} CASCADE`)
-	);
+export function truncateTables(Bookshelf: Object, tables: Array<string>) {
+	return Promise.all(tables.map((table) =>
+		Bookshelf.knex.raw(`TRUNCATE ${table} CASCADE`)));
 }

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -46,6 +46,38 @@ export function getEntityModels(orm: Object): Object {
 	};
 }
 
+export function filterIdentifierTypesByEntityType(
+	identifierTypes: Array<Object>,
+	entityType: string
+): Array<Object> {
+	return identifierTypes.filter(
+		(type) => type.entityType === entityType
+	);
+}
+
+export function filterIdentifierTypesByEntity(
+	identifierTypes: Array<Object>,
+	entity: Object
+): Array<Object> {
+	const typesOnEntity = new Set();
+
+	if (!entity.identifierSet || entity.identifierSet.identifiers.length < 1) {
+		/*
+		 * If there are no identifiers, skip the work of trying to add types
+		 * which shouldn't be on this entity.
+		 */
+		return filterIdentifierTypesByEntityType(identifierTypes, entity.type);
+	}
+
+	for (const identifier of entity.identifierSet.identifiers) {
+		typesOnEntity.add(identifier.type.id);
+	}
+
+	return identifierTypes.filter(
+		(type) => type.entityType === entity.type || typesOnEntity.has(type.id)
+	);
+}
+
 /**
  * Retrieves the Bookshelf entity model with the given the model name
  *

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -19,6 +19,8 @@
 
 // @flow
 
+import Promise from 'bluebird';
+
 /**
  * Returns an API path for interacting with the given Bookshelf entity model
  *
@@ -208,6 +210,7 @@ export function incrementEditorEditCountById(
  *                    truncate tables completes
  */
 export function truncateTables(Bookshelf: Object, tables: Array<string>) {
-	return Promise.all(tables.map((table) =>
-		Bookshelf.knex.raw(`TRUNCATE ${table} CASCADE`)));
+	return Promise.each(
+		tables, (table) => Bookshelf.knex.raw(`TRUNCATE ${table} CASCADE`)
+	);
 }

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -90,12 +90,17 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders,	middleware.loadLanguages,
 	middleware.loadCreatorTypes, (req, res) => {
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
+			res.locals.identifierTypes,
+			'Creator'
+		);
+
 		const props = generateProps(req, res, {
 			creatorTypes: res.locals.creatorTypes,
 			entityType: 'creator',
 			genderOptions: res.locals.genders,
 			heading: 'Create Creator',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
 			requiresJS: true,
@@ -223,13 +228,18 @@ router.get(
 	(req, res) => {
 		const creator = res.locals.entity;
 
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
+			res.locals.identifierTypes,
+			creator
+		);
+
 		const props = generateProps(req, res, {
 			creator,
 			creatorTypes: res.locals.creatorTypes,
 			entityType: 'creator',
 			genderOptions: res.locals.genders,
 			heading: 'Edit Creator',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: creatorToFormState(creator),
 			languageOptions: res.locals.languages,
 			requiresJS: true,

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -112,13 +112,18 @@ router.get(
 	middleware.loadEditionStatuses, middleware.loadEditionFormats,
 	middleware.loadLanguages,
 	(req, res, next) => {
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
+			res.locals.identifierTypes,
+			'Edition'
+		);
+
 		const {Publication, Publisher} = req.app.locals.orm;
 		const propsPromise = generateProps(req, res, {
 			editionFormats: res.locals.editionFormats,
 			editionStatuses: res.locals.editionStatuses,
 			entityType: 'edition',
 			heading: 'Create Edition',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
 			requiresJS: true,
@@ -288,12 +293,17 @@ router.get(
 	(req, res) => {
 		const edition = res.locals.entity;
 
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
+			res.locals.identifierTypes,
+			edition
+		);
+
 		const props = generateProps(req, res, {
 			editionFormats: res.locals.editionFormats,
 			editionStatuses: res.locals.editionStatuses,
 			entityType: 'edition',
 			heading: 'Edit Edition',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: editionToFormState(edition),
 			languageOptions: res.locals.languages,
 			requiresJS: true,

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -95,10 +95,15 @@ router.get('/:bbid/revisions', (req, res, next) => {
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublicationTypes, (req, res) => {
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
+			res.locals.identifierTypes,
+			'Publication'
+		);
+
 		const props = generateProps(req, res, {
 			entityType: 'publication',
 			heading: 'Create Publication',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
 			publicationTypes: res.locals.publicationTypes,
@@ -205,10 +210,15 @@ router.get(
 	(req, res) => {
 		const publication = res.locals.entity;
 
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
+			res.locals.identifierTypes,
+			publication
+		);
+
 		const props = generateProps(req, res, {
 			entityType: 'publication',
 			heading: 'Edit Publication',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: publicationToFormState(publication),
 			languageOptions: res.locals.languages,
 			publicationTypes: res.locals.publicationTypes,

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -105,10 +105,15 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
 	(req, res) => {
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
+			res.locals.identifierTypes,
+			'Publisher'
+		);
+
 		const props = generateProps(req, res, {
 			entityType: 'publisher',
 			heading: 'Create Publisher',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
 			publisherTypes: res.locals.publisherTypes,
@@ -234,10 +239,15 @@ router.get(
 	(req, res) => {
 		const publisher = res.locals.entity;
 
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
+			res.locals.identifierTypes,
+			publisher
+		);
+
 		const props = generateProps(req, res, {
 			entityType: 'publisher',
 			heading: 'Edit Publisher',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: publisherToFormState(publisher),
 			languageOptions: res.locals.languages,
 			publisherTypes: res.locals.publisherTypes,

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -91,10 +91,15 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadWorkTypes,
 	(req, res) => {
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
+			res.locals.identifierTypes,
+			'Work'
+		);
+
 		const props = generateProps(req, res, {
 			entityType: 'work',
 			heading: 'Create Work',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
 			requiresJS: true,
@@ -203,12 +208,17 @@ router.get(
 	(req, res) => {
 		const work = res.locals.entity;
 
+		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
+			res.locals.identifierTypes,
+			work
+		);
+
 		workToFormState(work);
 
 		const props = generateProps(req, res, {
 			entityType: 'work',
 			heading: 'Edit Work',
-			identifierTypes: res.locals.identifierTypes,
+			identifierTypes: filteredIdentifierTypes,
 			initialState: workToFormState(work),
 			languageOptions: res.locals.languages,
 			requiresJS: true,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
We have provision in the database for making identifier types specific to entity type, but this is unused. As such, it is possible to set the ISBN of a Creator, which does not make sense.

### Solution
<!-- What does this PR do to fix the problem? -->
Before passing identifier types to the editor component, filter them by entity type. To allow users to edit existing identifiers which have been mistakenly added to the wrong entity type, the types of any existing identifiers are added on the edit page.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Entity creation and editing.

**NOTE**: The following script should be run to migrate existing data to use appropriate entity types: https://gist.github.com/leftmostcat/b2d91955769831887b0b28f0f13db40c