### PR TITLE
BBS-254: fix(package.json) Run tests recursively in all the subfolders

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+--recursive
 --require babel-register
 --timeout 20000
 --exit


### PR DESCRIPTION
Presently, tests are only run if they are direct children of test directory,
although there are some tests which lie in the subdirectory, like inside
test/src/client.


### Problem
Trying to run the tests inside the subdirectories in the `test` folder.


### Solution
Add `--recursive` flag to the `npm run test` script in package.json file.


### Areas of Impact
package.json
