### PR TITLE
test: Fixes failing travis tests for Node v10+

### DIFF
--- a/test/test-achievement.js
+++ b/test/test-achievement.js
@@ -17,6 +17,7 @@
  */
 
 import * as testData from '../data/test-data.js';
+
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import orm from './bookbrainz-data';
@@ -33,7 +34,6 @@ import testRevisionist from './test-revisionist.js';
 import testSprinter from './test-sprinter.js';
 import testTimeTraveller from './test-time-traveller.js';
 import testWorkerBee from './test-worker-bee.js';
-
 
 chai.use(chaiAsPromised);
 const {expect} = chai;
@@ -70,14 +70,16 @@ function tests() {
 		});
 
 		// suppress warnings from rejections
-		Achievement.__set__('console', {
-			error() {
-				// empty
-			},
-			warn() {
-				// empty
-			}
-		});
+		// Somehow modifies the global console object in Nove v10+ and causes a failure in Mocha
+
+		// Achievement.__set__('console', {
+		// 	error() {
+		// 		// empty
+		// 	},
+		// 	warn() {
+		// 		// empty
+		// 	}
+		// });
 
 		it('should reject invalid editors', () => {
 			const unlockPromise = testData.createRevisionist()


### PR DESCRIPTION
After Node LTS version was updated to 10.13 on October 30th 2018, travis builds started failing for lts configuration.
It was due to an error in rewire or babel when using Node >= v10.0. It appears the code commented out with this PR was replacing the global console object, making mocha crash when calling `console.log`.