### PR TITLE
BB-271 - feat(button-bar): Preload the first (empty) identifier

### DIFF
--- a/src/client/entity-editor/button-bar/button-bar.js
+++ b/src/client/entity-editor/button-bar/button-bar.js
@@ -28,6 +28,7 @@ import AliasButton from './alias-button';
 import IdentifierButton from './identifier-button';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {addIdentifierRow} from '../identifier-editor/actions';
 import {connect} from 'react-redux';
 
 /**
@@ -125,7 +126,10 @@ function mapDispatchToProps(dispatch) {
 	return {
 		onAliasButtonClick: () => dispatch(showAliasEditor()),
 		onDisambiguationButtonClick: () => dispatch(showDisambiguation()),
-		onIdentifierButtonClick: () => dispatch(showIdentifierEditor())
+		onIdentifierButtonClick: () => {
+			dispatch(showIdentifierEditor());
+			dispatch(addIdentifierRow());
+		}
 	};
 }
 

--- a/src/client/entity-editor/identifier-editor/value-field.js
+++ b/src/client/entity-editor/identifier-editor/value-field.js
@@ -45,7 +45,7 @@ function ValueField({
 	);
 
 	return (
-		<CustomInput label={label} type="text" {...rest}/>
+		<CustomInput autoFocus label={label} type="text" {...rest}/>
 	);
 }
 ValueField.displayName = 'ValueField';


### PR DESCRIPTION
Adds an empty identifier row whenever the Identifier Editor is opened.

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Ticket [BB-271](https://tickets.metabrainz.org/browse/BB-271):

> If I click "Add identifiers" when editing an entity, "This entity has no identifiers" gives me nothing of use and just wastes my time by making me click Add identifier. Just give me an empty, ready to fill set of identifier fields - I can figure out that if there's nothing else there, there are no identifiers currently. At most, show both "This entity has no identifiers" and empty fields to change that.

### Solution
<!-- What does this PR do to fix the problem? -->
Calls the addIdentifierRow action whenever the identifier button is pressed (the onIdentifierButtonClick function is called).


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Only the file responsible for the buttons in the aliases/identifiers/disambiguations ([here](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/entity-editor/button-bar/button-bar.js)).