### PR TITLE
Improve Alias Editor

### DIFF
--- a/src/client/entity-editor/alias-editor/actions.js
+++ b/src/client/entity-editor/alias-editor/actions.js
@@ -25,6 +25,7 @@ export const UPDATE_ALIAS_LANGUAGE = 'UPDATE_ALIAS_LANGUAGE';
 export const UPDATE_ALIAS_PRIMARY = 'UPDATE_ALIAS_PRIMARY';
 export const REMOVE_ALIAS_ROW = 'REMOVE_ALIAS_ROW';
 export const HIDE_ALIAS_EDITOR = 'HIDE_ALIAS_EDITOR';
+export const REMOVE_EMPTY_ALIASES = 'REMOVE_EMPTY_ALIASES';
 
 export type Action = {
 	type: string,
@@ -159,5 +160,16 @@ export function removeAliasRow(rowId: number): Action {
 export function hideAliasEditor(): Action {
 	return {
 		type: HIDE_ALIAS_EDITOR
+	};
+}
+
+/**
+ * Produces an action indicating that the empty rows should be deleted.
+ *
+ * @returns {Action} The resulting REMOVE_EMPTY_ALIASES action.
+ */
+export function removeEmptyAliases(): Action {
+	return {
+		type: REMOVE_EMPTY_ALIASES
 	};
 }

--- a/src/client/entity-editor/alias-editor/alias-editor.js
+++ b/src/client/entity-editor/alias-editor/alias-editor.js
@@ -17,7 +17,7 @@
  */
 
 import {Button, Col, Modal, Row} from 'react-bootstrap';
-import {addAliasRow, hideAliasEditor} from './actions';
+import {addAliasRow, hideAliasEditor, removeEmptyAliases} from './actions';
 
 import AliasRow from './alias-row';
 import Icon from 'react-fontawesome';
@@ -119,7 +119,10 @@ AliasEditor.defaultProps = {
 function mapDispatchToProps(dispatch) {
 	return {
 		onAddAlias: () => dispatch(addAliasRow()),
-		onClose: () => dispatch(hideAliasEditor())
+		onClose: () => {
+			dispatch(hideAliasEditor());
+			dispatch(removeEmptyAliases());
+		}
 	};
 }
 

--- a/src/client/entity-editor/alias-editor/alias-row.js
+++ b/src/client/entity-editor/alias-editor/alias-row.js
@@ -77,6 +77,7 @@ const AliasRow = ({
 		<Row>
 			<Col md={4}>
 				<NameField
+					autoFocus
 					defaultValue={nameValue}
 					empty={
 						isAliasEmpty(nameValue, sortNameValue, languageValue)

--- a/src/client/entity-editor/alias-editor/reducer.js
+++ b/src/client/entity-editor/alias-editor/reducer.js
@@ -17,7 +17,7 @@
  */
 
 import {
-	ADD_ALIAS_ROW, REMOVE_ALIAS_ROW, UPDATE_ALIAS_LANGUAGE,
+	ADD_ALIAS_ROW, REMOVE_ALIAS_ROW, REMOVE_EMPTY_ALIASES, UPDATE_ALIAS_LANGUAGE,
 	UPDATE_ALIAS_NAME, UPDATE_ALIAS_PRIMARY, UPDATE_ALIAS_SORT_NAME
 } from './actions';
 import Immutable from 'immutable';
@@ -48,6 +48,10 @@ function reducer(
 			return state.setIn([payload.rowId, 'primary'], payload.value);
 		case REMOVE_ALIAS_ROW:
 			return state.delete(payload);
+		case REMOVE_EMPTY_ALIASES:
+			return state.filterNot(alias =>
+				alias.get('name') === '' && alias.get('language') === null && alias.get('sortName') === ""
+			);
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/button-bar/button-bar.js
+++ b/src/client/entity-editor/button-bar/button-bar.js
@@ -28,6 +28,7 @@ import AliasButton from './alias-button';
 import IdentifierButton from './identifier-button';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {addAliasRow} from '../alias-editor/actions';
 import {addIdentifierRow} from '../identifier-editor/actions';
 import {connect} from 'react-redux';
 
@@ -124,7 +125,10 @@ function mapStateToProps(rootState, {identifierTypes}) {
 
 function mapDispatchToProps(dispatch) {
 	return {
-		onAliasButtonClick: () => dispatch(showAliasEditor()),
+		onAliasButtonClick: () => {
+			dispatch(showAliasEditor());
+			dispatch(addAliasRow());
+		},
 		onDisambiguationButtonClick: () => dispatch(showDisambiguation()),
 		onIdentifierButtonClick: () => {
 			dispatch(showIdentifierEditor());


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Similar to the changes made in #212 and #213:

1. Automatically add a new row when the alias editor is opened.
2. Remove blank rows when the alias editor is closed.
3. Automatically focus on Name value box.

### Solution
<!-- What does this PR do to fix the problem? -->
1. Import and dispatch the addAliasRow action whenever the editor is opened.
2. Creates a REMOVE_EMPTY_ALIASES action--the aliases themselves are removed in the reducer.
3. Add "autoFocus" to the name input box.


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Most edits are in the [alias-editor folder](https://github.com/bookbrainz/bookbrainz-site/tree/master/src/client/entity-editor/alias-editor/), other than dispatching the addAliasRow action in the [button-bar](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/entity-editor/button-bar/button-bar.js).