### PR TITLE
Display Entity Aliases

### DIFF
--- a/src/client/components/pages/entities/title.js
+++ b/src/client/components/pages/entities/title.js
@@ -23,12 +23,12 @@ import React from 'react';
 
 
 const {
-	getEntityAliases, getEntityDisambiguation, getEntityLabel
+	getEntitySecondaryAliases, getEntityDisambiguation, getEntityLabel
 } = entityHelper;
 
 
 function EntityTitle({entity}) {
-	const aliases = getEntityAliases(entity);
+	const aliases = getEntitySecondaryAliases(entity);
 	const disambiguation = getEntityDisambiguation(entity);
 	const label = getEntityLabel(entity);
 	return (

--- a/src/client/components/pages/entities/title.js
+++ b/src/client/components/pages/entities/title.js
@@ -29,12 +29,12 @@ const {
 
 function EntityTitle({entity}) {
 	const aliases = getEntityAlias(entity);
-	const disambiguation = getEntityDisambiguation(entity);	
+	const disambiguation = getEntityDisambiguation(entity);
 	const label = getEntityLabel(entity);
 	return (
 		<div>
 			<h1>{label}{disambiguation}</h1>
-				{aliases}
+			{aliases}
 			<hr/>
 		</div>
 	);

--- a/src/client/components/pages/entities/title.js
+++ b/src/client/components/pages/entities/title.js
@@ -23,12 +23,12 @@ import React from 'react';
 
 
 const {
-	getEntityAlias, getEntityDisambiguation, getEntityLabel
+	getEntityAliases, getEntityDisambiguation, getEntityLabel
 } = entityHelper;
 
 
 function EntityTitle({entity}) {
-	const aliases = getEntityAlias(entity);
+	const aliases = getEntityAliases(entity);
 	const disambiguation = getEntityDisambiguation(entity);
 	const label = getEntityLabel(entity);
 	return (

--- a/src/client/components/pages/entities/title.js
+++ b/src/client/components/pages/entities/title.js
@@ -23,16 +23,18 @@ import React from 'react';
 
 
 const {
-	getEntityDisambiguation, getEntityLabel
+	getEntityAlias, getEntityDisambiguation, getEntityLabel
 } = entityHelper;
 
 
 function EntityTitle({entity}) {
+	const aliases = getEntityAlias(entity);
+	const disambiguation = getEntityDisambiguation(entity);	
 	const label = getEntityLabel(entity);
-	const disambiguation = getEntityDisambiguation(entity);
 	return (
 		<div>
 			<h1>{label}{disambiguation}</h1>
+				{aliases}
 			<hr/>
 		</div>
 	);

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -168,7 +168,7 @@ export function getEntityDisambiguation(entity) {
 	return null;
 }
 
-export function getEntityAliases(entity) {
+export function getEntitySecondaryAliases(entity) {
 	const aliases = entity.aliasSet.aliases
 		.filter(item => item.id !== entity.defaultAlias.id)
 		.map(item => item.name)

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -170,14 +170,14 @@ export function getEntityDisambiguation(entity) {
 
 export function getEntityAlias(entity) {
 	const aliases = entity.aliasSet.aliases
-									.map(item => item.name)
-									.filter(item => item !== entity.defaultAlias.name)
-									.join(', ');
+		.map(item => item.name)
+		.filter(item => item !== entity.defaultAlias.name)
+		.join(', ');
 	if (entity.aliasSet.aliases.length > 1) {
 		return <h5>{aliases}</h5>;
-	} else {
-		return null;
 	}
+	
+	return null;
 }
 
 export function getEntityUrl(entity) {

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -168,6 +168,18 @@ export function getEntityDisambiguation(entity) {
 	return null;
 }
 
+export function getEntityAlias(entity) {
+	const aliases = entity.aliasSet.aliases
+									.map(item => item.name)
+									.filter(item => item !== entity.defaultAlias.name)
+									.join(', ');
+	if (entity.aliasSet.aliases.length > 1) {
+		return <h5>{aliases}</h5>;
+	} else {
+		return null;
+	}
+}
+
 export function getEntityUrl(entity) {
 	const entityType = entity.type.toLowerCase();
 	const entityId = entity.bbid;

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -176,7 +176,7 @@ export function getEntityAlias(entity) {
 	if (entity.aliasSet.aliases.length > 1) {
 		return <h5>{aliases}</h5>;
 	}
-	
+
 	return null;
 }
 

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -168,13 +168,13 @@ export function getEntityDisambiguation(entity) {
 	return null;
 }
 
-export function getEntityAlias(entity) {
+export function getEntityAliases(entity) {
 	const aliases = entity.aliasSet.aliases
+		.filter(item => item.id !== entity.defaultAlias.id)
 		.map(item => item.name)
-		.filter(item => item !== entity.defaultAlias.name)
 		.join(', ');
 	if (entity.aliasSet.aliases.length > 1) {
-		return <h5>{aliases}</h5>;
+		return <h4>{aliases}</h4>;
 	}
 
 	return null;


### PR DESCRIPTION
### Problem

> Currently in BookBrainz, entity aliases do not appear on an entity display page. Take for example the display page for [Lemony Snicket](https://bookbrainz.org/creator/cb5a7089-b36c-463e-9380-331ce94c2873) and compare it to the [edit page](https://bookbrainz.org/creator/cb5a7089-b36c-463e-9380-331ce94c2873/edit) for the same entity, and click on "edit 1 alias". You will see that the entity has 1 alias (Daniel Handler), that is not shown on the display page but visible when editing.

*-from the GCI task page.*

### Solution
Adds a helper function which returns the aliases.
This is then printed under the title (as `h5` is a block), if there actually are aliases.  
#### Before:
![image](https://user-images.githubusercontent.com/16269580/48100544-a846b280-e21b-11e8-84ea-96b0e6f04a1b.png)
#### After:
![image](https://user-images.githubusercontent.com/16269580/48100561-b8f72880-e21b-11e8-9a4b-86484a71db70.png)


### Areas of Impact
The [title page](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/components/pages/entities/title.js), and the [entity helper](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/helpers/entity).