### PR TITLE
New relationship editor

### DIFF
--- a/flow-typed/npm/express_v4.16.x.js
+++ b/flow-typed/npm/express_v4.16.x.js
@@ -1,0 +1,304 @@
+// flow-typed signature: cc24a4e737d9dfb8e1381c3bd4ebaa65
+// flow-typed version: d11eab7bb5/express_v4.16.x/flow_>=v0.32.x
+
+import type { Server } from "http";
+import type { Socket } from "net";
+
+declare type express$RouterOptions = {
+  caseSensitive?: boolean,
+  mergeParams?: boolean,
+  strict?: boolean
+};
+
+declare class express$RequestResponseBase {
+  app: express$Application;
+  get(field: string): string | void;
+}
+
+declare type express$RequestParams = {
+  [param: string]: string
+};
+
+declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
+  baseUrl: string;
+  body: mixed;
+  cookies: { [cookie: string]: string };
+  connection: Socket;
+  fresh: boolean;
+  hostname: string;
+  ip: string;
+  ips: Array<string>;
+  method: string;
+  originalUrl: string;
+  params: express$RequestParams;
+  path: string;
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string> };
+  route: string;
+  secure: boolean;
+  signedCookies: { [signedCookie: string]: string };
+  stale: boolean;
+  subdomains: Array<string>;
+  xhr: boolean;
+  accepts(types: string): string | false;
+  accepts(types: Array<string>): string | false;
+  acceptsCharsets(...charsets: Array<string>): string | false;
+  acceptsEncodings(...encoding: Array<string>): string | false;
+  acceptsLanguages(...lang: Array<string>): string | false;
+  header(field: string): string | void;
+  is(type: string): boolean;
+  param(name: string, defaultValue?: string): string | void;
+}
+
+declare type express$CookieOptions = {
+  domain?: string,
+  encode?: (value: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  secure?: boolean,
+  signed?: boolean
+};
+
+declare type express$Path = string | RegExp;
+
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
+
+declare type express$SendFileOptions = {
+  maxAge?: number,
+  root?: string,
+  lastModified?: boolean,
+  headers?: { [name: string]: string },
+  dotfiles?: "allow" | "deny" | "ignore"
+};
+
+declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
+  headersSent: boolean;
+  locals: { [name: string]: mixed };
+  append(field: string, value?: string): this;
+  attachment(filename?: string): this;
+  cookie(name: string, value: string, options?: express$CookieOptions): this;
+  clearCookie(name: string, options?: express$CookieOptions): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function }): this;
+  json(body?: mixed): this;
+  jsonp(body?: mixed): this;
+  links(links: { [name: string]: string }): this;
+  location(path: string): this;
+  redirect(url: string, ...args: Array<void>): this;
+  redirect(status: number, url: string, ...args: Array<void>): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed },
+    callback?: express$RenderCallback
+  ): this;
+  send(body?: mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
+  sendStatus(statusCode: number): this;
+  header(field: string, value?: string): this;
+  header(headers: { [name: string]: string }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string }): this;
+  status(statusCode: number): this;
+  type(type: string): this;
+  vary(field: string): this;
+  req: express$Request;
+}
+
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+declare type express$Middleware =
+  | ((
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed);
+declare interface express$RouteMethodType<T> {
+  (middleware: express$Middleware): T;
+  (...middleware: Array<express$Middleware>): T;
+  (
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): T;
+}
+declare class express$Route {
+  all: express$RouteMethodType<this>;
+  get: express$RouteMethodType<this>;
+  post: express$RouteMethodType<this>;
+  put: express$RouteMethodType<this>;
+  head: express$RouteMethodType<this>;
+  delete: express$RouteMethodType<this>;
+  options: express$RouteMethodType<this>;
+  trace: express$RouteMethodType<this>;
+  copy: express$RouteMethodType<this>;
+  lock: express$RouteMethodType<this>;
+  mkcol: express$RouteMethodType<this>;
+  move: express$RouteMethodType<this>;
+  purge: express$RouteMethodType<this>;
+  propfind: express$RouteMethodType<this>;
+  proppatch: express$RouteMethodType<this>;
+  unlock: express$RouteMethodType<this>;
+  report: express$RouteMethodType<this>;
+  mkactivity: express$RouteMethodType<this>;
+  checkout: express$RouteMethodType<this>;
+  merge: express$RouteMethodType<this>;
+
+  // @TODO Missing 'm-search' but get flow illegal name error.
+
+  notify: express$RouteMethodType<this>;
+  subscribe: express$RouteMethodType<this>;
+  unsubscribe: express$RouteMethodType<this>;
+  patch: express$RouteMethodType<this>;
+  search: express$RouteMethodType<this>;
+  connect: express$RouteMethodType<this>;
+}
+
+declare class express$Router extends express$Route {
+  constructor(options?: express$RouterOptions): void;
+  route(path: string): express$Route;
+  static (options?: express$RouterOptions): express$Router;
+  use(middleware: express$Middleware): this;
+  use(...middleware: Array<express$Middleware>): this;
+  use(
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+  handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
+  param(
+    param: string,
+    callback: (
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction,
+      id: string
+    ) => mixed
+  ): void;
+  (
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
+
+declare class express$Application extends express$Router mixins events$EventEmitter {
+  constructor(): void;
+  locals: { [name: string]: mixed };
+  mountpath: string;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): ?Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): ?Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?Server;
+  disable(name: string): void;
+  disabled(name: string): boolean;
+  enable(name: string): express$Application;
+  enabled(name: string): boolean;
+  engine(name: string, callback: Function): void;
+  /**
+   * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+   */
+  //   get(name: string): mixed;
+  set(name: string, value: mixed): mixed;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+  // callable signature is not inherited
+  (
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed
+};
+
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+}
+
+declare module "express" {
+  declare export type RouterOptions = express$RouterOptions;
+  declare export type CookieOptions = express$CookieOptions;
+  declare export type Middleware = express$Middleware;
+  declare export type NextFunction = express$NextFunction;
+  declare export type RequestParams = express$RequestParams;
+  declare export type $Response = express$Response;
+  declare export type $Request = express$Request;
+  declare export type $Application = express$Application;
+
+  declare module.exports: {
+    (): express$Application, // If you try to call like a function, it will use this signature
+    json: (opts: ?JsonOptions) => express$Middleware,
+    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
+    Router: typeof express$Router, // `Router` property on the function
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-runtime": "^6.23.0",
     "bluebird": "^3.5.1",
     "body-parser": "^1.14.1",
-    "bookbrainz-data": "^1.0.0",
+    "bookbrainz-data": "^1.1.1",
     "browserify": "^14.5.0",
     "classnames": "^2.2.5",
     "compression": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "express-static-cache": "0.0.6",
     "font-awesome": "^4.6.3",
     "git-rev": "^0.2.1",
-    "handlebars": "^4.0.11",
     "http-status": "^1.0.0",
     "immutable": "^3.8.2",
     "influx": "^5.0.7",

--- a/src/client/entity-editor/common/entity-search-field.js
+++ b/src/client/entity-editor/common/entity-search-field.js
@@ -70,7 +70,7 @@ function entityToOption(entity) {
 
 type EntitySearchFieldProps = {
 	label: string,
-	type: string,
+	type: string | Array<string>,
 	empty?: boolean,
 	error?: boolean
 };
@@ -85,7 +85,8 @@ type EntitySearchFieldProps = {
  *        component to indicate a validation error.
  * @param {boolean} props.empty - Passed to the ValidationLabel within the
  *        component to indicate that the field is empty.
- * @param {string} props.type - Determines the type of entity to search for.
+ * @param {string | Array<string>} props.type - Determines the types of entity
+ *        to search for.
  * @param {string} props.label - The text to be used for the input label.
  * @returns {Object} A React component containing the rendered input.
  */

--- a/src/client/entity-editor/entity-editor.js
+++ b/src/client/entity-editor/entity-editor.js
@@ -24,6 +24,7 @@ import ButtonBar from './button-bar/button-bar';
 import IdentifierEditor from './identifier-editor/identifier-editor';
 import NameSection from './name-section/name-section';
 import {Panel} from 'react-bootstrap';
+import RelationshipSection from './relationship-editor/relationship-section';
 import SubmissionSection from './submission-section/submission-section';
 import {connect} from 'react-redux';
 
@@ -63,6 +64,7 @@ const EntityEditor = (props: Props) => {
 			<AliasEditor show={aliasEditorVisible} {...props}/>
 			<NameSection {...props}/>
 			<ButtonBar {...props}/>
+			<RelationshipSection {...props}/>
 			{
 				React.cloneElement(
 					React.Children.only(children),

--- a/src/client/entity-editor/helpers.js
+++ b/src/client/entity-editor/helpers.js
@@ -32,6 +32,7 @@ import identifierEditorReducer from './identifier-editor/reducer';
 import nameSectionReducer from './name-section/reducer';
 import publicationSectionReducer from './publication-section/reducer';
 import publisherSectionReducer from './publisher-section/reducer';
+import relationshipSectionReducer from './relationship-editor/reducer';
 import submissionSectionReducer from './submission-section/reducer';
 import {validateForm as validateCreatorForm} from './validators/creator.js';
 import {validateForm as validateEditionForm} from './validators/edition.js';
@@ -99,6 +100,7 @@ export function createRootReducer(entityType: string) {
 		[entityReducerKey]: entityReducer,
 		identifierEditor: identifierEditorReducer,
 		nameSection: nameSectionReducer,
+		relationshipSection: relationshipSectionReducer,
 		submissionSection: submissionSectionReducer
 	});
 }

--- a/src/client/entity-editor/relationship-editor/actions.js
+++ b/src/client/entity-editor/relationship-editor/actions.js
@@ -26,6 +26,7 @@ export const HIDE_RELATIONSHIP_EDITOR = 'HIDE_RELATIONSHIP_EDITOR';
 export const SAVE_RELATIONSHIP = 'SAVE_RELATIONSHIP';
 export const EDIT_RELATIONSHIP = 'EDIT_RELATIONSHIP';
 export const REMOVE_RELATIONSHIP = 'REMOVE_RELATIONSHIP';
+export const UNDO_LAST_SAVE = 'UNDO_LAST_SAVE';
 
 export type Action = {
 	type: string,
@@ -66,5 +67,11 @@ export function removeRelationship(rowID: number): Action {
 	return {
 		payload: rowID,
 		type: REMOVE_RELATIONSHIP
+	};
+}
+
+export function undoLastSave(): Action {
+	return {
+		type: UNDO_LAST_SAVE
 	};
 }

--- a/src/client/entity-editor/relationship-editor/actions.js
+++ b/src/client/entity-editor/relationship-editor/actions.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+// @flow
+
+import type {Relationship} from './types';
+
+
+export const SHOW_RELATIONSHIP_EDITOR = 'SHOW_RELATIONSHIP_EDITOR';
+export const HIDE_RELATIONSHIP_EDITOR = 'HIDE_RELATIONSHIP_EDITOR';
+export const SAVE_RELATIONSHIP = 'SAVE_RELATIONSHIP';
+export const EDIT_RELATIONSHIP = 'EDIT_RELATIONSHIP';
+
+export type Action = {
+	type: string,
+	payload?: mixed,
+	metadata?: {
+		debounce?: string
+	}
+};
+
+export function showRelationshipEditor(): Action {
+	return {
+		type: SHOW_RELATIONSHIP_EDITOR
+	};
+}
+
+export function hideRelationshipEditor(): Action {
+	return {
+		type: HIDE_RELATIONSHIP_EDITOR
+	};
+}
+
+let nextRowID = 0;
+export function saveRelationship(data: Relationship): Action {
+	return {
+		payload: {data, rowID: `n${nextRowID++}`},
+		type: SAVE_RELATIONSHIP
+	};
+}
+
+export function editRelationship(rowID: number): Action {
+	return {
+		payload: rowID,
+		type: EDIT_RELATIONSHIP
+	};
+}

--- a/src/client/entity-editor/relationship-editor/actions.js
+++ b/src/client/entity-editor/relationship-editor/actions.js
@@ -25,6 +25,7 @@ export const SHOW_RELATIONSHIP_EDITOR = 'SHOW_RELATIONSHIP_EDITOR';
 export const HIDE_RELATIONSHIP_EDITOR = 'HIDE_RELATIONSHIP_EDITOR';
 export const SAVE_RELATIONSHIP = 'SAVE_RELATIONSHIP';
 export const EDIT_RELATIONSHIP = 'EDIT_RELATIONSHIP';
+export const REMOVE_RELATIONSHIP = 'REMOVE_RELATIONSHIP';
 
 export type Action = {
 	type: string,
@@ -58,5 +59,12 @@ export function editRelationship(rowID: number): Action {
 	return {
 		payload: rowID,
 		type: EDIT_RELATIONSHIP
+	};
+}
+
+export function removeRelationship(rowID: number): Action {
+	return {
+		payload: rowID,
+		type: REMOVE_RELATIONSHIP
 	};
 }

--- a/src/client/entity-editor/relationship-editor/reducer.js
+++ b/src/client/entity-editor/relationship-editor/reducer.js
@@ -18,8 +18,8 @@
 
 import * as Immutable from 'immutable';
 import {
-	EDIT_RELATIONSHIP, HIDE_RELATIONSHIP_EDITOR, SAVE_RELATIONSHIP,
-	SHOW_RELATIONSHIP_EDITOR
+	EDIT_RELATIONSHIP, HIDE_RELATIONSHIP_EDITOR, REMOVE_RELATIONSHIP,
+	SAVE_RELATIONSHIP, SHOW_RELATIONSHIP_EDITOR
 } from './actions';
 
 
@@ -54,6 +54,8 @@ function reducer(
 				'relationshipEditorProps',
 				state.getIn(['relationships', action.payload])
 			).set('relationshipEditorVisible', true);
+		case REMOVE_RELATIONSHIP:
+			return state.deleteIn(['relationships', action.payload]);
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/relationship-editor/reducer.js
+++ b/src/client/entity-editor/relationship-editor/reducer.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as Immutable from 'immutable';
+import {
+	EDIT_RELATIONSHIP, HIDE_RELATIONSHIP_EDITOR, SAVE_RELATIONSHIP,
+	SHOW_RELATIONSHIP_EDITOR
+} from './actions';
+
+
+function reducer(
+	state = Immutable.Map({
+		relationshipEditorProps: null,
+		relationshipEditorVisible: false,
+		relationships: Immutable.OrderedMap()
+	}),
+	action
+) {
+	switch (action.type) {
+		case SHOW_RELATIONSHIP_EDITOR:
+			return state.set('relationshipEditorVisible', true)
+				.set('relationshipEditorProps', null);
+		case HIDE_RELATIONSHIP_EDITOR:
+			return state.set('relationshipEditorVisible', false);
+		case SAVE_RELATIONSHIP: {
+			const rowID = state.getIn(
+				['relationshipEditorProps', 'rowID'],
+				action.payload.rowID
+			);
+			return state.setIn(
+				['relationships', rowID],
+				Immutable.fromJS({rowID, ...action.payload.data})
+			)
+				.set('relationshipEditorProps', null)
+				.set('relationshipEditorVisible', false);
+		}
+		case EDIT_RELATIONSHIP:
+			return state.set(
+				'relationshipEditorProps',
+				state.getIn(['relationships', action.payload])
+			).set('relationshipEditorVisible', true);
+		// no default
+	}
+	return state;
+}
+
+export default reducer;

--- a/src/client/entity-editor/relationship-editor/reducer.js
+++ b/src/client/entity-editor/relationship-editor/reducer.js
@@ -19,12 +19,13 @@
 import * as Immutable from 'immutable';
 import {
 	EDIT_RELATIONSHIP, HIDE_RELATIONSHIP_EDITOR, REMOVE_RELATIONSHIP,
-	SAVE_RELATIONSHIP, SHOW_RELATIONSHIP_EDITOR
+	SAVE_RELATIONSHIP, SHOW_RELATIONSHIP_EDITOR, UNDO_LAST_SAVE
 } from './actions';
 
 
 function reducer(
 	state = Immutable.Map({
+		lastRelationships: null,
 		relationshipEditorProps: null,
 		relationshipEditorVisible: false,
 		relationships: Immutable.OrderedMap()
@@ -47,7 +48,8 @@ function reducer(
 				Immutable.fromJS({rowID, ...action.payload.data})
 			)
 				.set('relationshipEditorProps', null)
-				.set('relationshipEditorVisible', false);
+				.set('relationshipEditorVisible', false)
+				.set('lastRelationships', state.get('relationships'));
 		}
 		case EDIT_RELATIONSHIP:
 			return state.set(
@@ -55,7 +57,11 @@ function reducer(
 				state.getIn(['relationships', action.payload])
 			).set('relationshipEditorVisible', true);
 		case REMOVE_RELATIONSHIP:
-			return state.deleteIn(['relationships', action.payload]);
+			return state.deleteIn(['relationships', action.payload])
+				.set('lastRelationships', state.get('relationships'));
+		case UNDO_LAST_SAVE:
+			return state.set('relationships', state.get('lastRelationships'))
+				.set('lastRelationships', null);
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -105,7 +105,7 @@ type RelationshipModalProps = {
 	initRelationship: ?_Relationship,
 	onCancel?: () => mixed,
 	onClose?: () => mixed,
-	onSave?: (_Relationship) => mixed
+	onAdd?: (_Relationship) => mixed
 };
 
 type RelationshipModalState = {
@@ -153,9 +153,9 @@ function getInitState(
 class RelationshipModal
 	extends React.Component<RelationshipModalProps, RelationshipModalState> {
 	static defaultProps = {
+		onAdd: null,
 		onCancel: null,
-		onClose: null,
-		onSave: null
+		onClose: null
 	};
 
 	constructor(props: RelationshipModalProps) {
@@ -179,11 +179,11 @@ class RelationshipModal
 		});
 	};
 
-	handleSave = () => {
-		const {onSave} = this.props;
-		if (onSave) {
+	handleAdd = () => {
+		const {onAdd} = this.props;
+		if (onAdd) {
 			if (this.state.relationship) {
-				onSave(this.state.relationship);
+				onAdd(this.state.relationship);
 			}
 		}
 	};
@@ -301,9 +301,9 @@ class RelationshipModal
 					<Button
 						bsStyle="success"
 						disabled={submitDisabled}
-						onClick={this.handleSave}
+						onClick={this.handleAdd}
 					>
-						Save
+						Add
 					</Button>
 				</Modal.Footer>
 			</Modal>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -36,14 +36,6 @@ import _ from 'lodash';
  * action, which allows the rest of the app to
  */
 
-const ENTITY_TYPE_VALUES = [
-	{id: 'creator', label: 'Creator'},
-	{id: 'edition', label: 'Edition'},
-	{id: 'publication', label: 'Publication'},
-	{id: 'publisher', label: 'Publisher'},
-	{id: 'work', label: 'Work'}
-];
-
 function isValidRelationship(relationship: _Relationship) {
 	const {relationshipType, sourceEntity, targetEntity} = relationship;
 
@@ -89,15 +81,15 @@ function getValidOtherEntityTypes(
 ) {
 	const validEntityTypes = relationshipTypes.map((relationshipType) => {
 		if (relationshipType.sourceEntityType === baseEntity.type) {
-			return _.toLower(relationshipType.targetEntityType);
+			return relationshipType.targetEntityType;
 		}
 		if (relationshipType.targetEntityType === baseEntity.type) {
-			return _.toLower(relationshipType.sourceEntityType);
+			return relationshipType.sourceEntityType;
 		}
 		return null;
 	});
 
-	return _.uniq(_.compact(validEntityTypes));
+	return _.uniq(_.compact(validEntityTypes)).sort();
 }
 
 type EntitySearchResult = {
@@ -212,13 +204,17 @@ class RelationshipModal
 		const {baseEntity, relationshipTypes} = this.props;
 		const types = getValidOtherEntityTypes(relationshipTypes, baseEntity);
 
+		const label =
+			`Other Entity (${_.join(types.slice(0, -1), ', ')}` +
+			` or ${_.last(types)})`;
+
 		return (
 			<EntitySearchField
 				cache={false}
 				instanceId="publication"
-				label="Entity"
+				label={label}
 				name="entity"
-				type={types}
+				type={types.map(_.toLower)}
 				value={this.state.targetEntity}
 				onChange={this.handleEntityChange}
 			/>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -83,6 +83,23 @@ function generateRelationshipSelection(
 	return candidateRelationships.filter(isValidRelationship);
 }
 
+function getValidOtherEntityTypes(
+	relationshipTypes: Array<RelationshipType>,
+	baseEntity: Entity
+) {
+	const validEntityTypes = relationshipTypes.map((relationshipType) => {
+		if (relationshipType.sourceEntityType === baseEntity.type) {
+			return _.toLower(relationshipType.targetEntityType);
+		}
+		if (relationshipType.targetEntityType === baseEntity.type) {
+			return _.toLower(relationshipType.sourceEntityType);
+		}
+		return null;
+	});
+
+	return _.uniq(_.compact(validEntityTypes));
+}
+
 type EntitySearchResult = {
 	text: string,
 	id: string | number,
@@ -192,12 +209,16 @@ class RelationshipModal
 	}
 
 	renderEntitySelect() {
+		const {baseEntity, relationshipTypes} = this.props;
+		const types = getValidOtherEntityTypes(relationshipTypes, baseEntity);
+
 		return (
 			<EntitySearchField
 				cache={false}
 				instanceId="publication"
 				label="Entity"
 				name="entity"
+				type={types}
 				value={this.state.targetEntity}
 				onChange={this.handleEntityChange}
 			/>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -31,10 +31,6 @@ import ReactSelect from 'react-select';
 import Relationship from './relationship';
 import _ from 'lodash';
 
-/*
- * This is a simple React component. No Redux connection. Has an onSubmit
- * action, which allows the rest of the app to
- */
 
 function isValidRelationship(relationship: _Relationship) {
 	const {relationshipType, sourceEntity, targetEntity} = relationship;
@@ -150,6 +146,29 @@ function getInitState(
 	};
 }
 
+// Disable valid-jsdoc because eslint is looking for a "value" parameter
+/* eslint-disable valid-jsdoc */
+/**
+ * This is a simple React component. No Redux connection. Renders a modal
+ * containing a form with two fields (entity and relationship) and two buttons
+ * (cancel and add), allowing new relationships to be set up and added to the
+ * entity editor.
+ *
+ * @param {Object} props - The properties passed to the component.
+ * @param {Entity} props.baseEntity - The entity currently being edited in the
+ *        entity editor
+ * @param {?_Relationship} props.initRelationship - The relationship being
+ *        edited, if not creating a new relationship.
+ * @param {Array<RelationshipType>} props.relationshipTypes - All the possible
+ *        relationship types for any pair of entities.
+ * @param {Function} props.onCancel - A function to be called when the cancel
+ *        button is clicked.
+ * @param {Function} props.onClose - A function to be called when the modal is
+ *        closed.
+ * @param {Function} props.onAdd - A function to be called when the add button
+ *        is clicked.
+ */
+/* eslint-enable valid-jsdoc */
 class RelationshipModal
 	extends React.Component<RelationshipModalProps, RelationshipModalState> {
 	static defaultProps = {

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -22,7 +22,7 @@ import {
 	Button, Col, ControlLabel, FormGroup, Modal, ProgressBar, Row
 } from 'react-bootstrap';
 import type {
-	Entity, EntityType, EntityTypeObject, RelationshipType,
+	Entity, EntityType, RelationshipType,
 	RelationshipWithLabel, Relationship as _Relationship
 } from './types';
 import EntitySearchField from '../common/entity-search-field';
@@ -100,7 +100,6 @@ type RelationshipModalProps = {
 };
 
 type RelationshipModalState = {
-	entityType?: ?EntityTypeObject,
 	relationshipType?: ?RelationshipType,
 	relationship?: ?_Relationship,
 	targetEntity?: ?EntitySearchResult
@@ -111,7 +110,6 @@ function getInitState(
 ): RelationshipModalState {
 	if (_.isNull(initRelationship)) {
 		return {
-			entityType: null,
 			relationship: null,
 			relationshipType: null,
 			targetEntity: null
@@ -137,10 +135,6 @@ function getInitState(
 	};
 
 	return {
-		entityType: {
-			id: _.lowerCase(_.get(searchFormatOtherEntity, 'type')),
-			label: _.get(searchFormatOtherEntity, 'type')
-		},
 		relationship: initRelationship,
 		relationshipType: _.get(initRelationship, ['relationshipType']),
 		targetEntity: searchFormatOtherEntity
@@ -160,15 +154,6 @@ class RelationshipModal
 
 		this.state = getInitState(props.baseEntity, props.initRelationship);
 	}
-
-	handleEntityTypeChange = (value: EntityTypeObject) => {
-		this.setState({
-			entityType: value,
-			relationship: null,
-			relationshipType: null,
-			targetEntity: null
-		});
-	};
 
 	handleEntityChange = (value: EntitySearchResult) => {
 		this.setState({
@@ -195,44 +180,24 @@ class RelationshipModal
 	};
 
 	calculateProgressAmount() {
-		if (!this.state.entityType) {
+		if (!this.state.targetEntity) {
 			return 1;
 		}
 
-		if (!this.state.targetEntity) {
-			return 30;
-		}
-
 		if (!this.state.relationshipType) {
-			return 60;
+			return 50;
 		}
 
 		return 100;
-	}
-
-	renderEntityTypeSelect() {
-		return (
-			<FormGroup>
-				<ControlLabel>Entity Type</ControlLabel>
-				<ReactSelect
-					name="entityType"
-					options={ENTITY_TYPE_VALUES}
-					value={this.state.entityType}
-					onChange={this.handleEntityTypeChange}
-				/>
-			</FormGroup>
-		);
 	}
 
 	renderEntitySelect() {
 		return (
 			<EntitySearchField
 				cache={false}
-				disabled={!this.state.entityType}
 				instanceId="publication"
-				label={_.get(this.state, 'entityType.label', 'Entity')}
+				label="Entity"
 				name="entity"
-				type={_.get(this.state, 'entityType.id')}
 				value={this.state.targetEntity}
 				onChange={this.handleEntityChange}
 			/>
@@ -296,19 +261,12 @@ class RelationshipModal
 					<Row>
 						<Col md={10} mdOffset={1}>
 							<form>
-								<Row>
-									<Col md={4}>
-										{this.renderEntityTypeSelect()}
-									</Col>
-									<Col md={8}>
-										{this.renderEntitySelect()}
-									</Col>
-								</Row>
-								<Row>
-									<Col md={12}>
-										{this.renderRelationshipSelect()}
-									</Col>
-								</Row>
+								<div>
+									{this.renderEntitySelect()}
+								</div>
+								<div>
+									{this.renderRelationshipSelect()}
+								</div>
 							</form>
 						</Col>
 					</Row>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2018  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+// @flow
+
+import {
+	Button, Col, ControlLabel, FormGroup, Modal, ProgressBar, Row
+} from 'react-bootstrap';
+import type {
+	Entity, EntityType, EntityTypeObject, RelationshipType,
+	RelationshipWithLabel, Relationship as _Relationship
+} from './types';
+import EntitySearchField from '../common/entity-search-field';
+import React from 'react';
+import ReactSelect from 'react-select';
+import Relationship from './relationship';
+import _ from 'lodash';
+
+/*
+ * This is a simple React component. No Redux connection. Has an onSubmit
+ * action, which allows the rest of the app to
+ */
+
+const ENTITY_TYPE_VALUES = [
+	{id: 'creator', label: 'Creator'},
+	{id: 'edition', label: 'Edition'},
+	{id: 'publication', label: 'Publication'},
+	{id: 'publisher', label: 'Publisher'},
+	{id: 'work', label: 'Work'}
+];
+
+function isValidRelationship(relationship: _Relationship) {
+	const {relationshipType, sourceEntity, targetEntity} = relationship;
+
+	return (
+		(relationshipType.sourceEntityType === sourceEntity.type) &&
+		(relationshipType.targetEntityType === targetEntity.type)
+	);
+}
+
+function generateRelationshipSelection(
+	relationshipTypes: Array<RelationshipType>,
+	entityA: Entity,
+	entityB: Entity
+): Array<RelationshipWithLabel> {
+	const forwardRelationships = relationshipTypes.map(
+		(relationshipType) => ({
+			label: relationshipType.linkPhrase,
+			relationshipType,
+			sourceEntity: entityA,
+			targetEntity: entityB
+		})
+	);
+	const reverseRelationships = relationshipTypes.map(
+		(relationshipType) => ({
+			label: relationshipType.linkPhrase,
+			relationshipType,
+			sourceEntity: entityB,
+			targetEntity: entityA
+		})
+	);
+
+	const candidateRelationships = [
+		...forwardRelationships,
+		...reverseRelationships
+	];
+
+	return candidateRelationships.filter(isValidRelationship);
+}
+
+type EntitySearchResult = {
+	text: string,
+	id: string | number,
+	value: string | number,
+	type: EntityType
+};
+
+type RelationshipModalProps = {
+	relationshipTypes: Array<RelationshipType>,
+	baseEntity: Entity,
+	initRelationship: ?_Relationship,
+	onCancel?: () => mixed,
+	onClose?: () => mixed,
+	onSave?: (_Relationship) => mixed
+};
+
+type RelationshipModalState = {
+	entityType?: ?EntityTypeObject,
+	relationshipType?: ?RelationshipType,
+	relationship?: ?_Relationship,
+	targetEntity?: ?EntitySearchResult
+};
+
+function getInitState(
+	baseEntity: Entity, initRelationship: ?_Relationship
+): RelationshipModalState {
+	if (_.isNull(initRelationship)) {
+		return {
+			entityType: null,
+			relationship: null,
+			relationshipType: null,
+			targetEntity: null
+		};
+	}
+
+	const sourceEntity = _.get(initRelationship, ['sourceEntity']);
+	const targetEntity = _.get(initRelationship, ['targetEntity']);
+
+	const baseEntityBBID = _.get(baseEntity, ['bbid']);
+
+	const sourceEntityBBID = _.get(sourceEntity, ['bbid']);
+	const otherEntity = baseEntityBBID === sourceEntityBBID ?
+		targetEntity : sourceEntity;
+
+	const searchFormatOtherEntity = otherEntity && {
+		id: _.get(otherEntity, ['bbid']),
+		text: _.get(
+			otherEntity, ['defaultAlias', 'name'], '(unnamed)'
+		),
+		type: _.get(otherEntity, ['type']),
+		value: _.get(otherEntity, ['bbid'])
+	};
+
+	return {
+		entityType: {
+			id: _.lowerCase(_.get(searchFormatOtherEntity, 'type')),
+			label: _.get(searchFormatOtherEntity, 'type')
+		},
+		relationship: initRelationship,
+		relationshipType: _.get(initRelationship, ['relationshipType']),
+		targetEntity: searchFormatOtherEntity
+	};
+}
+
+class RelationshipModal
+	extends React.Component<RelationshipModalProps, RelationshipModalState> {
+	static defaultProps = {
+		onCancel: null,
+		onClose: null,
+		onSave: null
+	};
+
+	constructor(props: RelationshipModalProps) {
+		super(props);
+
+		this.state = getInitState(props.baseEntity, props.initRelationship);
+	}
+
+	handleEntityTypeChange = (value: EntityTypeObject) => {
+		this.setState({
+			entityType: value,
+			relationship: null,
+			relationshipType: null,
+			targetEntity: null
+		});
+	};
+
+	handleEntityChange = (value: EntitySearchResult) => {
+		this.setState({
+			relationship: null,
+			relationshipType: null,
+			targetEntity: value
+		});
+	};
+
+	handleRelationshipTypeChange = (value: _Relationship) => {
+		this.setState({
+			relationship: value,
+			relationshipType: value.relationshipType
+		});
+	};
+
+	handleSave = () => {
+		const {onSave} = this.props;
+		if (onSave) {
+			if (this.state.relationship) {
+				onSave(this.state.relationship);
+			}
+		}
+	};
+
+	calculateProgressAmount() {
+		if (!this.state.entityType) {
+			return 1;
+		}
+
+		if (!this.state.targetEntity) {
+			return 30;
+		}
+
+		if (!this.state.relationshipType) {
+			return 60;
+		}
+
+		return 100;
+	}
+
+	renderEntityTypeSelect() {
+		return (
+			<FormGroup>
+				<ControlLabel>Entity Type</ControlLabel>
+				<ReactSelect
+					name="entityType"
+					options={ENTITY_TYPE_VALUES}
+					value={this.state.entityType}
+					onChange={this.handleEntityTypeChange}
+				/>
+			</FormGroup>
+		);
+	}
+
+	renderEntitySelect() {
+		return (
+			<EntitySearchField
+				cache={false}
+				disabled={!this.state.entityType}
+				instanceId="publication"
+				label={_.get(this.state, 'entityType.label', 'Entity')}
+				name="entity"
+				type={_.get(this.state, 'entityType.id')}
+				value={this.state.targetEntity}
+				onChange={this.handleEntityChange}
+			/>
+		);
+	}
+
+	renderRelationshipSelect() {
+		const {baseEntity, relationshipTypes} = this.props;
+
+		const otherEntity = {
+			bbid: _.get(this.state, ['targetEntity', 'id']),
+			defaultAlias: {
+				name: _.get(this.state, ['targetEntity', 'text'])
+			},
+			type: _.get(this.state, ['targetEntity', 'type'])
+		};
+
+		const relationships = generateRelationshipSelection(
+			relationshipTypes, baseEntity, otherEntity
+		);
+
+		return (
+			<FormGroup>
+				<ControlLabel>Relationship</ControlLabel>
+				<ReactSelect
+					disabled={!this.state.targetEntity}
+					name="relationshipType"
+					optionRenderer={Relationship}
+					options={relationships}
+					value={this.state.relationship}
+					valueKey="selectId"
+					valueRenderer={Relationship}
+					onChange={this.handleRelationshipTypeChange}
+				/>
+			</FormGroup>
+		);
+	}
+
+	render() {
+		const {onCancel, onClose, baseEntity} = this.props;
+
+		const submitDisabled = this.calculateProgressAmount() < 100;
+
+		return (
+			<Modal show bsSize="large" onHide={onClose}>
+				<Modal.Header>
+					<Modal.Title>Add a relationship</Modal.Title>
+				</Modal.Header>
+				<Modal.Body>
+					<p>
+						<strong>
+							Use this form to add links between this{' '}
+							{baseEntity.type}
+							{' '}and other entities.
+						</strong>
+						{' '}For example, you can link a creator
+						to a work as an author, or a work to another work
+						to show translation or derivation.
+					</p>
+					<hr/>
+					<Row>
+						<Col md={10} mdOffset={1}>
+							<form>
+								<Row>
+									<Col md={4}>
+										{this.renderEntityTypeSelect()}
+									</Col>
+									<Col md={8}>
+										{this.renderEntitySelect()}
+									</Col>
+								</Row>
+								<Row>
+									<Col md={12}>
+										{this.renderRelationshipSelect()}
+									</Col>
+								</Row>
+							</form>
+						</Col>
+					</Row>
+				</Modal.Body>
+				<Modal.Footer>
+					<Row>
+						<Col md={10} mdOffset={1}>
+							<ProgressBar
+								bsStyle="success"
+								now={this.calculateProgressAmount()}
+							/>
+						</Col>
+					</Row>
+					<Button bsStyle="danger" onClick={onCancel}>Cancel</Button>
+					<Button
+						bsStyle="success"
+						disabled={submitDisabled}
+						onClick={this.handleSave}
+					>
+						Save
+					</Button>
+				</Modal.Footer>
+			</Modal>
+		);
+	}
+}
+
+export default RelationshipModal;

--- a/src/client/entity-editor/relationship-editor/relationship-section.js
+++ b/src/client/entity-editor/relationship-editor/relationship-section.js
@@ -20,8 +20,8 @@
 
 import * as Immutable from 'immutable';
 import {
-	type Action, editRelationship, hideRelationshipEditor, saveRelationship,
-	showRelationshipEditor
+	type Action, editRelationship, hideRelationshipEditor, removeRelationship,
+	saveRelationship, showRelationshipEditor
 } from './actions';
 import {Button, ButtonGroup, Col, Row} from 'react-bootstrap';
 import type {
@@ -39,11 +39,12 @@ import {connect} from 'react-redux';
 type RelationshipListProps = {
 	contextEntity: Entity,
 	relationships: Array<RelationshipForDisplay>,
-	onEdit: (number) => mixed
+	onEdit: (number) => mixed,
+	onRemove: (number) => mixed
 };
 
 function RelationshipList(
-	{contextEntity, relationships, onEdit}: RelationshipListProps
+	{contextEntity, relationships, onEdit, onRemove}: RelationshipListProps
 ) {
 	/* eslint-disable react/jsx-no-bind */
 
@@ -71,7 +72,12 @@ function RelationshipList(
 							</Button>
 						</ButtonGroup>
 						<ButtonGroup>
-							<Button bsStyle="danger">Remove</Button>
+							<Button
+								bsStyle="danger"
+								onClick={onRemove.bind(this, rowID)}
+							>
+								Remove
+							</Button>
 						</ButtonGroup>
 					</ButtonGroup>
 				</Col>
@@ -101,7 +107,8 @@ type DispatchProps = {
 	onAddRelationship: () => mixed,
 	onEditorClose: () => mixed,
 	onEditorSave: (_Relationship) => mixed,
-	onEdit: (number) => mixed
+	onEdit: (number) => mixed,
+	onRemove: (number) => mixed
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -110,7 +117,7 @@ type Props = OwnProps & StateProps & DispatchProps;
 function RelationshipSection({
 	entity, entityType, entityName, showEditor, relationships,
 	relationshipEditorProps, relationshipTypes, onAddRelationship,
-	onEditorClose, onEditorSave, onEdit
+	onEditorClose, onEditorSave, onEdit, onRemove
 }: Props) {
 	const baseEntity = {
 		bbid: _.get(entity, 'bbid'),
@@ -143,6 +150,7 @@ function RelationshipSection({
 						contextEntity={baseEntity}
 						relationships={relationships.toJS()}
 						onEdit={onEdit}
+						onRemove={onRemove}
 					/>
 				</Col>
 			</Row>
@@ -179,7 +187,8 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 		onAddRelationship: () => dispatch(showRelationshipEditor()),
 		onEdit: (rowID) => dispatch(editRelationship(rowID)),
 		onEditorClose: () => dispatch(hideRelationshipEditor()),
-		onEditorSave: (data) => dispatch(saveRelationship(data))
+		onEditorSave: (data) => dispatch(saveRelationship(data)),
+		onRemove: (rowID) => dispatch(removeRelationship(rowID))
 	};
 }
 

--- a/src/client/entity-editor/relationship-editor/relationship-section.js
+++ b/src/client/entity-editor/relationship-editor/relationship-section.js
@@ -21,7 +21,7 @@
 import * as Immutable from 'immutable';
 import {
 	type Action, editRelationship, hideRelationshipEditor, removeRelationship,
-	saveRelationship, showRelationshipEditor
+	saveRelationship, showRelationshipEditor, undoLastSave
 } from './actions';
 import {Button, ButtonGroup, Col, Row} from 'react-bootstrap';
 import type {
@@ -100,7 +100,8 @@ type StateProps = {
 	entityName: string,
 	relationships: Immutable.List<any>,
 	relationshipEditorProps: Immutable.Map<string, any>,
-	showEditor: boolean
+	showEditor: boolean,
+	undoPossible: boolean
 };
 
 type DispatchProps = {
@@ -108,7 +109,8 @@ type DispatchProps = {
 	onEditorClose: () => mixed,
 	onEditorSave: (_Relationship) => mixed,
 	onEdit: (number) => mixed,
-	onRemove: (number) => mixed
+	onRemove: (number) => mixed,
+	onUndo: () => mixed
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -117,7 +119,7 @@ type Props = OwnProps & StateProps & DispatchProps;
 function RelationshipSection({
 	entity, entityType, entityName, showEditor, relationships,
 	relationshipEditorProps, relationshipTypes, onAddRelationship,
-	onEditorClose, onEditorSave, onEdit, onRemove
+	onEditorClose, onEditorSave, onEdit, onRemove, onUndo, undoPossible
 }: Props) {
 	const baseEntity = {
 		bbid: _.get(entity, 'bbid'),
@@ -162,12 +164,27 @@ function RelationshipSection({
 				>
 					<Button
 						bsStyle="success"
-						onClick={(onAddRelationship)}
+						onClick={onAddRelationship}
 					>
 						Add relationship
 					</Button>
 				</Col>
 			</Row>
+			{undoPossible &&
+				<Row className="margin-top-d5">
+					<Col
+						className="text-center"
+						md={4}
+						mdOffset={4}
+					>
+						<Button
+							onClick={onUndo}
+						>
+							Undo last action
+						</Button>
+					</Col>
+				</Row>
+			}
 		</div>
 	);
 }
@@ -178,7 +195,8 @@ function mapStateToProps(rootState): StateProps {
 		entityName: rootState.getIn(['nameSection', 'name']),
 		relationshipEditorProps: state.get('relationshipEditorProps'),
 		relationships: state.get('relationships'),
-		showEditor: state.get('relationshipEditorVisible')
+		showEditor: state.get('relationshipEditorVisible'),
+		undoPossible: state.get('lastRelationships') !== null
 	};
 }
 
@@ -188,7 +206,8 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 		onEdit: (rowID) => dispatch(editRelationship(rowID)),
 		onEditorClose: () => dispatch(hideRelationshipEditor()),
 		onEditorSave: (data) => dispatch(saveRelationship(data)),
-		onRemove: (rowID) => dispatch(removeRelationship(rowID))
+		onRemove: (rowID) => dispatch(removeRelationship(rowID)),
+		onUndo: () => dispatch(undoLastSave())
 	};
 }
 

--- a/src/client/entity-editor/relationship-editor/relationship-section.js
+++ b/src/client/entity-editor/relationship-editor/relationship-section.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2018  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+// @flow
+
+import * as Immutable from 'immutable';
+import {
+	type Action, editRelationship, hideRelationshipEditor, saveRelationship,
+	showRelationshipEditor
+} from './actions';
+import {Button, ButtonGroup, Col, Row} from 'react-bootstrap';
+import type {
+	Entity, EntityType, RelationshipForDisplay, RelationshipType,
+	Relationship as _Relationship
+} from './types';
+import type {Dispatch} from 'redux'; // eslint-disable-line import/named
+import React from 'react';
+import Relationship from './relationship';
+import RelationshipEditor from './relationship-editor';
+import _ from 'lodash';
+import {connect} from 'react-redux';
+
+
+type RelationshipListProps = {
+	contextEntity: Entity,
+	relationships: Array<RelationshipForDisplay>,
+	onEdit: (number) => mixed
+};
+
+function RelationshipList(
+	{contextEntity, relationships, onEdit}: RelationshipListProps
+) {
+	/* eslint-disable react/jsx-no-bind */
+
+	const renderedRelationships = _.map(
+		relationships,
+		({relationshipType, sourceEntity, targetEntity}, rowID) => (
+			<Row className="margin-top-d5" key={rowID}>
+				<Col md={8}>
+					<Relationship
+						link
+						contextEntity={contextEntity}
+						relationshipType={relationshipType}
+						sourceEntity={sourceEntity}
+						targetEntity={targetEntity}
+					/>
+				</Col>
+				<Col className="text-right" md={4}>
+					<ButtonGroup justified>
+						<ButtonGroup>
+							<Button
+								bsStyle="warning"
+								onClick={onEdit.bind(this, rowID)}
+							>
+								Edit
+							</Button>
+						</ButtonGroup>
+						<ButtonGroup>
+							<Button bsStyle="danger">Remove</Button>
+						</ButtonGroup>
+					</ButtonGroup>
+				</Col>
+			</Row>
+		)
+	);
+
+	/* eslint-enable react/jsx-no-bind */
+
+	return <div>{renderedRelationships}</div>;
+}
+
+type OwnProps = {
+	entity: Entity,
+	entityType: EntityType,
+	relationshipTypes: Array<RelationshipType>
+};
+
+type StateProps = {
+	entityName: string,
+	relationships: Immutable.List<any>,
+	relationshipEditorProps: Immutable.Map<string, any>,
+	showEditor: boolean
+};
+
+type DispatchProps = {
+	onAddRelationship: () => mixed,
+	onEditorClose: () => mixed,
+	onEditorSave: (_Relationship) => mixed,
+	onEdit: (number) => mixed
+};
+
+type Props = OwnProps & StateProps & DispatchProps;
+
+
+function RelationshipSection({
+	entity, entityType, entityName, showEditor, relationships,
+	relationshipEditorProps, relationshipTypes, onAddRelationship,
+	onEditorClose, onEditorSave, onEdit
+}: Props) {
+	const baseEntity = {
+		bbid: _.get(entity, 'bbid'),
+		defaultAlias: {
+			name: entityName
+		},
+		type: _.upperFirst(entityType)
+	};
+
+	const editor = (
+		<RelationshipEditor
+			baseEntity={baseEntity}
+			initRelationship={
+				relationshipEditorProps && relationshipEditorProps.toJS()
+			}
+			relationshipTypes={relationshipTypes}
+			onCancel={onEditorClose}
+			onClose={onEditorClose}
+			onSave={onEditorSave}
+		/>
+	);
+
+	return (
+		<div>
+			{showEditor && editor}
+			<h2>How are other entities related to this entity?</h2>
+			<Row>
+				<Col md={10} mdOffset={1}>
+					<RelationshipList
+						contextEntity={baseEntity}
+						relationships={relationships.toJS()}
+						onEdit={onEdit}
+					/>
+				</Col>
+			</Row>
+			<Row className="margin-top-1">
+				<Col
+					className="text-center"
+					md={4}
+					mdOffset={4}
+				>
+					<Button
+						bsStyle="success"
+						onClick={(onAddRelationship)}
+					>
+						Add relationship
+					</Button>
+				</Col>
+			</Row>
+		</div>
+	);
+}
+
+function mapStateToProps(rootState): StateProps {
+	const state = rootState.get('relationshipSection');
+	return {
+		entityName: rootState.getIn(['nameSection', 'name']),
+		relationshipEditorProps: state.get('relationshipEditorProps'),
+		relationships: state.get('relationships'),
+		showEditor: state.get('relationshipEditorVisible')
+	};
+}
+
+function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
+	return {
+		onAddRelationship: () => dispatch(showRelationshipEditor()),
+		onEdit: (rowID) => dispatch(editRelationship(rowID)),
+		onEditorClose: () => dispatch(hideRelationshipEditor()),
+		onEditorSave: (data) => dispatch(saveRelationship(data))
+	};
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+	RelationshipSection
+);

--- a/src/client/entity-editor/relationship-editor/relationship.js
+++ b/src/client/entity-editor/relationship-editor/relationship.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+// @flow
+
+import type {RelationshipType, Entity as _Entity} from './types';
+import Entity from '../common/entity';
+import React from 'react';
+import _ from 'lodash';
+import {getEntityLink} from '../../../server/helpers/utils';
+
+
+function getEntityObjectForDisplay(entity: _Entity, makeLink: boolean) {
+	const link = makeLink && entity.bbid &&
+		getEntityLink({bbid: entity.bbid, type: entity.type});
+	return {
+		link,
+		text: _.get(entity, ['defaultAlias', 'name']),
+		type: entity.type,
+		unnamedText: entity.bbid ? '(unnamed)' : 'New Entity'
+	};
+}
+
+type RelationshipProps = {
+	link: boolean, // eslint-disable-line react/require-default-props
+	contextEntity: ?_Entity, // eslint-disable-line react/require-default-props
+	sourceEntity: _Entity,
+	targetEntity: _Entity,
+	relationshipType: RelationshipType
+};
+
+function Relationship({
+	contextEntity, link, relationshipType, sourceEntity, targetEntity
+}: RelationshipProps) {
+	const {linkPhrase, reverseLinkPhrase} = relationshipType;
+
+	const reversed = contextEntity &&
+		(_.get(contextEntity, 'bbid') === _.get(targetEntity, 'bbid'));
+
+	const sourceObject = getEntityObjectForDisplay(
+		reversed ? targetEntity : sourceEntity, link
+	);
+	const targetObject = getEntityObjectForDisplay(
+		reversed ? sourceEntity : targetEntity, link
+	);
+
+	const usedLinkPhrase = reversed ? reverseLinkPhrase : linkPhrase;
+
+	return (
+		<div>
+			<Entity {...sourceObject}/>
+			{` ${usedLinkPhrase} `}
+			<Entity {...targetObject}/>
+		</div>
+	);
+}
+Relationship.displayName = 'Relationship';
+Relationship.defaultProps = {
+	contextEntity: null, // eslint-disable-line react/default-props-match-prop-types, max-len
+	link: false // eslint-disable-line react/default-props-match-prop-types
+};
+
+export default Relationship;

--- a/src/client/entity-editor/relationship-editor/types.js
+++ b/src/client/entity-editor/relationship-editor/types.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018  Ben Ockmore
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+// @flow
+
+export type EntityType = string;
+
+export type EntityTypeObject = {
+	id: string,
+	label: string
+};
+
+export type Entity = {
+	bbid: string,
+	defaultAlias?: {
+		name: string
+	},
+	type: EntityType
+};
+
+export type RelationshipType = {
+	id: number,
+	childOrder: number,
+	deprecated: boolean,
+	description: string,
+	label: string,
+	linkPhrase: string,
+	parentId: number,
+	reverseLinkPhrase: string,
+	sourceEntityType: EntityType,
+	targetEntityType: EntityType
+};
+
+export type Relationship = {
+	relationshipType: RelationshipType,
+	sourceEntity: Entity,
+	targetEntity: Entity
+};
+
+export type RelationshipWithLabel = {
+	label: string,
+	relationshipType: RelationshipType,
+	sourceEntity: Entity,
+	targetEntity: Entity
+};
+
+export type RelationshipForDisplay = {
+	relationshipType: RelationshipType,
+	sourceEntity: Entity,
+	targetEntity: Entity,
+	rowID: number
+};

--- a/src/client/entity-editor/relationship-editor/types.js
+++ b/src/client/entity-editor/relationship-editor/types.js
@@ -20,11 +20,6 @@
 
 export type EntityType = string;
 
-export type EntityTypeObject = {
-	id: string,
-	label: string
-};
-
 export type Entity = {
 	bbid: string,
 	defaultAlias?: {

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -250,3 +250,7 @@ html {
 .Select-menu-outer {
 	z-index: 5;
 }
+
+.progress {
+	height: 10px;
+}

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -167,11 +167,13 @@ export function makeEntityCreateOrEditHandler(
 	propertiesToPick: string | string[],
 ) {
 	const entityName = _.capitalize(entityType);
+	const validate = getValidator(entityType);
+
 	return function createOrEditHandler(
 		action: EntityAction,
 		req: express.request,
-		res: express.response) {
-		const validate = getValidator(entityType);
+		res: express.response
+	) {
 		if (!validate(req.body)) {
 			const err = new error.FormSubmissionError();
 			error.sendErrorAsJSON(res, err);

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -165,8 +165,7 @@ export function makeEntityCreateOrEditHandler(
 	entityType: string,
 	transformNewForm: Function,
 	propertiesToPick: string | string[],
-	additionalCallback?: (req: Object, res: Object) => any =
-	(req, res) => null) {
+) {
 	const entityName = _.capitalize(entityType);
 	return function createOrEditHandler(
 		action: EntityAction,
@@ -185,8 +184,7 @@ export function makeEntityCreateOrEditHandler(
 			  entityRoutes.editEntity;
 
 		return entityFunction(
-			req, res, entityName, _.pick(req.body, propertiesToPick),
-			additionalCallback(req, res)
+			req, res, entityName, _.pick(req.body, propertiesToPick)
 		);
 	};
 }

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -170,7 +170,6 @@ export function makeEntityCreateOrEditHandler(
 	const validate = getValidator(entityType);
 
 	return function createOrEditHandler(
-		action: EntityAction,
 		req: express.request,
 		res: express.response
 	) {

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -179,11 +179,7 @@ export function makeEntityCreateOrEditHandler(
 
 		req.body = transformNewForm(req.body);
 
-		const entityFunction = action === 'create' ?
-			  entityRoutes.createEntity :
-			  entityRoutes.editEntity;
-
-		return entityFunction(
+		return entityRoutes.handleCreateOrEditEntity(
 			req, res, entityName, _.pick(req.body, propertiesToPick)
 		);
 	};

--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -49,6 +49,8 @@ export const loadPublicationTypes =
 	makeLoader('PublicationType', 'publicationTypes');
 export const loadPublisherTypes = makeLoader('PublisherType', 'publisherTypes');
 export const loadWorkTypes = makeLoader('WorkType', 'workTypes');
+export const loadRelationshipTypes =
+	makeLoader('RelationshipType', 'relationshipTypes');
 
 export const loadGenders =
 	makeLoader('Gender', 'genders', (a, b) => a.id > b.id);

--- a/src/server/helpers/render.js
+++ b/src/server/helpers/render.js
@@ -20,7 +20,6 @@
 // @flow
 
 import * as utils from './utils';
-import Handlebars from 'handlebars';
 
 
 type EntityInRelationship = {
@@ -61,10 +60,13 @@ type Relationship = {
  * @returns {string} - Rendered HTML string.
  */
 function renderRelationship(relationship: Relationship) {
-	const template = Handlebars.compile(
-		relationship.type.displayTemplate,
-		{noEscape: true}
-	);
+	function template(data) {
+		return (
+			`${data.entities[0]} ` +
+			`${relationship.type.linkPhrase} ` +
+			`${data.entities[1]}`
+		);
+	}
 
 	const data = {
 		entities: [

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -148,6 +148,9 @@ function creatorToFormState(creator) {
 	};
 
 	const relationshipSection = {
+		lastRelationships: null,
+		relationshipEditorProps: null,
+		relationshipEditorVisible: false,
 		relationships: {}
 	};
 

--- a/src/server/routes/entity/creator.js
+++ b/src/server/routes/entity/creator.js
@@ -234,9 +234,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 );
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'create'));
+	createOrEditHandler);
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'edit'));
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -338,9 +338,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 );
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'create'));
+	createOrEditHandler);
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'edit'));
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -125,7 +125,7 @@ router.get(
 		}
 
 		function render(props) {
-			const {initialState, ...rest} = props;
+			const {initialState} = props;
 
 			if (props.publisher || props.publication) {
 				initialState.editionSection = {};

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -236,6 +236,9 @@ function editionToFormState(edition) {
 	};
 
 	const relationshipSection = {
+		lastRelationships: null,
+		relationshipEditorProps: null,
+		relationshipEditorVisible: false,
 		relationships: {}
 	};
 

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -316,40 +316,9 @@ const additionalEditionProps = [
 	'formatId', 'statusId'
 ];
 
-function getAdditionalEditionSets(orm) {
-	const {LanguageSet, PublisherSet, ReleaseEventSet} = orm;
-	return [
-		{
-			entityIdField: 'languageSetId',
-			idField: 'id',
-			model: LanguageSet,
-			name: 'languageSet',
-			propName: 'languages'
-		},
-		{
-			entityIdField: 'publisherSetId',
-			idField: 'bbid',
-			model: PublisherSet,
-			name: 'publisherSet',
-			propName: 'publishers'
-		},
-		{
-			entityIdField: 'releaseEventSetId',
-			idField: 'id',
-			model: ReleaseEventSet,
-			mutableFields: [
-				'date',
-				'areaId'
-			],
-			name: 'releaseEventSet',
-			propName: 'releaseEvents'
-		}
-	];
-}
-
 const createOrEditHandler = makeEntityCreateOrEditHandler(
-	'edition', transformNewForm, additionalEditionProps, (req, res) =>
-		getAdditionalEditionSets(req.app.locals.orm));
+	'edition', transformNewForm, additionalEditionProps
+);
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
 	_.partial(createOrEditHandler, 'create'));

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -209,12 +209,12 @@ export function displayRevisions(
 		.catch(next);
 }
 
-function _createNote(orm, content, editor, revision, transacting) {
+function _createNote(orm, content, editorID, revision, transacting) {
 	const {Note} = orm;
 	if (content) {
 		const revisionId = revision.get('id');
 		return new Note({
-			authorId: editor.id,
+			authorId: editorID,
 			content,
 			revisionId
 		})
@@ -232,7 +232,7 @@ export function addNoteToRevision(req: PassportRequest, res: $Response) {
 	const {body}: {body: any} = req;
 	const revisionNotePromise = bookshelf.transaction(
 		(transacting) => _createNote(
-			orm, body.note, editorJSON, revision, transacting
+			orm, body.note, editorJSON.id, revision, transacting
 		)
 	);
 	return handler.sendPromiseResult(res, revisionNotePromise);
@@ -257,7 +257,7 @@ export function handleDelete(
 
 		const notePromise = newRevisionPromise
 			.then((revision) => _createNote(
-				orm, body.note, editorJSON, revision, transacting
+				orm, body.note, editorJSON.id, revision, transacting
 			));
 
 		/*
@@ -641,7 +641,7 @@ export function createEntity(
 
 		const notePromise = newRevisionPromise
 			.then((revision) => _createNote(
-				orm, req.body.note, editorJSON, revision, transacting
+				orm, req.body.note, editorJSON.id, revision, transacting
 			));
 
 		const aliasSetPromise = processFormAliases(
@@ -889,7 +889,7 @@ export function editEntity(
 					);
 
 				const notePromise = _createNote(
-					orm, req.body.note, editorJSON, newRevision, transacting
+					orm, req.body.note, editorJSON.id, newRevision, transacting
 				);
 
 				return Promise.join(

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -797,6 +797,18 @@ export function constructIdentifiers(
 	);
 }
 
+export function constructRelationships(relationshipSection) {
+	return _.map(
+		relationshipSection.relationships,
+		({rowID, relationshipType, sourceEntity, targetEntity}) => ({
+			id: rowID,
+			sourceBbid: _.get(sourceEntity, 'bbid'),
+			targetBbid: _.get(targetEntity, 'bbid'),
+			typeId: relationshipType.id
+		})
+	);
+}
+
 export function getDefaultAliasIndex(aliases) {
 	const index = aliases.findIndex((alias) => alias.default);
 	return index > 0 ? index : 0;

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -370,10 +370,12 @@ async function processWorkSets(
 			.fetch({transacting, withRelated: ['languages']})
 	);
 
+	const languages = _.get(body, 'languages') || [];
 	return Promise.props({
 		languageSetId: orm.func.language.updateLanguageSet(
-			orm, transacting, oldSet, body.languages
-		)
+			orm, transacting, oldSet,
+			languages.map((languageID) => ({id: languageID}))
+		).then((set) => set && set.get('id'))
 	});
 }
 

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -705,7 +705,8 @@ export function handleCreateOrEditEntity(
 			const bbid: string = entityModel.get('bbid');
 			if (_.has(relationshipSets, bbid)) {
 				entityModel.set(
-					'relationshipSetId', relationshipSets[bbid].get('id')
+					'relationshipSetId',
+					relationshipSets[bbid] && relationshipSets[bbid].get('id')
 				);
 			}
 		});

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -19,7 +19,6 @@
 
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
-import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
@@ -217,7 +216,8 @@ function transformNewForm(data) {
 }
 
 const createOrEditHandler = makeEntityCreateOrEditHandler(
-	'publication', transformNewForm, 'typeId');
+	'publication', transformNewForm, 'typeId'
+);
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
 	createOrEditHandler);

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -220,9 +220,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 	'publication', transformNewForm, 'typeId');
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'create'));
+	createOrEditHandler);
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'edit'));
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -152,6 +152,9 @@ function publicationToFormState(publication) {
 	};
 
 	const relationshipSection = {
+		lastRelationships: null,
+		relationshipEditorProps: null,
+		relationshipEditorVisible: false,
 		relationships: {}
 	};
 

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -177,7 +177,7 @@ function publicationToFormState(publication) {
 router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublicationTypes, middleware.loadLanguages,
-	middleware.loadRelationshipTypes,
+	 middleware.loadEntityRelationships, middleware.loadRelationshipTypes,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'publication', req, res, {}, publicationToFormState

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -186,7 +186,7 @@ function publisherToFormState(publisher) {
 router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadPublisherTypes, middleware.loadLanguages,
-	middleware.loadRelationshipTypes,
+	 middleware.loadEntityRelationships, middleware.loadRelationshipTypes,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'publisher', req, res, {}, publisherToFormState

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -19,7 +19,6 @@
 
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
-import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {
@@ -236,7 +235,8 @@ const additionalPublisherProps = [
 ];
 
 const createOrEditHandler = makeEntityCreateOrEditHandler(
-	'publisher', transformNewForm, additionalPublisherProps);
+	'publisher', transformNewForm, additionalPublisherProps
+);
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
 	createOrEditHandler);

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -239,9 +239,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 	'publisher', transformNewForm, additionalPublisherProps);
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'create'));
+	createOrEditHandler);
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'edit'));
+	createOrEditHandler);
 
 export default router;

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -161,6 +161,9 @@ function publisherToFormState(publisher) {
 	};
 
 	const relationshipSection = {
+		lastRelationships: null,
+		relationshipEditorProps: null,
+		relationshipEditorVisible: false,
 		relationships: {}
 	};
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -174,7 +174,7 @@ function workToFormState(work) {
 router.get(
 	'/:bbid/edit', auth.isAuthenticated, middleware.loadIdentifierTypes,
 	middleware.loadWorkTypes, middleware.loadLanguages,
-	middleware.loadRelationshipTypes,
+	 middleware.loadEntityRelationships, middleware.loadRelationshipTypes,
 	(req, res) => {
 		const {markup, props} = entityEditorMarkup(generateEntityProps(
 			'work', req, res, {}, workToFormState

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -19,7 +19,6 @@
 
 import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
-import * as error from '../../helpers/error';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
 import {

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -149,6 +149,9 @@ function workToFormState(work) {
 	};
 
 	const relationshipSection = {
+		lastRelationships: null,
+		relationshipEditorProps: null,
+		relationshipEditorVisible: false,
 		relationships: {}
 	};
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -177,20 +177,6 @@ router.get(
 	}
 );
 
-function getAdditionalWorkSets(orm) {
-	const {LanguageSet} = orm;
-	return [
-		{
-			entityIdField: 'languageSetId',
-			idField: 'id',
-			model: LanguageSet,
-			name: 'languageSet',
-			propName: 'languages'
-		}
-	];
-}
-
-
 function transformNewForm(data) {
 	const aliases = entityRoutes.constructAliases(
 		data.aliasEditor, data.nameSection
@@ -215,8 +201,8 @@ function transformNewForm(data) {
 }
 
 const createOrEditHandler = makeEntityCreateOrEditHandler(
-	'work', transformNewForm, 'typeId', (req, res) =>
-		getAdditionalWorkSets(req.app.locals.orm));
+	'work', transformNewForm, 'typeId'
+);
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
 	_.partial(createOrEditHandler, 'create'));

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -223,9 +223,9 @@ const createOrEditHandler = makeEntityCreateOrEditHandler(
 );
 
 router.post('/create/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'create'));
+	createOrEditHandler);
 
 router.post('/:bbid/edit/handler', auth.isAuthenticatedForHandler,
-	_.partial(createOrEditHandler, 'edit'));
+	createOrEditHandler);
 
 export default router;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
There is no way to edit relationships in the site.


### Solution
This PR consolidates the entity creation and editing code. It adds a client side relationship editor as part of the existing entity editor React app, and then adds functions to handle the new relationship data server-side, as part of the new entity creation and editing function. The relationship schema has also changed, so some updates are made to relationship rendering to deal with this.


### Areas of Impact
The client-side entity editor, the server side entity revision handling code, and relationship rendering code.
