### PR TITLE
fix(IdentifierEditor): Remove blank identifiers

### DIFF
--- a/src/client/entity-editor/identifier-editor/actions.js
+++ b/src/client/entity-editor/identifier-editor/actions.js
@@ -23,6 +23,7 @@ export const REMOVE_IDENTIFIER_ROW = 'REMOVE_IDENTIFIER_ROW';
 export const UPDATE_IDENTIFIER_TYPE = 'UPDATE_IDENTIFIER_TYPE';
 export const UPDATE_IDENTIFIER_VALUE = 'UPDATE_IDENTIFIER_VALUE';
 export const HIDE_IDENTIFIER_EDITOR = 'HIDE_IDENTIFIER_EDITOR';
+export const REMOVE_EMPTY_IDENTIFIERS = 'REMOVE_EMPTY_IDENTIFIERS';
 
 export type Action = {
 	type: string,
@@ -122,5 +123,16 @@ export function updateIdentifierType(rowId: number, value: number): Action {
 			value
 		},
 		type: UPDATE_IDENTIFIER_TYPE
+	};
+}
+
+/**
+ * Produces an action indicating that the empty rows should be deleted.
+ *
+ * @returns {Action} The resulting REMOVE_EMPTY_IDENTIFIERS action.
+ */
+export function removeEmptyIdentifiers(): Action {
+	return {
+		type: REMOVE_EMPTY_IDENTIFIERS
 	};
 }

--- a/src/client/entity-editor/identifier-editor/identifier-editor.js
+++ b/src/client/entity-editor/identifier-editor/identifier-editor.js
@@ -17,7 +17,7 @@
  */
 
 import {Button, Col, Modal, Row} from 'react-bootstrap';
-import {addIdentifierRow, hideIdentifierEditor} from './actions';
+import {removeEmptyIdentifiers, addIdentifierRow, hideIdentifierEditor} from './actions';
 
 import Icon from 'react-fontawesome';
 import IdentifierRow from './identifier-row';
@@ -27,7 +27,8 @@ import ReactTooltip from 'react-tooltip';
 import classNames from 'classnames';
 import {connect} from 'react-redux';
 
-/**
+
+/**.
  * Container component. The IdentifierEditor component contains a number of
  * IdentifierRow elements, and renders these inside a modal, which appears when
  * the show property of the component is set.
@@ -121,7 +122,10 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
 	return {
 		onAddIdentifier: () => dispatch(addIdentifierRow()),
-		onClose: () => dispatch(hideIdentifierEditor())
+		onClose: () => {
+			dispatch(hideIdentifierEditor());
+			dispatch(removeEmptyIdentifiers())
+		}
 	};
 }
 

--- a/src/client/entity-editor/identifier-editor/reducer.js
+++ b/src/client/entity-editor/identifier-editor/reducer.js
@@ -18,7 +18,7 @@
 
 import {
 	ADD_IDENTIFIER_ROW, REMOVE_IDENTIFIER_ROW, UPDATE_IDENTIFIER_TYPE,
-	UPDATE_IDENTIFIER_VALUE
+	UPDATE_IDENTIFIER_VALUE, REMOVE_EMPTY_IDENTIFIERS
 } from './actions';
 import Immutable from 'immutable';
 
@@ -53,7 +53,10 @@ function reducer(
 			return state.setIn([payload.rowId, 'type'], payload.value);
 		case REMOVE_IDENTIFIER_ROW:
 			return state.delete(payload);
-
+		case REMOVE_EMPTY_IDENTIFIERS:
+			return state.filterNot(identifier => (
+				identifier.get('value') === "" || identifier.get('type') === null)
+			);
 		// no default
 	}
 	return state;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Ticket [BB-276](https://tickets.metabrainz.org/browse/BB-276):

> On creating or editing an entity, if I click "Add identifier" three times in the identifier editor popup, but only fill one, I still get "Edit 3 identifiers" on the link after closing the popup.
> It should realize there's only 1, and probably get rid of the empty identifier rows when I close the popup in the first place.


### Solution
<!-- What does this PR do to fix the problem? -->
Creates a new action ("REMOVE_EMPTY_IDENTIFIERS"), which removes all Identifiers without a value/type, and removes them when the Identifiers editor window is closed.


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Only [src/client/entity-editor/identifier-editor](https://github.com/Ge0rg3/bookbrainz-site/tree/master/src/client/entity-editor/identifier-editor), which relates to [this](http://46.101.26.141:9099/edition/create) area of Bookbrainz.
