### PR TITLE
Modifies PartialDate's validate function to take an optional function…

### DIFF
--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -32,7 +32,7 @@ import request from 'superagent-bluebird-promise';
 
 
 const {Button, Col, Grid, Row} = bootstrap;
-const {formatDate, injectDefaultAliasName} = utilsHelper;
+const {formatDate, injectDefaultAliasName, isValidUserBirthday} = utilsHelper;
 
 class ProfileForm extends React.Component {
 	constructor(props) {
@@ -173,6 +173,7 @@ class ProfileForm extends React.Component {
 								ref={(ref) => this.gender = ref}
 							/>
 							<PartialDate
+								customValidator={isValidUserBirthday}
 								defaultValue={initialBirthDate}
 								label="Birth Date"
 								placeholder="YYYY-MM-DD"

--- a/src/client/components/forms/registration-details.js
+++ b/src/client/components/forms/registration-details.js
@@ -19,6 +19,7 @@
  */
 
 import * as bootstrap from 'react-bootstrap';
+import * as utilsHelper from '../../helpers/utils';
 import * as validators from '../../helpers/react-validators';
 import CustomInput from '../../input';
 import LoadingSpinner from '../loading-spinner';
@@ -31,6 +32,7 @@ import request from 'superagent-bluebird-promise';
 
 
 const {Alert, Button, PageHeader} = bootstrap;
+const {isValidUserBirthday} = utilsHelper;
 
 class RegistrationForm extends React.Component {
 	constructor(props) {
@@ -154,6 +156,7 @@ class RegistrationForm extends React.Component {
 								wrapperClassName="col-md-4"
 							/>
 							<PartialDate
+								customValidator={isValidUserBirthday}
 								label="Birthday"
 								labelClassName="col-md-4"
 								placeholder="YYYY-MM-DD"

--- a/src/client/components/input/partial-date.js
+++ b/src/client/components/input/partial-date.js
@@ -36,10 +36,11 @@ class PartialDate extends React.Component {
 	/**
 	 * Function to check validity of the partial date.
 	 * @param {string} value - Partial Date to be validated.
+	 * @param {function} customValidator - custom validation function
 	 * @returns {boolean} - True if the partial date value is null or if
 	 * the partial date is valid.
 	 */
-	static validate(value) {
+	static validate(value, customValidator) {
 		if (!value) {
 			return true;
 		}
@@ -51,7 +52,11 @@ class PartialDate extends React.Component {
 		);
 		const validValue = !isNaN(Date.parse(value));
 
-		return validSyntax && validValue;
+		let passesCustomValidation = true;
+		if (customValidator) {
+			passesCustomValidation = Boolean(customValidator(value));
+		}
+		return validSyntax && validValue && passesCustomValidation;
 	}
 
 	/**
@@ -93,7 +98,9 @@ class PartialDate extends React.Component {
 		}
 
 		this.setState({
-			valid: PartialDate.validate(input),
+			valid: PartialDate.validate(input,
+				this.props.customValidator
+			),
 			value: input
 		});
 
@@ -108,7 +115,9 @@ class PartialDate extends React.Component {
 	 * @returns {boolean} - The result as obtained from the date validator.
 	 */
 	valid() {
-		return PartialDate.validate(this.input.getValue().trim());
+		return PartialDate.validate(this.input.getValue().trim(),
+			this.props.customValidator
+		);
 	}
 
 	/**
@@ -153,6 +162,7 @@ class PartialDate extends React.Component {
 // TODO: pass props to underlying Input using spread syntax
 PartialDate.displayName = 'PartialDate';
 PartialDate.propTypes = {
+	customValidator: PropTypes.func,
 	defaultValue: PropTypes.string,
 	groupClassName: PropTypes.string,
 	help: PropTypes.string,
@@ -163,6 +173,7 @@ PartialDate.propTypes = {
 	wrapperClassName: PropTypes.string
 };
 PartialDate.defaultProps = {
+	customValidator: null,
 	defaultValue: null,
 	groupClassName: null,
 	help: null,

--- a/src/client/helpers/utils.js
+++ b/src/client/helpers/utils.js
@@ -52,3 +52,14 @@ const MILLISECONDS_PER_DAY = 86400000;
 export function isWithinDayFromNow(date) {
 	return Boolean(Date.now() - date.getTime() < MILLISECONDS_PER_DAY);
 }
+
+/**
+ * Adds extra validation for form fields recording user's birthdays.
+ * Specifically checks that a given date value is in the past.
+ *
+ * @param {string} value - Date that is going to be validated.
+ * @returns {boolean} - True if value is a date in the past. False otherwise.
+ */
+export function isValidUserBirthday(value) {
+	return Date.parse(value) < Date.now();
+}


### PR DESCRIPTION
Recovery of #134 @inondle 

## Problem
The 'birthday' field of the registration and profile forms allowed users to enter birthdays in the future.

## Solution
The PR adds a parameter to `PartialDate.validate()` that takes a function and, if defined, also validates the value with that function. The forms that use `PartialDate` as a field for taking birthdays now pass in an extra function to check that the date put into the field is in the past.

## Areas of Impact
This modifies the validation functions of `PartialDate`, `PartialDate` can now be rendered with the `customValidation` field which takes in a callback for extra validation.