### PR TITLE
Various duplication refactors

### DIFF
--- a/.jsinspectrc
+++ b/.jsinspectrc
@@ -1,0 +1,7 @@
+{
+    "threshold": 35,
+    "identifiers": true,
+    "literals": true,
+    "truncate": 100,
+    "reporter": "default"
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test-ci": "nyc --reporter=lcovonly --reporter=text-summary npm run test",
     "jsdoc": "node_modules/.bin/jsdoc -r src",
     "flow": "flow",
+    "dupreport": "jsinspect src/ || true",
     "precommit": "lint-staged"
   },
   "lint-staged": {
@@ -112,6 +113,7 @@
     "husky": "^0.14.3",
     "jsdoc": "^3.4.0",
     "less": "^2.7.3",
+    "jsinspect": "^0.12.7",
     "lint-staged": "^6.0.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.12.5",

--- a/src/client/components/pages/entities/creator.js
+++ b/src/client/components/pages/entities/creator.js
@@ -19,10 +19,9 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
+import EntityDetails from './details';
 import EntityFooter from './footer';
-import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
-import EntityRelationships from './relationships';
 import EntityTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -100,20 +99,11 @@ function CreatorDisplayPage({entity, identifierTypes}) {
 					<CreatorAttributes creator={entity}/>
 				</Col>
 			</Row>
-			<Row>
-				<Col md={8}>
-					<EntityRelationships
-						entityUrl={urlPrefix}
-						relationships={entity.relationships}
-					/>
-				</Col>
-				<Col md={4}>
-					<EntityIdentifiers
-						identifierSet={entity.identifierSet}
-						identifierTypes={identifierTypes}
-					/>
-				</Col>
-			</Row>
+			<EntityDetails
+				entity={entity}
+				identifierTypes={identifierTypes}
+				urlPrefix={urlPrefix}
+			/>
 			<hr className="margin-top-d40"/>
 			<EntityFooter
 				entityUrl={urlPrefix}

--- a/src/client/components/pages/entities/creator.js
+++ b/src/client/components/pages/entities/creator.js
@@ -19,9 +19,9 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
-import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityImage from './image';
+import EntityLinks from './links';
 import EntityTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -99,7 +99,7 @@ function CreatorDisplayPage({entity, identifierTypes}) {
 					<CreatorAttributes creator={entity}/>
 				</Col>
 			</Row>
-			<EntityDetails
+			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}
 				urlPrefix={urlPrefix}

--- a/src/client/components/pages/entities/details.js
+++ b/src/client/components/pages/entities/details.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017  Eshan Singh
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as bootstrap from 'react-bootstrap';
+
+import EntityIdentifiers from './identifiers';
+import EntityRelationships from './relationships';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+
+const {Col, Row} = bootstrap;
+
+function EntityDetails({entity, identifierTypes, urlPrefix}) {
+	return (
+		<Row>
+			<Col md={8}>
+				<EntityRelationships
+					entityUrl={urlPrefix}
+					relationships={entity.relationships}
+				/>
+			</Col>
+			<Col md={4}>
+				<EntityIdentifiers
+					identifierSet={entity.identifierSet}
+					identifierTypes={identifierTypes}
+				/>
+			</Col>
+		</Row>
+	);
+}
+EntityDetails.displayName = 'EntityDetails';
+EntityDetails.propTypes = {
+	entity: PropTypes.object.isRequired,
+	identifierTypes: PropTypes.array,
+	urlPrefix: PropTypes.string.isRequired
+};
+EntityDetails.defaultProps = {
+	identifierTypes: []
+};
+
+export default EntityDetails;

--- a/src/client/components/pages/entities/edition.js
+++ b/src/client/components/pages/entities/edition.js
@@ -19,9 +19,9 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
-import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityImage from './image';
+import EntityLinks from './links';
 import EntityTitle from './title';
 import Icon from 'react-fontawesome';
 import PropTypes from 'prop-types';
@@ -113,7 +113,7 @@ function EditionDisplayPage({entity, identifierTypes}) {
 					</div>
 				</Col>
 			</Row>
-			<EntityDetails
+			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}
 				urlPrefix={urlPrefix}

--- a/src/client/components/pages/entities/edition.js
+++ b/src/client/components/pages/entities/edition.js
@@ -19,10 +19,9 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
+import EntityDetails from './details';
 import EntityFooter from './footer';
-import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
-import EntityRelationships from './relationships';
 import EntityTitle from './title';
 import Icon from 'react-fontawesome';
 import PropTypes from 'prop-types';
@@ -114,20 +113,11 @@ function EditionDisplayPage({entity, identifierTypes}) {
 					</div>
 				</Col>
 			</Row>
-			<Row>
-				<Col md={8}>
-					<EntityRelationships
-						entityUrl={urlPrefix}
-						relationships={entity.relationships}
-					/>
-				</Col>
-				<Col md={4}>
-					<EntityIdentifiers
-						identifierSet={entity.identifierSet}
-						identifierTypes={identifierTypes}
-					/>
-				</Col>
-			</Row>
+			<EntityDetails
+				entity={entity}
+				identifierTypes={identifierTypes}
+				urlPrefix={urlPrefix}
+			/>
 			<hr className="margin-top-d40"/>
 			<EntityFooter
 				entityUrl={urlPrefix}

--- a/src/client/components/pages/entities/links.js
+++ b/src/client/components/pages/entities/links.js
@@ -26,7 +26,7 @@ import React from 'react';
 
 const {Col, Row} = bootstrap;
 
-function EntityDetails({entity, identifierTypes, urlPrefix}) {
+function EntityLinks({entity, identifierTypes, urlPrefix}) {
 	return (
 		<Row>
 			<Col md={8}>
@@ -44,14 +44,14 @@ function EntityDetails({entity, identifierTypes, urlPrefix}) {
 		</Row>
 	);
 }
-EntityDetails.displayName = 'EntityDetails';
-EntityDetails.propTypes = {
+EntityLinks.displayName = 'EntityLinks';
+EntityLinks.propTypes = {
 	entity: PropTypes.object.isRequired,
 	identifierTypes: PropTypes.array,
 	urlPrefix: PropTypes.string.isRequired
 };
-EntityDetails.defaultProps = {
+EntityLinks.defaultProps = {
 	identifierTypes: []
 };
 
-export default EntityDetails;
+export default EntityLinks;

--- a/src/client/components/pages/entities/publication.js
+++ b/src/client/components/pages/entities/publication.js
@@ -20,10 +20,9 @@ import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
 import EditionTable from './edition-table';
+import EntityDetails from './details';
 import EntityFooter from './footer';
-import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
-import EntityRelationships from './relationships';
 import EntityTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -71,20 +70,11 @@ function PublicationDisplayPage({entity, identifierTypes}) {
 				</Col>
 			</Row>
 			<EditionTable entity={entity}/>
-			<Row>
-				<Col md={8}>
-					<EntityRelationships
-						entityUrl={urlPrefix}
-						relationships={entity.relationships}
-					/>
-				</Col>
-				<Col md={4}>
-					<EntityIdentifiers
-						identifierSet={entity.identifierSet}
-						identifierTypes={identifierTypes}
-					/>
-				</Col>
-			</Row>
+			<EntityDetails
+				entity={entity}
+				identifierTypes={identifierTypes}
+				urlPrefix={urlPrefix}
+			/>
 			<hr className="margin-top-d40"/>
 			<EntityFooter
 				entityUrl={urlPrefix}

--- a/src/client/components/pages/entities/publication.js
+++ b/src/client/components/pages/entities/publication.js
@@ -20,9 +20,9 @@ import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
 import EditionTable from './edition-table';
-import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityImage from './image';
+import EntityLinks from './links';
 import EntityTitle from './title';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -70,7 +70,7 @@ function PublicationDisplayPage({entity, identifierTypes}) {
 				</Col>
 			</Row>
 			<EditionTable entity={entity}/>
-			<EntityDetails
+			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}
 				urlPrefix={urlPrefix}

--- a/src/client/components/pages/entities/publisher.js
+++ b/src/client/components/pages/entities/publisher.js
@@ -20,6 +20,7 @@ import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
 import EditionTable from './edition-table';
+import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
@@ -95,20 +96,11 @@ function PublisherDisplayPage({entity, identifierTypes}) {
 				</Col>
 			</Row>
 			<EditionTable entity={entity}/>
-			<Row>
-				<Col md={8}>
-					<EntityRelationships
-						entityUrl={urlPrefix}
-						relationships={entity.relationships}
-					/>
-				</Col>
-				<Col md={4}>
-					<EntityIdentifiers
-						identifierSet={entity.identifierSet}
-						identifierTypes={identifierTypes}
-					/>
-				</Col>
-			</Row>
+			<EntityDetails
+				entity={entity}
+				identifierTypes={identifierTypes}
+				urlPrefix={urlPrefix}
+			/>
 			<hr className="margin-top-d40"/>
 			<EntityFooter
 				entityUrl={urlPrefix}

--- a/src/client/components/pages/entities/publisher.js
+++ b/src/client/components/pages/entities/publisher.js
@@ -20,10 +20,10 @@ import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
 import EditionTable from './edition-table';
-import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
+import EntityLinks from './links';
 import EntityRelationships from './relationships';
 import EntityTitle from './title';
 import PropTypes from 'prop-types';
@@ -96,7 +96,7 @@ function PublisherDisplayPage({entity, identifierTypes}) {
 				</Col>
 			</Row>
 			<EditionTable entity={entity}/>
-			<EntityDetails
+			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}
 				urlPrefix={urlPrefix}

--- a/src/client/components/pages/entities/work.js
+++ b/src/client/components/pages/entities/work.js
@@ -19,10 +19,10 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
-import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
+import EntityLinks from './links';
 import EntityRelationships from './relationships';
 import EntityTitle from './title';
 import PropTypes from 'prop-types';
@@ -78,7 +78,7 @@ function WorkDisplayPage({entity, identifierTypes}) {
 					<WorkAttributes work={entity}/>
 				</Col>
 			</Row>
-			<EntityDetails
+			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}
 				urlPrefix={urlPrefix}

--- a/src/client/components/pages/entities/work.js
+++ b/src/client/components/pages/entities/work.js
@@ -19,6 +19,7 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
+import EntityDetails from './details';
 import EntityFooter from './footer';
 import EntityIdentifiers from './identifiers';
 import EntityImage from './image';
@@ -77,20 +78,11 @@ function WorkDisplayPage({entity, identifierTypes}) {
 					<WorkAttributes work={entity}/>
 				</Col>
 			</Row>
-			<Row>
-				<Col md={8}>
-					<EntityRelationships
-						entityUrl={urlPrefix}
-						relationships={entity.relationships}
-					/>
-				</Col>
-				<Col md={4}>
-					<EntityIdentifiers
-						identifierSet={entity.identifierSet}
-						identifierTypes={identifierTypes}
-					/>
-				</Col>
-			</Row>
+			<EntityDetails
+				entity={entity}
+				identifierTypes={identifierTypes}
+				urlPrefix={urlPrefix}
+			/>
 			<hr className="margin-top-d40"/>
 			<EntityFooter
 				entityUrl={urlPrefix}

--- a/src/client/entity-editor/validators/common.js
+++ b/src/client/entity-editor/validators/common.js
@@ -67,7 +67,7 @@ export function validateAlias(value: any): boolean {
 }
 
 export const validateAliases = _.partial(
-	validateMultiple, _, validateAlias);
+	validateMultiple, _.partial.placeholder, validateAlias);
 
 export type IdentifierType = {
 	id: number,
@@ -124,7 +124,8 @@ export function validateIdentifier(
 }
 
 export const validateIdentifiers = _.partial(
-	validateMultiple, _, validateIdentifier, _);
+	validateMultiple, _.partial.placeholder,
+	validateIdentifier, _.partial.placeholder);
 
 export function validateNameSectionName(value: any): boolean {
 	return validateRequiredString(value);

--- a/src/client/entity-editor/validators/common.js
+++ b/src/client/entity-editor/validators/common.js
@@ -25,6 +25,22 @@ import {Iterable} from 'immutable';
 import _ from 'lodash';
 
 
+export function validateMultiple(
+	values: any[],
+	validationFunction: (value: any, ...rest: any[]) => boolean,
+	additionalArgs?: any): boolean {
+	let every = (object, predicate) => _.every(object, predicate);
+	if (Iterable.isIterable(values)) {
+		every = (object, predicate) => object.every(predicate);
+	}
+	else if (!_.isObject(values)) {
+		return false;
+	}
+
+	return every(values, (value) =>
+		validationFunction(value, additionalArgs));
+}
+
 export function validateAliasName(value: any): boolean {
 	return validateRequiredString(value);
 }
@@ -50,17 +66,8 @@ export function validateAlias(value: any): boolean {
 	);
 }
 
-export function validateAliases(values: any): boolean {
-	let every = (object, predicate) => _.every(object, predicate);
-	if (Iterable.isIterable(values)) {
-		every = (object, predicate) => object.every(predicate);
-	}
-	else if (!_.isObject(values)) {
-		return false;
-	}
-
-	return every(values, (value) => validateAlias(value));
-}
+export const validateAliases = _.partial(
+	validateMultiple, _, validateAlias);
 
 export type IdentifierType = {
 	id: number,
@@ -116,19 +123,8 @@ export function validateIdentifier(
 	);
 }
 
-export function validateIdentifiers(
-	values: any, types?: ?Array<IdentifierType>
-): boolean {
-	let every = (object, predicate) => _.every(object, predicate);
-	if (Iterable.isIterable(values)) {
-		every = (object, predicate) => object.every(predicate);
-	}
-	else if (!_.isObject(values)) {
-		return false;
-	}
-
-	return every(values, (value) => validateIdentifier(value, types));
-}
+export const validateIdentifiers = _.partial(
+	validateMultiple, _, validateIdentifier, _);
 
 export function validateNameSectionName(value: any): boolean {
 	return validateRequiredString(value);

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -65,9 +65,11 @@ export function generateEntityProps(
 	const {entity} = res.locals;
 	const isEdit = Boolean(entity);
 
-	const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
-		res.locals.identifierTypes,
-		isEdit ? entity : entityName
+	const getFilteredIdentifierTypes = isEdit ?
+		_.partialRight(utils.filterIdentifierTypesByEntity, entity) :
+		_.partialRight(utils.filterIdentifierTypesByEntityType, entityName);
+	const filteredIdentifierTypes = getFilteredIdentifierTypes(
+		res.locals.identifierTypes
 	);
 
 	const submissionUrl = isEdit ?

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -98,7 +98,7 @@ export function generateEntityProps(
  * This also modifies the props value with a new initialState!
  * @param {object} props - react props
  * @param {function} rootReducer - redux root reducer
- * @returns {string} - HTML string
+ * @returns {object} - Updated props and HTML string with markup
  */
 export function entityEditorMarkup(
 	props: { initialState: Object,
@@ -121,7 +121,7 @@ export function entityEditorMarkup(
 	);
 	props.initialState = store.getState();
 
-	return markup;
+	return {markup, props};
 }
 
 

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -123,9 +123,13 @@ export function entityEditorMarkup(
 			</Provider>
 		</Layout>
 	);
-	props.initialState = store.getState();
 
-	return {markup, props};
+	return {
+		markup,
+		props: Object.assign({}, props, {
+			intitialState: store.getState()
+		})
+	};
 }
 
 

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -35,7 +35,7 @@ import express from 'express';
 import {generateProps} from './props';
 
 
-const {getEntitySection, getValidator} = entityEditorHelpers;
+const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
 
 type EntityAction = 'create' | 'edit';
 
@@ -102,9 +102,9 @@ export function generateEntityProps(
  */
 export function entityEditorMarkup(
 	props: { initialState: Object,
-			 entityType: string },
-	rootReducer: Function) {
+			 entityType: string }) {
 	const {initialState, ...rest} = props;
+	const rootReducer = createRootReducer(props.entityType);
 	const store = createStore(rootReducer, Immutable.fromJS(initialState));
 	const EntitySection = getEntitySection(props.entityType);
 	const markup = ReactDOMServer.renderToString(

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -69,6 +69,7 @@ export function generateEntityProps(
 
 /**
  * Return markup for the entity editor.
+ * This also modifies the props value with a new initialState!
  * @param {object} props - react props
  * @param {function} rootReducer - redux root reducer
  * @returns {string} - HTML string

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017  Eshan Singh
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+// @flow
+
+import * as utils from './utils';
+import _ from 'lodash';
+import express from 'express';
+import {generateProps} from './props';
+
+
+type EntityAction = 'create' | 'edit';
+
+/**
+ * Returns a props object with reasonable defaults for entity creation/editing.
+ * @param {string} entityType - entity type
+ * @param {string} action - 'create' or 'edit'
+ * @param {request} req - request object
+ * @param {response} res - response object
+ * @param {object} additionalProps - additional props
+ * @returns {object} - props
+ */
+export function generateEntityProps(
+	entityType: string, action: EntityAction,
+	req: express.request, res: express.response,
+	additionalProps: Object): Object {
+	const entityName = _.capitalize(entityType);
+	const props = Object.assign({
+		entityType,
+		heading: `${_.capitalize(action)} ${entityName}`,
+		initialState: {},
+		languageOptions: res.locals.languages,
+		requiresJS: true,
+		subheading: action === 'create' ?
+			`Add a new ${entityName} to BookBrainz` :
+			`Edit an existing ${entityName} on BookBrainz`
+	}, additionalProps);
+
+	return generateProps(req, res, props);
+}

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -48,7 +48,6 @@ type EntityAction = 'create' | 'edit';
 /**
  * Returns a props object with reasonable defaults for entity creation/editing.
  * @param {string} entityType - entity type
- * @param {string} action - 'create' or 'edit'
  * @param {request} req - request object
  * @param {response} res - response object
  * @param {object} additionalProps - additional props
@@ -57,33 +56,36 @@ type EntityAction = 'create' | 'edit';
  * @returns {object} - props
  */
 export function generateEntityProps(
-	entityType: string, action: EntityAction,
+	entityType: string,
 	req: express.request, res: express.response,
 	additionalProps: Object,
 	initialStateCallback: (entity: ?Object) => Object =
 	(entity) => new Object()): Object {
 	const entityName = _.capitalize(entityType);
 	const {entity} = res.locals;
+	const isEdit = Boolean(entity);
 
 	const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
 		res.locals.identifierTypes,
-		entity ? entity : entityName
+		isEdit ? entity : entityName
 	);
 
-	const submissionUrl = entity ?
+	const submissionUrl = isEdit ?
 		`/${entityType}/${entity.bbid}/edit/handler` :
 		`/${entityType}/create/handler`;
 
 	const props = Object.assign({
 		entityType,
-		heading: `${_.capitalize(action)} ${entityName}`,
+		heading: isEdit ?
+			`Edit ${entityName}` :
+			`Create ${entityName}`,
 		identifierTypes: filteredIdentifierTypes,
 		initialState: initialStateCallback(entity),
 		languageOptions: res.locals.languages,
 		requiresJS: true,
-		subheading: action === 'create' ?
-			`Add a new ${entityName} to BookBrainz` :
-			`Edit an existing ${entityName} on BookBrainz`,
+		subheading: isEdit ?
+			`Edit an existing ${entityName} on BookBrainz` :
+			`Add a new ${entityName} to BookBrainz`,
 		submissionUrl
 	}, additionalProps);
 

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -177,7 +177,7 @@ function getIdEditorJSONPromise(userId, req) {
 
 			return editorJSON;
 		})
-		.then(getEditorTitleJSON, TitleUnlock)
+		.then(getEditorTitleJSON(TitleUnlock))
 		.catch(Editor.NotFoundError, () => {
 			throw new error.NotFoundError('Editor not found', req);
 		});
@@ -248,7 +248,7 @@ router.get('/:id/revisions', (req, res, next) => {
 				}
 			}
 		})
-		.then(getEditorTitleJSON, TitleUnlock)
+		.then(getEditorTitleJSON(TitleUnlock))
 		.then((editorJSON) => {
 			const props = generateProps(req, res, {
 				editor: editorJSON,

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -177,7 +177,7 @@ function getIdEditorJSONPromise(userId, req) {
 
 			return editorJSON;
 		})
-		.then(getEditorTitleJSON(TitleUnlock))
+		.then(_.partialRight(getEditorTitleJSON, TitleUnlock))
 		.catch(Editor.NotFoundError, () => {
 			throw new error.NotFoundError('Editor not found', req);
 		});
@@ -248,7 +248,7 @@ router.get('/:id/revisions', (req, res, next) => {
 				}
 			}
 		})
-		.then(getEditorTitleJSON(TitleUnlock))
+		.then((editor) => getEditorTitleJSON(editor.toJSON(), TitleUnlock))
 		.then((editorJSON) => {
 			const props = generateProps(req, res, {
 				editor: editorJSON,

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -20,12 +20,12 @@
 import * as auth from '../../helpers/auth';
 import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
-import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
 	entityEditorMarkup,
-	generateEntityProps
+	generateEntityProps,
+	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
@@ -254,33 +254,14 @@ function transformNewForm(data) {
 	};
 }
 
-router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) => {
-	const validate = getValidator('creator');
-	if (!validate(req.body)) {
-		const err = new error.FormSubmissionError();
-		error.sendErrorAsJSON(res, err);
-	}
-
-	req.body = transformNewForm(req.body);
-	return entityRoutes.createEntity(
-		req, res, 'Creator', _.pick(req.body, additionalCreatorProps)
-	);
-});
-
-router.post(
-	'/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	(req, res) => {
-		const validate = getValidator('creator');
-		if (!validate(req.body)) {
-			const err = new error.FormSubmissionError();
-			error.sendErrorAsJSON(res, err);
-		}
-
-		req.body = transformNewForm(req.body);
-		return entityRoutes.editEntity(
-			req, res, 'Creator', _.pick(req.body, additionalCreatorProps)
-		);
-	}
+const createOrEditHandler = makeEntityCreateOrEditHandler(
+	'creator', transformNewForm, additionalCreatorProps
 );
+
+router.post('/create/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
+
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -22,22 +22,17 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import EntityEditor from '../../../client/entity-editor/entity-editor';
-import Immutable from 'immutable';
-import Layout from '../../../client/containers/layout';
-import {Provider} from 'react-redux';
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import {
+	entityEditorMarkup,
+	generateEntityProps
+} from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
-import {createStore} from 'redux';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
-import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
-const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
+const {createRootReducer, getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -104,32 +99,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -238,32 +210,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -87,7 +87,7 @@ router.get(
 	middleware.loadGenders,	middleware.loadLanguages,
 	middleware.loadCreatorTypes, (req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'creator', 'create', req, res, {
+			'creator', req, res, {
 				genderOptions: res.locals.genders
 			}
 		));
@@ -165,7 +165,7 @@ router.get(
 	middleware.loadCreatorTypes,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'creator', 'edit', req, res, {
+			'creator', req, res, {
 				genderOptions: res.locals.genders
 			}, creatorToFormState
 		));

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -239,9 +239,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 );
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'create'));
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'edit'));
 
 export default router;

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -111,26 +111,6 @@ router.get(
 	}
 );
 
-function getDefaultAliasIndex(aliases) {
-	const index = aliases.findIndex((alias) => alias.default);
-	return index > 0 ? index : 0;
-}
-
-function areaToOption(area) {
-	if (!area) {
-		return null;
-	}
-
-	const {id} = area;
-
-	return {
-		disambiguation: area.comment,
-		id,
-		text: area.name,
-		type: 'area'
-	};
-}
-
 function creatorToFormState(creator) {
 	const aliases = creator.aliasSet ?
 		creator.aliasSet.aliases.map(({language, ...rest}) => ({
@@ -138,7 +118,7 @@ function creatorToFormState(creator) {
 			...rest
 		})) : [];
 
-	const defaultAliasIndex = getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(aliases);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};
@@ -170,9 +150,9 @@ function creatorToFormState(creator) {
 	);
 
 	const creatorSection = {
-		beginArea: areaToOption(creator.beginArea),
+		beginArea: entityRoutes.areaToOption(creator.beginArea),
 		beginDate: creator.beginDate,
-		endArea: areaToOption(creator.endArea),
+		endArea: entityRoutes.areaToOption(creator.endArea),
 		endDate: creator.endDate,
 		ended: creator.ended,
 		gender: creator.gender && creator.gender.id,

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -24,7 +24,6 @@ import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -33,7 +32,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import {createStore} from 'redux';
+import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
 const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
@@ -95,17 +96,13 @@ router.get(
 			'Creator'
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'creator',
-			genderOptions: res.locals.genders,
-			heading: 'Create Creator',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: {},
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Add a new Creator to BookBrainz',
-			submissionUrl: '/creator/create/handler'
-		});
+		const props = generateEntityProps(
+			'creator', 'create', req, res, {
+				genderOptions: res.locals.genders,
+				identifierTypes: filteredIdentifierTypes,
+				submissionUrl: '/creator/create/handler'
+			}
+		);
 
 		const {initialState, ...rest} = props;
 
@@ -232,18 +229,14 @@ router.get(
 			creator
 		);
 
-		const props = generateProps(req, res, {
-			creator,
-			entityType: 'creator',
-			genderOptions: res.locals.genders,
-			heading: 'Edit Creator',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: creatorToFormState(creator),
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Edit an existing Creator in BookBrainz',
-			submissionUrl: `/creator/${creator.bbid}/edit/handler`
-		});
+		const props = generateEntityProps(
+			'creator', 'edit', req, res, {
+				genderOptions: res.locals.genders,
+				identifierTypes: filteredIdentifierTypes,
+				initialState: creatorToFormState(creator),
+				submissionUrl: `/creator/${creator.bbid}/edit/handler`
+			}
+		);
 
 		const {initialState, ...rest} = props;
 

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -96,7 +96,6 @@ router.get(
 		);
 
 		const props = generateProps(req, res, {
-			creatorTypes: res.locals.creatorTypes,
 			entityType: 'creator',
 			genderOptions: res.locals.genders,
 			heading: 'Create Creator',
@@ -235,7 +234,6 @@ router.get(
 
 		const props = generateProps(req, res, {
 			creator,
-			creatorTypes: res.locals.creatorTypes,
 			entityType: 'creator',
 			genderOptions: res.locals.genders,
 			heading: 'Edit Creator',

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -32,7 +32,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 
 
-const {createRootReducer, getValidator} = entityEditorHelpers;
+const {getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -92,9 +92,7 @@ router.get(
 			}
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -173,9 +171,7 @@ router.get(
 			}, creatorToFormState
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -86,16 +86,9 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders,	middleware.loadLanguages,
 	middleware.loadCreatorTypes, (req, res) => {
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
-			res.locals.identifierTypes,
-			'Creator'
-		);
-
 		const props = generateEntityProps(
 			'creator', 'create', req, res, {
-				genderOptions: res.locals.genders,
-				identifierTypes: filteredIdentifierTypes,
-				submissionUrl: '/creator/create/handler'
+				genderOptions: res.locals.genders
 			}
 		);
 
@@ -174,20 +167,10 @@ router.get(
 	middleware.loadGenders, middleware.loadLanguages,
 	middleware.loadCreatorTypes,
 	(req, res) => {
-		const creator = res.locals.entity;
-
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
-			res.locals.identifierTypes,
-			creator
-		);
-
 		const props = generateEntityProps(
 			'creator', 'edit', req, res, {
-				genderOptions: res.locals.genders,
-				identifierTypes: filteredIdentifierTypes,
-				initialState: creatorToFormState(creator),
-				submissionUrl: `/creator/${creator.bbid}/edit/handler`
-			}
+				genderOptions: res.locals.genders
+			}, creatorToFormState
 		);
 
 		const rootReducer = createRootReducer(props.entityType);

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -86,13 +86,12 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadGenders,	middleware.loadLanguages,
 	middleware.loadCreatorTypes, (req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'creator', 'create', req, res, {
 				genderOptions: res.locals.genders
 			}
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -165,13 +164,12 @@ router.get(
 	middleware.loadGenders, middleware.loadLanguages,
 	middleware.loadCreatorTypes,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'creator', 'edit', req, res, {
 				genderOptions: res.locals.genders
 			}, creatorToFormState
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -119,8 +119,6 @@ router.get(
 
 		const {Publication, Publisher} = req.app.locals.orm;
 		const propsPromise = generateProps(req, res, {
-			editionFormats: res.locals.editionFormats,
-			editionStatuses: res.locals.editionStatuses,
 			entityType: 'edition',
 			heading: 'Create Edition',
 			identifierTypes: filteredIdentifierTypes,
@@ -299,8 +297,6 @@ router.get(
 		);
 
 		const props = generateProps(req, res, {
-			editionFormats: res.locals.editionFormats,
-			editionStatuses: res.locals.editionStatuses,
 			entityType: 'edition',
 			heading: 'Edit Edition',
 			identifierTypes: filteredIdentifierTypes,

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -128,7 +128,7 @@ router.get(
 		}
 
 		function render(props) {
-			let {initialState, ...rest} = props;
+			const {initialState, ...rest} = props;
 
 			if (props.publisher || props.publication) {
 				initialState.editionSection = {};

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -20,12 +20,12 @@
 import * as auth from '../../helpers/auth';
 import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
-import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
 	entityEditorMarkup,
-	generateEntityProps
+	generateEntityProps,
+	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 import Promise from 'bluebird';
 import _ from 'lodash';
@@ -369,45 +369,14 @@ function getAdditionalEditionSets(orm) {
 	];
 }
 
-router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) => {
-	const {orm} = req.app.locals;
+const createOrEditHandler = makeEntityCreateOrEditHandler(
+	'edition', transformNewForm, additionalEditionProps, (req, res) =>
+		getAdditionalEditionSets(req.app.locals.orm));
 
-	const validate = getValidator('edition');
-	if (!validate(req.body)) {
-		const err = new error.FormSubmissionError();
-		error.sendErrorAsJSON(res, err);
-	}
+router.post('/create/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
-	req.body = transformNewForm(req.body);
-	return entityRoutes.createEntity(
-		req,
-		res,
-		'Edition',
-		_.pick(req.body, additionalEditionProps),
-		getAdditionalEditionSets(orm)
-	);
-});
-
-router.post(
-	'/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	(req, res) => {
-		const {orm} = req.app.locals;
-
-		const validate = getValidator('edition');
-		if (!validate(req.body)) {
-			const err = new error.FormSubmissionError();
-			error.sendErrorAsJSON(res, err);
-		}
-
-		req.body = transformNewForm(req.body);
-		return entityRoutes.editEntity(
-			req,
-			res,
-			'Edition',
-			_.pick(req.body, additionalEditionProps),
-			getAdditionalEditionSets(orm)
-		);
-	}
-);
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -108,17 +108,9 @@ router.get(
 	middleware.loadEditionStatuses, middleware.loadEditionFormats,
 	middleware.loadLanguages,
 	(req, res, next) => {
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
-			res.locals.identifierTypes,
-			'Edition'
-		);
-
 		const {Publication, Publisher} = req.app.locals.orm;
 		const propsPromise = generateEntityProps(
-			'edition', 'create', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				submissionUrl: '/edition/create/handler'
-			}
+			'edition', 'create', req, res, {}
 		);
 
 		if (req.query.publication) {
@@ -260,19 +252,8 @@ router.get(
 	middleware.loadEditionStatuses, middleware.loadEditionFormats,
 	middleware.loadLanguages,
 	(req, res) => {
-		const edition = res.locals.entity;
-
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
-			res.locals.identifierTypes,
-			edition
-		);
-
 		const props = generateEntityProps(
-			'edition', 'edit', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				initialState: editionToFormState(edition),
-				submissionUrl: `/edition/${edition.bbid}/edit/handler`
-			}
+			'edition', 'edit', req, res, {}, editionToFormState
 		);
 
 		const rootReducer = createRootReducer(props.entityType);

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -33,7 +33,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 
 
-const {createRootReducer, getValidator} = entityEditorHelpers;
+const {getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -142,9 +142,7 @@ router.get(
 				initialState.editionSection.publication = props.publication;
 			}
 
-			const rootReducer = createRootReducer(props.entityType);
-
-			const markup = entityEditorMarkup(props, rootReducer);
+			const markup = entityEditorMarkup(props);
 			return res.render('target', {
 				markup,
 				props: escapeProps(props),
@@ -256,9 +254,7 @@ router.get(
 			'edition', 'edit', req, res, {}, editionToFormState
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -374,9 +374,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 		getAdditionalEditionSets(req.app.locals.orm));
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'create'));
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'edit'));
 
 export default router;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -142,7 +142,9 @@ router.get(
 				initialState.editionSection.publication = props.publication;
 			}
 
-			const {updatedProps, markup} = entityEditorMarkup(props);
+			const editorMarkup = entityEditorMarkup(props);
+			const {markup} = editorMarkup;
+			const updatedProps = editorMarkup.props;
 			return res.render('target', {
 				markup,
 				props: escapeProps(updatedProps),

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -128,7 +128,7 @@ router.get(
 		}
 
 		function render(props) {
-			const {initialState, ...rest} = props;
+			let {initialState, ...rest} = props;
 
 			if (props.publisher || props.publication) {
 				initialState.editionSection = {};
@@ -142,10 +142,10 @@ router.get(
 				initialState.editionSection.publication = props.publication;
 			}
 
-			const markup = entityEditorMarkup(props);
+			const {updatedProps, markup} = entityEditorMarkup(props);
 			return res.render('target', {
 				markup,
-				props: escapeProps(props),
+				props: escapeProps(updatedProps),
 				script: '/js/entity-editor.js',
 				title: 'Add Edition'
 			});
@@ -250,11 +250,10 @@ router.get(
 	middleware.loadEditionStatuses, middleware.loadEditionFormats,
 	middleware.loadLanguages,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'edition', 'edit', req, res, {}, editionToFormState
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -110,7 +110,7 @@ router.get(
 	(req, res, next) => {
 		const {Publication, Publisher} = req.app.locals.orm;
 		const propsPromise = generateEntityProps(
-			'edition', 'create', req, res, {}
+			'edition', req, res, {}
 		);
 
 		if (req.query.publication) {
@@ -253,7 +253,7 @@ router.get(
 	middleware.loadLanguages,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'edition', 'edit', req, res, {}, editionToFormState
+			'edition', req, res, {}, editionToFormState
 		));
 
 		return res.render('target', {

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -22,23 +22,18 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import EntityEditor from '../../../client/entity-editor/entity-editor';
-import Immutable from 'immutable';
-import Layout from '../../../client/containers/layout';
+import {
+	entityEditorMarkup,
+	generateEntityProps
+} from '../../helpers/entityRouteUtils';
 import Promise from 'bluebird';
-import {Provider} from 'react-redux';
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
-import {createStore} from 'redux';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
-import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
-const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
+const {createRootReducer, getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -143,8 +138,6 @@ router.get(
 		function render(props) {
 			const {initialState, ...rest} = props;
 
-			const rootReducer = createRootReducer(props.entityType);
-
 			if (props.publisher || props.publication) {
 				initialState.editionSection = {};
 			}
@@ -157,28 +150,9 @@ router.get(
 				initialState.editionSection.publication = props.publication;
 			}
 
-			const store = createStore(
-				rootReducer,
-				Immutable.fromJS(initialState)
-			);
+			const rootReducer = createRootReducer(props.entityType);
 
-			const EntitySection = getEntitySection(props.entityType);
-
-			const markup = ReactDOMServer.renderToString(
-				<Layout {...propHelpers.extractLayoutProps(rest)}>
-					<Provider store={store}>
-						<EntityEditor
-							validate={getValidator(props.entityType)}
-							{...propHelpers.extractChildProps(rest)}
-						>
-							<EntitySection/>
-						</EntityEditor>
-					</Provider>
-				</Layout>
-			);
-
-			props.initialState = store.getState();
-
+			const markup = entityEditorMarkup(props, rootReducer);
 			return res.render('target', {
 				markup,
 				props: escapeProps(props),
@@ -301,32 +275,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -24,7 +24,6 @@ import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -34,7 +33,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import {createStore} from 'redux';
+import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
 const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
@@ -118,16 +119,12 @@ router.get(
 		);
 
 		const {Publication, Publisher} = req.app.locals.orm;
-		const propsPromise = generateProps(req, res, {
-			entityType: 'edition',
-			heading: 'Create Edition',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: {},
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Add a new Edition to BookBrainz',
-			submissionUrl: '/edition/create/handler'
-		});
+		const propsPromise = generateEntityProps(
+			'edition', 'create', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				submissionUrl: '/edition/create/handler'
+			}
+		);
 
 		if (req.query.publication) {
 			propsPromise.publication =
@@ -296,16 +293,13 @@ router.get(
 			edition
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'edition',
-			heading: 'Edit Edition',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: editionToFormState(edition),
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Edit an existing Edition in BookBrainz',
-			submissionUrl: `/edition/${edition.bbid}/edit/handler`
-		});
+		const props = generateEntityProps(
+			'edition', 'edit', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				initialState: editionToFormState(edition),
+				submissionUrl: `/edition/${edition.bbid}/edit/handler`
+			}
+		);
 
 		const {initialState, ...rest} = props;
 

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -944,3 +944,23 @@ export function constructIdentifiers(identifierEditor) {
 		value
 	}));
 }
+
+export function getDefaultAliasIndex(aliases) {
+	const index = aliases.findIndex((alias) => alias.default);
+	return index > 0 ? index : 0;
+}
+
+export function areaToOption(area) {
+	if (!area) {
+		return null;
+	}
+
+	const {id} = area;
+
+	return {
+		disambiguation: area.comment,
+		id,
+		text: area.name,
+		type: 'area'
+	};
+}

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -92,16 +92,8 @@ router.get('/:bbid/revisions', (req, res, next) => {
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublicationTypes, (req, res) => {
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
-			res.locals.identifierTypes,
-			'Publication'
-		);
-
 		const props = generateEntityProps(
-			'publication', 'create', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				submissionUrl: '/publication/create/handler'
-			}
+			'publication', 'create', req, res, {}
 		);
 
 		const rootReducer = createRootReducer(props.entityType);
@@ -177,19 +169,8 @@ router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublicationTypes, middleware.loadLanguages,
 	(req, res) => {
-		const publication = res.locals.entity;
-
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
-			res.locals.identifierTypes,
-			publication
-		);
-
 		const props = generateEntityProps(
-			'publication', 'edit', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				initialState: publicationToFormState(publication),
-				submissionUrl: `/publication/${publication.bbid}/edit/handler`
-			}
+			'publication', 'edit', req, res, {}, publicationToFormState
 		);
 
 		const rootReducer = createRootReducer(props.entityType);

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -106,7 +106,6 @@ router.get(
 			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
-			publicationTypes: res.locals.publicationTypes,
 			requiresJS: true,
 			subheading: 'Add a new Publication to BookBrainz',
 			submissionUrl: '/publication/create/handler'
@@ -221,7 +220,6 @@ router.get(
 			identifierTypes: filteredIdentifierTypes,
 			initialState: publicationToFormState(publication),
 			languageOptions: res.locals.languages,
-			publicationTypes: res.locals.publicationTypes,
 			requiresJS: true,
 			subheading: 'Edit an existing Publication in BookBrainz',
 			submissionUrl: `/publication/${publication.bbid}/edit/handler`

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -33,7 +33,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 
 
-const {createRootReducer, getValidator} = entityEditorHelpers;
+const {getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -96,9 +96,7 @@ router.get(
 			'publication', 'create', req, res, {}
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -173,9 +171,7 @@ router.get(
 			'publication', 'edit', req, res, {}, publicationToFormState
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -22,22 +22,17 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import EntityEditor from '../../../client/entity-editor/entity-editor';
-import Immutable from 'immutable';
-import Layout from '../../../client/containers/layout';
-import {Provider} from 'react-redux';
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import {
+	entityEditorMarkup,
+	generateEntityProps
+} from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
-import {createStore} from 'redux';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
-import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
-const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
+const {createRootReducer, getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -108,32 +103,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -219,32 +191,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -92,11 +92,10 @@ router.get('/:bbid/revisions', (req, res, next) => {
 router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublicationTypes, (req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'publication', 'create', req, res, {}
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -167,11 +166,10 @@ router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublicationTypes, middleware.loadLanguages,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'publication', 'edit', req, res, {}, publicationToFormState
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -226,9 +226,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 	'publication', transformNewForm, 'typeId');
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'create'));
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'edit'));
 
 export default router;

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -93,7 +93,7 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublicationTypes, (req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'publication', 'create', req, res, {}
+			'publication', req, res, {}
 		));
 
 		return res.render('target', {
@@ -167,7 +167,7 @@ router.get(
 	middleware.loadPublicationTypes, middleware.loadLanguages,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'publication', 'edit', req, res, {}, publicationToFormState
+			'publication', req, res, {}, publicationToFormState
 		));
 
 		return res.render('target', {

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -25,7 +25,8 @@ import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
 	entityEditorMarkup,
-	generateEntityProps
+	generateEntityProps,
+	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
@@ -221,33 +222,13 @@ function transformNewForm(data) {
 	};
 }
 
-router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) => {
-	const validate = getValidator('publication');
-	if (!validate(req.body)) {
-		const err = new error.FormSubmissionError();
-		error.sendErrorAsJSON(res, err);
-	}
+const createOrEditHandler = makeEntityCreateOrEditHandler(
+	'publication', transformNewForm, 'typeId');
 
-	req.body = transformNewForm(req.body);
-	return entityRoutes.createEntity(
-		req, res, 'Publication', _.pick(req.body, 'typeId')
-	);
-});
+router.post('/create/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
-router.post(
-	'/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	(req, res) => {
-		const validate = getValidator('publication');
-		if (!validate(req.body)) {
-			const err = new error.FormSubmissionError();
-			error.sendErrorAsJSON(res, err);
-		}
-
-		req.body = transformNewForm(req.body);
-		return entityRoutes.editEntity(
-			req, res, 'Publication', _.pick(req.body, 'typeId')
-		);
-	}
-);
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -24,7 +24,6 @@ import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -33,7 +32,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import {createStore} from 'redux';
+import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
 const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
@@ -100,16 +101,12 @@ router.get(
 			'Publication'
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'publication',
-			heading: 'Create Publication',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: {},
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Add a new Publication to BookBrainz',
-			submissionUrl: '/publication/create/handler'
-		});
+		const props = generateEntityProps(
+			'publication', 'create', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				submissionUrl: '/publication/create/handler'
+			}
+		);
 
 		const {initialState, ...rest} = props;
 
@@ -214,16 +211,13 @@ router.get(
 			publication
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'publication',
-			heading: 'Edit Publication',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: publicationToFormState(publication),
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Edit an existing Publication in BookBrainz',
-			submissionUrl: `/publication/${publication.bbid}/edit/handler`
-		});
+		const props = generateEntityProps(
+			'publication', 'edit', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				initialState: publicationToFormState(publication),
+				submissionUrl: `/publication/${publication.bbid}/edit/handler`
+			}
+		);
 
 		const {initialState, ...rest} = props;
 

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -102,16 +102,8 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
 	(req, res) => {
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
-			res.locals.identifierTypes,
-			'Publisher'
-		);
-
 		const props = generateEntityProps(
-			'publisher', 'create', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				submissionUrl: '/publisher/create/handler'
-			}
+			'publisher', 'create', req, res, {}
 		);
 
 		const rootReducer = createRootReducer(props.entityType);
@@ -185,19 +177,8 @@ router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublisherTypes, middleware.loadLanguages,
 	(req, res) => {
-		const publisher = res.locals.entity;
-
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
-			res.locals.identifierTypes,
-			publisher
-		);
-
 		const props = generateEntityProps(
-			'publisher', 'edit', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				initialState: publisherToFormState(publisher),
-				submissionUrl: `/publisher/${publisher.bbid}/create/handler`
-			}
+			'publisher', 'edit', req, res, {}, publisherToFormState
 		);
 
 		const rootReducer = createRootReducer(props.entityType);

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -244,9 +244,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 	'publisher', transformNewForm, additionalPublisherProps);
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'create'));
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'edit'));
 
 export default router;

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -25,7 +25,8 @@ import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
 	entityEditorMarkup,
-	generateEntityProps
+	generateEntityProps,
+	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
@@ -260,33 +261,13 @@ const additionalPublisherProps = [
 	'typeId', 'areaId', 'beginDate', 'endDate', 'ended'
 ];
 
-router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) => {
-	const validate = getValidator('publisher');
-	if (!validate(req.body)) {
-		const err = new error.FormSubmissionError();
-		error.sendErrorAsJSON(res, err);
-	}
+const createOrEditHandler = makeEntityCreateOrEditHandler(
+	'publisher', transformNewForm, additionalPublisherProps);
 
-	req.body = transformNewForm(req.body);
-	return entityRoutes.createEntity(
-		req, res, 'Publisher', _.pick(req.body, additionalPublisherProps)
-	);
-});
+router.post('/create/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
-router.post(
-	'/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	(req, res) => {
-		const validate = getValidator('publisher');
-		if (!validate(req.body)) {
-			const err = new error.FormSubmissionError();
-			error.sendErrorAsJSON(res, err);
-		}
-
-		req.body = transformNewForm(req.body);
-		return entityRoutes.editEntity(
-			req, res, 'Publisher', _.pick(req.body, additionalPublisherProps)
-		);
-	}
-);
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -116,7 +116,6 @@ router.get(
 			identifierTypes: filteredIdentifierTypes,
 			initialState: {},
 			languageOptions: res.locals.languages,
-			publisherTypes: res.locals.publisherTypes,
 			requiresJS: true,
 			subheading: 'Add a new Publisher to BookBrainz',
 			submissionUrl: '/publisher/create/handler'
@@ -250,7 +249,6 @@ router.get(
 			identifierTypes: filteredIdentifierTypes,
 			initialState: publisherToFormState(publisher),
 			languageOptions: res.locals.languages,
-			publisherTypes: res.locals.publisherTypes,
 			requiresJS: true,
 			subheading: 'Edit an existing Publisher in BookBrainz',
 			submissionUrl: `/publisher/${publisher.bbid}/edit/handler`

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -24,7 +24,6 @@ import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -33,7 +32,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import {createStore} from 'redux';
+import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
 const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
@@ -110,16 +111,12 @@ router.get(
 			'Publisher'
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'publisher',
-			heading: 'Create Publisher',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: {},
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Add a new Publisher to BookBrainz',
-			submissionUrl: '/publisher/create/handler'
-		});
+		const props = generateEntityProps(
+			'publisher', 'create', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				submissionUrl: '/publisher/create/handler'
+			}
+		);
 
 		const {initialState, ...rest} = props;
 
@@ -243,16 +240,13 @@ router.get(
 			publisher
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'publisher',
-			heading: 'Edit Publisher',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: publisherToFormState(publisher),
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Edit an existing Publisher in BookBrainz',
-			submissionUrl: `/publisher/${publisher.bbid}/edit/handler`
-		});
+		const props = generateEntityProps(
+			'publisher', 'edit', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				initialState: publisherToFormState(publisher),
+				submissionUrl: `/publisher/${publisher.bbid}/create/handler`
+			}
+		);
 
 		const {initialState, ...rest} = props;
 

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -102,11 +102,10 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadPublisherTypes,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'publisher', 'create', req, res, {}
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -175,11 +174,10 @@ router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublisherTypes, middleware.loadLanguages,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'publisher', 'edit', req, res, {}, publisherToFormState
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -22,22 +22,17 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import EntityEditor from '../../../client/entity-editor/entity-editor';
-import Immutable from 'immutable';
-import Layout from '../../../client/containers/layout';
-import {Provider} from 'react-redux';
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import {
+	entityEditorMarkup,
+	generateEntityProps
+} from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
-import {createStore} from 'redux';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
-import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
-const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
+const {createRootReducer, getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -118,32 +113,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -248,32 +220,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -126,27 +126,6 @@ router.get(
 	}
 );
 
-
-function getDefaultAliasIndex(aliases) {
-	const index = aliases.findIndex((alias) => alias.default);
-	return index > 0 ? index : 0;
-}
-
-function areaToOption(area) {
-	if (!area) {
-		return null;
-	}
-
-	const {id} = area;
-
-	return {
-		disambiguation: area.comment,
-		id,
-		text: area.name,
-		type: 'area'
-	};
-}
-
 function publisherToFormState(publisher) {
 	const aliases = publisher.aliasSet ?
 		publisher.aliasSet.aliases.map(({language, ...rest}) => ({
@@ -154,7 +133,7 @@ function publisherToFormState(publisher) {
 			...rest
 		})) : [];
 
-	const defaultAliasIndex = getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(aliases);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};
@@ -186,7 +165,7 @@ function publisherToFormState(publisher) {
 	);
 
 	const publisherSection = {
-		area: areaToOption(publisher.area),
+		area: entityRoutes.areaToOption(publisher.area),
 		beginDate: publisher.beginDate,
 		endDate: publisher.endDate,
 		ended: publisher.ended,

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -103,7 +103,7 @@ router.get(
 	middleware.loadLanguages, middleware.loadPublisherTypes,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'publisher', 'create', req, res, {}
+			'publisher', req, res, {}
 		));
 
 		return res.render('target', {
@@ -175,7 +175,7 @@ router.get(
 	middleware.loadPublisherTypes, middleware.loadLanguages,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'publisher', 'edit', req, res, {}, publisherToFormState
+			'publisher', req, res, {}, publisherToFormState
 		));
 
 		return res.render('target', {

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -33,7 +33,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 
 
-const {createRootReducer, getValidator} = entityEditorHelpers;
+const {getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -106,9 +106,7 @@ router.get(
 			'publisher', 'create', req, res, {}
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -181,9 +179,7 @@ router.get(
 			'publisher', 'edit', req, res, {}, publisherToFormState
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -88,16 +88,8 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadWorkTypes,
 	(req, res) => {
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntityType(
-			res.locals.identifierTypes,
-			'Work'
-		);
-
 		const props = generateEntityProps(
-			'work', 'create', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				submissionUrl: '/work/create/handler'
-			}
+			'work', 'create', req, res, {}
 		);
 
 		const rootReducer = createRootReducer(props.entityType);
@@ -175,21 +167,8 @@ router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadWorkTypes, middleware.loadLanguages,
 	(req, res) => {
-		const work = res.locals.entity;
-
-		const filteredIdentifierTypes = utils.filterIdentifierTypesByEntity(
-			res.locals.identifierTypes,
-			work
-		);
-
-		workToFormState(work);
-
 		const props = generateEntityProps(
-			'work', 'edit', req, res, {
-				identifierTypes: filteredIdentifierTypes,
-				initialState: workToFormState(work),
-				submissionUrl: `/work/${work.bbid}/edit/handler`
-			}
+			'work', 'edit', req, res, {}, workToFormState
 		);
 
 		const rootReducer = createRootReducer(props.entityType);

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -24,7 +24,6 @@ import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import {escapeProps, generateProps} from '../../helpers/props';
 import EntityEditor from '../../../client/entity-editor/entity-editor';
 import Immutable from 'immutable';
 import Layout from '../../../client/containers/layout';
@@ -33,7 +32,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
 import {createStore} from 'redux';
+import {escapeProps} from '../../helpers/props';
 import express from 'express';
+import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
 const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
@@ -96,16 +97,12 @@ router.get(
 			'Work'
 		);
 
-		const props = generateProps(req, res, {
-			entityType: 'work',
-			heading: 'Create Work',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: {},
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Add a new Work to BookBrainz',
-			submissionUrl: '/work/create/handler'
-		});
+		const props = generateEntityProps(
+			'work', 'create', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				submissionUrl: '/work/create/handler'
+			}
+		);
 
 		const {initialState, ...rest} = props;
 
@@ -214,16 +211,13 @@ router.get(
 
 		workToFormState(work);
 
-		const props = generateProps(req, res, {
-			entityType: 'work',
-			heading: 'Edit Work',
-			identifierTypes: filteredIdentifierTypes,
-			initialState: workToFormState(work),
-			languageOptions: res.locals.languages,
-			requiresJS: true,
-			subheading: 'Edit an existing Work in BookBrainz',
-			submissionUrl: `/work/${work.bbid}/edit/handler`
-		});
+		const props = generateEntityProps(
+			'work', 'edit', req, res, {
+				identifierTypes: filteredIdentifierTypes,
+				initialState: workToFormState(work),
+				submissionUrl: `/work/${work.bbid}/edit/handler`
+			}
+		);
 
 		const {initialState, ...rest} = props;
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -22,22 +22,17 @@ import * as entityEditorHelpers from '../../../client/entity-editor/helpers';
 import * as entityRoutes from './entity';
 import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
-import * as propHelpers from '../../../client/helpers/props';
 import * as utils from '../../helpers/utils';
-import EntityEditor from '../../../client/entity-editor/entity-editor';
-import Immutable from 'immutable';
-import Layout from '../../../client/containers/layout';
-import {Provider} from 'react-redux';
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import {
+	entityEditorMarkup,
+	generateEntityProps
+} from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
-import {createStore} from 'redux';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
-import {generateEntityProps} from '../../helpers/entityRouteUtils';
 
 
-const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
+const {createRootReducer, getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -104,32 +99,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -219,32 +191,9 @@ router.get(
 			}
 		);
 
-		const {initialState, ...rest} = props;
-
 		const rootReducer = createRootReducer(props.entityType);
 
-		const store = createStore(
-			rootReducer,
-			Immutable.fromJS(initialState)
-		);
-
-		const EntitySection = getEntitySection(props.entityType);
-
-		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(rest)}>
-				<Provider store={store}>
-					<EntityEditor
-						validate={getValidator(props.entityType)}
-						{...propHelpers.extractChildProps(rest)}
-					>
-						<EntitySection/>
-					</EntityEditor>
-				</Provider>
-			</Layout>
-		);
-
-		props.initialState = store.getState();
-
+		const markup = entityEditorMarkup(props, rootReducer);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -104,8 +104,7 @@ router.get(
 			languageOptions: res.locals.languages,
 			requiresJS: true,
 			subheading: 'Add a new Work to BookBrainz',
-			submissionUrl: '/work/create/handler',
-			workTypes: res.locals.workTypes
+			submissionUrl: '/work/create/handler'
 		});
 
 		const {initialState, ...rest} = props;
@@ -223,8 +222,7 @@ router.get(
 			languageOptions: res.locals.languages,
 			requiresJS: true,
 			subheading: 'Edit an existing Work in BookBrainz',
-			submissionUrl: `/work/${work.bbid}/edit/handler`,
-			workTypes: res.locals.workTypes
+			submissionUrl: `/work/${work.bbid}/edit/handler`
 		});
 
 		const {initialState, ...rest} = props;

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -88,11 +88,10 @@ router.get(
 	'/create', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadLanguages, middleware.loadWorkTypes,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'work', 'create', req, res, {}
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -165,11 +164,10 @@ router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadWorkTypes, middleware.loadLanguages,
 	(req, res) => {
-		const props = generateEntityProps(
+		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'work', 'edit', req, res, {}, workToFormState
-		);
+		));
 
-		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -246,9 +246,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 		getAdditionalWorkSets(req.app.locals.orm));
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'create'));
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	createOrEditHandler);
+	_.partial(createOrEditHandler, 'edit'));
 
 export default router;

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -33,7 +33,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 
 
-const {createRootReducer, getValidator} = entityEditorHelpers;
+const {getValidator} = entityEditorHelpers;
 
 const router = express.Router();
 
@@ -92,9 +92,7 @@ router.get(
 			'work', 'create', req, res, {}
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),
@@ -171,9 +169,7 @@ router.get(
 			'work', 'edit', req, res, {}, workToFormState
 		);
 
-		const rootReducer = createRootReducer(props.entityType);
-
-		const markup = entityEditorMarkup(props, rootReducer);
+		const markup = entityEditorMarkup(props);
 		return res.render('target', {
 			markup,
 			props: escapeProps(props),

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -25,7 +25,8 @@ import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
 	entityEditorMarkup,
-	generateEntityProps
+	generateEntityProps,
+	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
@@ -240,38 +241,14 @@ function transformNewForm(data) {
 	};
 }
 
-router.post('/create/handler', auth.isAuthenticatedForHandler, (req, res) => {
-	const {orm} = req.app.locals;
+const createOrEditHandler = makeEntityCreateOrEditHandler(
+	'work', transformNewForm, 'typeId', (req, res) =>
+		getAdditionalWorkSets(req.app.locals.orm));
 
-	const validate = getValidator('work');
-	if (!validate(req.body)) {
-		const err = new error.FormSubmissionError();
-		error.sendErrorAsJSON(res, err);
-	}
+router.post('/create/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
-	req.body = transformNewForm(req.body);
-	return entityRoutes.createEntity(
-		req, res, 'Work', _.pick(req.body, 'typeId'), getAdditionalWorkSets(orm)
-	);
-});
-
-router.post(
-	'/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	(req, res) => {
-		const {orm} = req.app.locals;
-
-		const validate = getValidator('work');
-		if (!validate(req.body)) {
-			const err = new error.FormSubmissionError();
-			error.sendErrorAsJSON(res, err);
-		}
-
-		req.body = transformNewForm(req.body);
-		return entityRoutes.editEntity(
-			req, res, 'Work', _.pick(req.body, 'typeId'),
-			getAdditionalWorkSets(orm)
-		);
-	}
-);
+router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -89,7 +89,7 @@ router.get(
 	middleware.loadLanguages, middleware.loadWorkTypes,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'work', 'create', req, res, {}
+			'work', req, res, {}
 		));
 
 		return res.render('target', {
@@ -165,7 +165,7 @@ router.get(
 	middleware.loadWorkTypes, middleware.loadLanguages,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
-			'work', 'edit', req, res, {}, workToFormState
+			'work', req, res, {}, workToFormState
 		));
 
 		return res.render('target', {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

_**NOTE**: This PR is #173, but all at once, with signed commits, and as such no coveralls spam. Will push less often next time 🙇_

### Problem

Various instances of duplication. See current `dupreport`:

https://gist.github.com/naiveaiguy/1eb8a12f2aa75876a1729d6f0bff1c10

Originally 23 matches were there. Now there are only 12. 

### Solution

Extracts methods that abstract out the functionality of these duplicates. I've tried as much as possible to keep each commit sensible and working, so any of these can be reverted individually relatively cleanly if the need arises. 

### Areas of Impact

* package.json - `dupreport` script
* entity routes on server - unchanged behaviour - various extracted utils
* entity page on client - unchanged behaviour - `EntityDetail` component - *EDIT*: changed name to `EntityLinks`
* `editor` - unchanged behaviour - small extractions
	I actually want  to do a total refactor of this code because there are some larger problems with 	
    it, but I'll do that after GCI as it's a pretty big undertaking.
* `validators/common` - unchanged behaviour - small extraction