### PR TITLE
Add feature to warn users if an entity name already exists 

### DIFF
--- a/src/client/entity-editor/common/name-field.js
+++ b/src/client/entity-editor/common/name-field.js
@@ -25,7 +25,8 @@ import ValidationLabel from '../common/validation-label';
 
 type Props = {
 	empty?: boolean,
-	error?: boolean
+	error?: boolean,
+	warn?: boolean
 };
 
 /**
@@ -35,6 +36,8 @@ type Props = {
  * @param {Object} props - The properties passed to the component.
  * @param {boolean} props.error - Passed to the ValidationLabel within the
  *        component to indicate a validation error.
+ * @param {boolean} props.warn - Passed to the ValidationLabel within the
+ * 		  component to indicate a validation warning.
  * @param {boolean} props.empty - Passed to the ValidationLabel within the
  *        component to indicate that the field is empty.
  * @param {Function} props.onChange - Function to be called when the value in
@@ -44,10 +47,14 @@ type Props = {
 function NameField({
 	empty,
 	error,
+	warn,
 	...rest
 }: Props) {
-	const label =
-		<ValidationLabel empty={empty} error={error}>Name</ValidationLabel>;
+	const label = (
+		<ValidationLabel empty={empty} error={error} warn={warn}>
+			Name
+		</ValidationLabel>
+	);
 
 	return (
 		<CustomInput label={label} type="text" {...rest}/>
@@ -56,7 +63,8 @@ function NameField({
 NameField.displayName = 'NameField';
 NameField.defaultProps = {
 	empty: false,
-	error: false
+	error: false,
+	warn: false
 };
 
 export default NameField;

--- a/src/client/entity-editor/common/validation-label.js
+++ b/src/client/entity-editor/common/validation-label.js
@@ -22,13 +22,17 @@ import * as React from 'react';
 import Icon from 'react-fontawesome';
 
 
-function icon(empty: ?boolean, error: ?boolean): string | null {
+function icon(empty: ?boolean, error: ?boolean, warn: ?boolean): string | null {
 	if (empty) {
 		return null;
 	}
 
 	if (error) {
 		return 'times';
+	}
+
+	if (warn) {
+		return 'exclamation-triangle';
 	}
 
 	return 'check';

--- a/src/client/entity-editor/common/validation-label.js
+++ b/src/client/entity-editor/common/validation-label.js
@@ -61,7 +61,8 @@ function contextualColor(
 type Props = {
 	children?: React.Node,
 	empty?: boolean,
-	error?: boolean
+	error?: boolean,
+	warn?: boolean
 };
 
 /**
@@ -81,13 +82,14 @@ type Props = {
 function ValidationLabel({
 	children,
 	empty,
-	error
+	error,
+	warn
 }: Props) {
-	const iconElement = icon(empty, error) &&
-		<Icon className="margin-left-0-5" name={icon(empty, error)}/>;
+	const iconElement = icon(empty, error, warn) &&
+		<Icon className="margin-left-0-5" name={icon(empty, error, warn)}/>;
 
 	return (
-		<span className={contextualColor(empty, error)}>
+		<span className={contextualColor(empty, error, warn)}>
 			{children}
 			{iconElement}
 		</span>
@@ -97,7 +99,8 @@ ValidationLabel.displayName = 'ValidationLabel';
 ValidationLabel.defaultProps = {
 	children: null,
 	empty: false,
-	error: false
+	error: false,
+	warn: false
 };
 
 export default ValidationLabel;

--- a/src/client/entity-editor/common/validation-label.js
+++ b/src/client/entity-editor/common/validation-label.js
@@ -38,14 +38,21 @@ function icon(empty: ?boolean, error: ?boolean, warn: ?boolean): string | null {
 	return 'check';
 }
 
-
-function contextualColor(empty: ?boolean, error: ?boolean): string | null {
+function contextualColor(
+	empty: ?boolean,
+	error: ?boolean,
+	warn: ?boolean
+): string | null {
 	if (empty) {
 		return null;
 	}
 
 	if (error) {
 		return 'text-danger';
+	}
+
+	if (warn) {
+		return 'text-warning';
 	}
 
 	return 'text-success';

--- a/src/client/entity-editor/name-section/actions.js
+++ b/src/client/entity-editor/name-section/actions.js
@@ -18,10 +18,14 @@
 
 // @flow
 
+import request from 'superagent-bluebird-promise';
+
+
 export const UPDATE_DISAMBIGUATION_FIELD = 'UPDATE_DISAMBIGUATION_FIELD';
 export const UPDATE_LANGUAGE_FIELD = 'UPDATE_LANGUAGE_FIELD';
 export const UPDATE_NAME_FIELD = 'UPDATE_NAME_FIELD';
 export const UPDATE_SORT_NAME_FIELD = 'UPDATE_SORT_NAME_FIELD';
+export const UPDATE_WARN_IF_EXISTS = 'UPDATE_WARN_IF_EXISTS';
 
 export type Action = {
 	type: string,
@@ -93,5 +97,35 @@ export function debouncedUpdateDisambiguationField(
 		meta: {debounce: 'keystroke'},
 		payload: newDisambiguation,
 		type: UPDATE_DISAMBIGUATION_FIELD
+	};
+}
+
+/**
+ * Produces an action containing boolean value indicating if the name of the
+ * entity already exists. This is done by asynchronously checking if the name
+ * of the entity already exists in the database.
+ *
+ * @param  {string} name - The value to be checked if it already exists.
+ * @param  {string} entityType - The entity type of the value to be checked.
+ * @returns {many_prompts~inner} The returned function.
+ */
+export function checkIfNameExists(
+	name: string,
+	entityType: string
+): ((Action) => mixed) => mixed {
+	/**
+	 * @param  {function} dispatch - The redux dispatch function.
+	 */
+	return (dispatch) => {
+		request.get('/search/exists')
+			.query({
+				collection: entityType,
+				q: name
+			})
+			.then(res => dispatch({
+				payload: res.text === 'true',
+				type: UPDATE_WARN_IF_EXISTS
+			}))
+			.catch((error: {message: string}) => error);
 	};
 }

--- a/src/client/entity-editor/name-section/reducer.js
+++ b/src/client/entity-editor/name-section/reducer.js
@@ -18,7 +18,7 @@
 
 import {
 	UPDATE_DISAMBIGUATION_FIELD, UPDATE_LANGUAGE_FIELD, UPDATE_NAME_FIELD,
-	UPDATE_SORT_NAME_FIELD
+	UPDATE_SORT_NAME_FIELD, UPDATE_WARN_IF_EXISTS
 } from './actions';
 import Immutable from 'immutable';
 
@@ -28,7 +28,8 @@ function reducer(
 		disambiguation: '',
 		language: null,
 		name: '',
-		sortName: ''
+		sortName: '',
+		warnIfExists: false
 	}),
 	action
 ) {
@@ -42,6 +43,8 @@ function reducer(
 			return state.set('language', payload);
 		case UPDATE_DISAMBIGUATION_FIELD:
 			return state.set('disambiguation', payload);
+		case UPDATE_WARN_IF_EXISTS:
+			return state.set('warnIfExists', payload);
 		// no default
 	}
 	return state;

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -339,6 +339,31 @@ export async function generateIndex(orm) {
 	await refreshIndex();
 }
 
+export function checkIfExists(orm, name, collection) {
+	const {bookshelf} = orm;
+	const rawSql = `
+		SELECT (
+			CASE WHEN count > 0 THEN 'true' ELSE 'false' END
+		) FROM (
+			SELECT COUNT(*)
+			AS count
+			FROM ${collection}
+			JOIN (
+				SELECT DISTINCT set_id
+				FROM alias_set__alias
+				WHERE alias_id IN (
+					SELECT id
+					FROM alias
+					WHERE name = '${name}'
+				)
+			) AS sets
+			ON sets.set_id = ${collection}.alias_set_id
+			WHERE master = 'true'
+		) AS result;`;
+
+	return bookshelf.knex.raw(rawSql).then(val => val.rows[0].case);
+}
+
 export function searchByName(orm, name, collection) {
 	const dslQuery = {
 		body: {

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -94,6 +94,19 @@ router.get('/autocomplete', (req, res) => {
 });
 
 /**
+ * Responds with stringified boolean value which signifies if the given user
+ * query already exists
+ */
+router.get('/exists', (req, res) => {
+	const {orm} = req.app.locals;
+	const {q, collection} = req.query;
+
+	const searchPromise = search.checkIfExists(orm, q, collection);
+
+	handler.sendPromiseResult(res, searchPromise);
+});
+
+/**
  * Regenerates search index. Restricted to administrators.
  *
  * @throws {error.PermissionDeniedError} - Thrown if user is not admin.


### PR DESCRIPTION
### Problem
Presently, there is no warning if a user enters an entity with a name already existing in the database. While it may be the case that two entities with same name exists, it may also lead to user mistakenly adding an entity which may already be present in the database.

### Solution
It adds raises a warning if the user enters an entity with a name which already exists in the database.


### Areas of Impact
src/client/entity-editor/name-section
src/client/entity-editor/commons
src/server/routes 
src/server/helpers 
