### PR TITLE
feat(delete): Upon deletion of an entity, redirect to home page

### DIFF
--- a/src/client/components/forms/deletion.js
+++ b/src/client/components/forms/deletion.js
@@ -49,7 +49,7 @@ class EntityDeletionForm extends React.Component {
 		request.post(this.deleteUrl)
 			.send()
 			.then(() => {
-				window.location.href = this.entityUrl;
+				window.location.href = '/';
 			})
 			.catch((res) => {
 				const {error} = res.body;


### PR DESCRIPTION
### Problem
Upon deleting an entity, the user lands up on the new revised entity page which is unnamed and contains no relevant information. Infact, the user still has access to the delete entity button - which means s/he can delete a previously deleted entity. 


### Solution
After deleting an entity, the user is redirected to the home page, and thus has no access to the previously deleted entity (once #190 is merged, the user cannot access it via search too). In future we can perhaps develop a way by which we can provide access to the previously deleted entities displaying the parent_revision data to undo the deletion.


### Areas of Impact
Deletion form.
