### PR TITLE
BB-241: fix(deletion): Add missing spaces in remove entity screen.

### DIFF
--- a/src/client/components/forms/deletion.js
+++ b/src/client/components/forms/deletion.js
@@ -111,9 +111,9 @@ class EntityDeletionForm extends React.Component {
 								footer={footerComponent}
 								header={headerComponent}
 							>
-								If you’re sure that {entity.type} {entityName}
-								should be deleted, please enter a revision note
-								below and confirm deletion.
+								If you’re sure that {entity.type} {' '}
+								{entityName} should be deleted, please enter a
+								revision note below and confirm deletion.
 
 								<CustomInput
 									ref={(ref) => this.note = ref}


### PR DESCRIPTION
### Problem
BB-241: Space error in remove entity screen
https://tickets.metabrainz.org/projects/BB/issues/BB-241?filter=allopenissues

### Solution
Insert spaces at relevant positions.

### Areas of Impact
src/client/components/forms/deletion.js
Remove entity screen.

### Final result
![commit](https://user-images.githubusercontent.com/9463078/35069748-23ecc084-fc01-11e7-87e6-f0216c349a0d.jpeg)