### PR TITLE
Add documentation and tests for renderRelationship

### DIFF
--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -52,6 +52,10 @@ type Relationship = {
 
 /**
  * Returns the markup corresponding to the given entity relationship.
+ * This markup is defined by a Handlebars template in
+ * relationship.type.displayTemplate.
+ * This function is used, for example, to render
+ * relationships on entity display pages.
  * @param {Relationship} relationship - Relationship object.
  * @returns {string} - Rendered HTML string.
  */

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -23,7 +23,7 @@ import Handlebars from 'handlebars';
 
 
 type EntityInRelationship = {
-	bbid: number | string,
+	bbid: string,
 	defaultAlias?: {name: string},
 	type: string
 };
@@ -36,7 +36,7 @@ type Relationship = {
 
 /**
  * @typedef {Object} EntityInRelationship
- * @property {number|string} bbid
+ * @property {string} bbid
  * @property {?Object} defaultAlias
  * @property {string} defaultAlias.name
  * @property {string} type

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015  Ben Ockmore
  *               2015  Sean Burke
+ *               2018  Eshan Singh
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -21,6 +21,27 @@ import * as utils from './utils';
 import Handlebars from 'handlebars';
 
 
+/**
+ * @typedef {Object} EntityInRelationship
+ * @property {number|string} bbid
+ * @property {?Object} defaultAlias
+ * @property {string} defaultAlias.name
+ * @property {string} type
+ */
+
+/**
+ * @typedef {Object} Relationship
+ * @property {EntityInRelationship} source
+ * @property {EntityInRelationship} target
+ * @property {Object} type
+ * @property {string} type.displayTemplate
+ */
+
+/**
+ * Renders a relationship object.
+ * @param {Relationship} relationship - Relationship object.
+ * @returns {string} - Rendered HTML string.
+ */
 function renderRelationship(relationship) {
 	const template = Handlebars.compile(
 		relationship.type.displayTemplate,

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -16,10 +16,23 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+// @flow
 
 import * as utils from './utils';
 import Handlebars from 'handlebars';
 
+
+type EntityInRelationship = {
+	bbid: number | string,
+	defaultAlias?: {name: string},
+	type: string
+};
+
+type Relationship = {
+	source: EntityInRelationship,
+	target: EntityInRelationship,
+	type: {displayTemplate: string}
+};
 
 /**
  * @typedef {Object} EntityInRelationship
@@ -42,7 +55,7 @@ import Handlebars from 'handlebars';
  * @param {Relationship} relationship - Relationship object.
  * @returns {string} - Rendered HTML string.
  */
-function renderRelationship(relationship) {
+function renderRelationship(relationship: Relationship) {
 	const template = Handlebars.compile(
 		relationship.type.displayTemplate,
 		{noEscape: true}

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -51,7 +51,7 @@ type Relationship = {
  */
 
 /**
- * Renders a relationship object.
+ * Returns the markup corresponding to the given entity relationship.
  * @param {Relationship} relationship - Relationship object.
  * @returns {string} - Rendered HTML string.
  */

--- a/test/test-render-relationship.js
+++ b/test/test-render-relationship.js
@@ -74,6 +74,30 @@ const relationshipTests = {
 			'<a href="/test-type2/2">test2</a>'
 		].join('')
 	},
+	nullEntities: {
+		error: TypeError,
+		rel: {
+			source: null,
+			target: null,
+			type: {displayTemplate: '{{entities.[0]}}{{entitites.[1]}}'}
+		}
+	},
+	nullTemplate: {
+		error: 'null',
+		rel: {
+			source: {
+				bbid: '1',
+				defaultAlias: {name: 'test'},
+				type: 'test-type'
+			},
+			target: {
+				bbid: '2',
+				defaultAlias: {name: 'test2'},
+				type: 'test-type2'
+			},
+			type: {displayTemplate: null}
+		}
+	},
 	unnamedSource: {
 		rel: {
 			source: {
@@ -96,7 +120,13 @@ const relationshipTests = {
 
 function makeRelationshipTest(test) {
 	return () => {
-		expect(renderRelationship(test.rel)).to.equal(test.renderedRel);
+		if ('error' in test) {
+			expect(() => renderRelationship(test.rel))
+				.to.throw(test.error);
+		}
+		else {
+			expect(renderRelationship(test.rel)).to.equal(test.renderedRel);
+		}
 	};
 }
 
@@ -109,4 +139,8 @@ describe('renderRelationship', () => {
 	   makeRelationshipTest(relationshipTests.unnamedSource));
 	it('works with an empty template',
 	   makeRelationshipTest(relationshipTests.emptyTemplate));
+	it('throws on null entities',
+	   makeRelationshipTest(relationshipTests.nullEntities));
+	it('throws on a null template',
+	   makeRelationshipTest(relationshipTests.nullTemplate));
 });

--- a/test/test-render-relationship.js
+++ b/test/test-render-relationship.js
@@ -20,6 +20,22 @@ import renderRelationship from '../src/server/helpers/render.js';
 
 
 const relationshipTests = {
+	emptyTemplate: {
+		rel: {
+			source: {
+				bbid: '1',
+				defaultAlias: {name: 'test'},
+				type: 'test-type'
+			},
+			target: {
+				bbid: '2',
+				defaultAlias: {name: 'test2'},
+				type: 'test-type2'
+			},
+			type: {displayTemplate: ''}
+		},
+		renderedRel: ''
+	},
 	fullySpecified: {
 		rel: {
 			source: {
@@ -70,4 +86,6 @@ describe('renderRelationship', () => {
 	   makeRelationshipTest(relationshipTests.fullySpecified));
 	it('renders a relationship where the source entity is unnamed',
 	   makeRelationshipTest(relationshipTests.unnamedSource));
+	it('works with an empty template',
+	   makeRelationshipTest(relationshipTests.emptyTemplate));
 });

--- a/test/test-render-relationship.js
+++ b/test/test-render-relationship.js
@@ -23,12 +23,12 @@ const relationshipTests = {
 	fullySpecified: {
 		rel: {
 			source: {
-				bbid: 1,
+				bbid: '1',
 				defaultAlias: {name: 'test'},
 				type: 'test-type'
 			},
 			target: {
-				bbid: 2,
+				bbid: '2',
 				defaultAlias: {name: 'test2'},
 				type: 'test-type2'
 			},
@@ -42,11 +42,11 @@ const relationshipTests = {
 	unnamedSource: {
 		rel: {
 			source: {
-				bbid: 1,
+				bbid: '1',
 				type: 'test-type'
 			},
 			target: {
-				bbid: 2,
+				bbid: '2',
 				defaultAlias: {name: 'test2'},
 				type: 'test-type2'
 			},

--- a/test/test-render-relationship.js
+++ b/test/test-render-relationship.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018  Eshan Singh
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import {expect} from 'chai';
+import renderRelationship from '../src/server/helpers/render.js';
+
+
+const relationshipTests = {
+	fullySpecified: {
+		rel: {
+			source: {
+				bbid: 1,
+				defaultAlias: {name: 'test'},
+				type: 'test-type'
+			},
+			target: {
+				bbid: 2,
+				defaultAlias: {name: 'test2'},
+				type: 'test-type2'
+			},
+			type: {displayTemplate: '{{entities.[0]}}{{entities.[1]}}'}
+		},
+		renderedRel: [
+			'<a href="/test-type/1">test</a>',
+			'<a href="/test-type2/2">test2</a>'
+		].join('')
+	},
+	unnamedSource: {
+		rel: {
+			source: {
+				bbid: 1,
+				type: 'test-type'
+			},
+			target: {
+				bbid: 2,
+				defaultAlias: {name: 'test2'},
+				type: 'test-type2'
+			},
+			type: {displayTemplate: '{{entities.[0]}}{{entities.[1]}}'}
+		},
+		renderedRel: [
+			'<a href="/test-type/1">(unnamed)</a>',
+			'<a href="/test-type2/2">test2</a>'
+		].join('')
+	}
+};
+
+function makeRelationshipTest(test) {
+	return () => {
+		expect(renderRelationship(test.rel)).to.equal(test.renderedRel);
+	};
+}
+
+describe('renderRelationship', () => {
+	it('renders a fully specified relationship',
+	   makeRelationshipTest(relationshipTests.fullySpecified));
+	it('renders a relationship where the source entity is unnamed',
+	   makeRelationshipTest(relationshipTests.unnamedSource));
+});

--- a/test/test-render-relationship.js
+++ b/test/test-render-relationship.js
@@ -55,6 +55,25 @@ const relationshipTests = {
 			'<a href="/test-type2/2">test2</a>'
 		].join('')
 	},
+	fullySpecifiedWithNumericBbids: {
+		rel: {
+			source: {
+				bbid: 1,
+				defaultAlias: {name: 'test'},
+				type: 'test-type'
+			},
+			target: {
+				bbid: 2,
+				defaultAlias: {name: 'test2'},
+				type: 'test-type2'
+			},
+			type: {displayTemplate: '{{entities.[0]}}{{entities.[1]}}'}
+		},
+		renderedRel: [
+			'<a href="/test-type/1">test</a>',
+			'<a href="/test-type2/2">test2</a>'
+		].join('')
+	},
 	unnamedSource: {
 		rel: {
 			source: {
@@ -84,6 +103,8 @@ function makeRelationshipTest(test) {
 describe('renderRelationship', () => {
 	it('renders a fully specified relationship',
 	   makeRelationshipTest(relationshipTests.fullySpecified));
+	it('renders a fully specified relationship with numeric bbids',
+	   makeRelationshipTest(relationshipTests.fullySpecifiedWithNumericBbids));
 	it('renders a relationship where the source entity is unnamed',
 	   makeRelationshipTest(relationshipTests.unnamedSource));
 	it('works with an empty template',


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
There's no documentation or tests for `renderRelationship`. 


### Solution
Add documentation and tests. Maybe not the biggest issue, but I though it was useful to have some anyway. It was also good to get used to `mocha` and `chai`. Will make some more substantial tests after GCI.


### Areas of Impact
No behaviour changes, only new tests and docs.

  