### PR TITLE
BB-272 - feat(RelationshipEditor): Submit on enter

### DIFF
--- a/src/client/entity-editor/identifier-editor/value-field.js
+++ b/src/client/entity-editor/identifier-editor/value-field.js
@@ -45,7 +45,7 @@ function ValueField({
 	);
 
 	return (
-		<CustomInput label={label} type="text" {...rest}/>
+		<CustomInput autoFocus label={label} type="text" {...rest}/>
 	);
 }
 ValueField.displayName = 'ValueField';

--- a/src/client/entity-editor/identifier-editor/value-field.js
+++ b/src/client/entity-editor/identifier-editor/value-field.js
@@ -45,7 +45,7 @@ function ValueField({
 	);
 
 	return (
-		<CustomInput autoFocus label={label} type="text" {...rest}/>
+		<CustomInput label={label} type="text" {...rest}/>
 	);
 }
 ValueField.displayName = 'ValueField';

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -208,11 +208,14 @@ class RelationshipModal
 	};
 
 	handleKeyPress = (event) => {
-		if (event.key === 'Enter') {
-			event.preventDefault();
-			this.handleAdd();
+		if (event.keyCode === 13) {
+			if (this.calculateProgressAmount() === 100) {
+				event.preventDefault();
+				this.handleAdd();
+			}
 		}
 	};
+
 
 	calculateProgressAmount() {
 		if (!this.state.targetEntity) {
@@ -285,7 +288,7 @@ class RelationshipModal
 		const submitDisabled = this.calculateProgressAmount() < 100;
 
 		return (
-			<Modal show bsSize="large" onHide={onClose}>
+			<Modal show bsSize="large" onHide={onClose} onKeyUp={this.handleKeyPress}>
 				<Modal.Header>
 					<Modal.Title>Add a relationship</Modal.Title>
 				</Modal.Header>
@@ -307,7 +310,7 @@ class RelationshipModal
 								<div>
 									{this.renderEntitySelect()}
 								</div>
-								<div onKeyUp={this.handleKeyPress}>
+								<div>
 									{this.renderRelationshipSelect()}
 								</div>
 							</form>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -207,6 +207,13 @@ class RelationshipModal
 		}
 	};
 
+	handleKeyPress = (event) => {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			this.handleAdd();
+		}
+	};
+
 	calculateProgressAmount() {
 		if (!this.state.targetEntity) {
 			return 1;
@@ -300,7 +307,7 @@ class RelationshipModal
 								<div>
 									{this.renderEntitySelect()}
 								</div>
-								<div>
+								<div onKeyUp={this.handleKeyPress}>
 									{this.renderRelationshipSelect()}
 								</div>
 							</form>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -216,7 +216,6 @@ class RelationshipModal
 		}
 	};
 
-
 	calculateProgressAmount() {
 		if (!this.state.targetEntity) {
 			return 1;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
As desribed on [BB-272](https://tickets.metabrainz.org/browse/BB-272): 

> Once I've selected both an entity and a relationship type, letting me submit the form by just pressing Enter while on either of the fields would be a big time saver. After all, it's trivial to just edit / undo if I messed it up.

### Solution
<!-- What does this PR do to fix the problem? -->
This creates a handle for keypresses, that calls the handleAdd handle whenever the "enter" key is pressed.
**Change from ticket criteria:**
While the ticket says that the enter key should submit the data anywhere in the form, I've made it only submit when on the second input box. This is because when selecting a user in the first input box, the enter key can be used to make your selection, which would thus close the Editor before the user has a chance to enter anything in the second input box.  
This can be easily, as we would just have to move the onKeyUp tag to the start of the Modal dialogue.  
**Why use onKeyUp:**
While most online resources use onKeyPress, onKeyUp is the most effective here because since the user is already in an input box, the keypresses do not get passed to that event listener. A common React workaround to this is to use onInputKeyDown, but this makes the code far less readable imo.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Only [src/client/entity-editor/relationship-editor/relationship-editor.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/entity-editor/identifier-editor/value-field.js) (the Relationship editor dialogue).