### PR TITLE
test(core): Added postgres version in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+  postgresql: "9.5"
 
 before_script:
   - git clone https://github.com/bookbrainz/bookbrainz-sql.git


### PR DESCRIPTION

### Problem & Solution
Fixes failing travis builds since [this commit to bookbrainz-sql](https://github.com/bookbrainz/bookbrainz-sql/commit/33425aeaedb003223a6b16276316562f17d80310#diff-699266fb29ba68cf5bb74045f6a50744R674), requiring version >= 9.4 of postgres to use jsonb
