### PR TITLE
Docker develop fix

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -5,6 +5,5 @@ if [[ ! -d "src" ]]; then
     exit -1
 fi
 
-docker-compose up -d elasticsearch postgres redis &&
-docker-compose run wait &&
+docker-compose run startup &&
 docker-compose up --build bookbrainz-site

--- a/develop.sh
+++ b/develop.sh
@@ -6,4 +6,5 @@ if [[ ! -d "src" ]]; then
 fi
 
 docker-compose up -d elasticsearch postgres redis &&
+docker-compose run wait &&
 docker-compose up --build bookbrainz-site

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
     container_name: elasticsearch
     restart: unless-stopped
     image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    environment:
+      # Skip bootstrap checks (see https://github.com/docker-library/elasticsearch/issues/98)
+      - transport.host=127.0.0.1
+      - discovery.zen.minimum_master_nodes=1
     ports:
       - "9200:9200"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,15 @@ services:
       - "6379:6379"
       - "3600:3600"
 
-  wait:
+  startup:
     image: waisbrot/wait
+    container_name: startup
     environment:
-      - TARGETS=elasticsearch:9200
+      - TARGETS=redis:6379,postgres:5432,elasticsearch:9200
+    depends_on:
+      - elasticsearch
+      - redis
+      - postgres
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,5 +42,10 @@ services:
       - "6379:6379"
       - "3600:3600"
 
+  wait:
+    image: waisbrot/wait
+    environment:
+      - TARGETS=elasticsearch:9200
+
 volumes:
   postgres-data:


### PR DESCRIPTION
### Problem
Some users were experiencing issues with ElasticSearch.
The two main issues were:
• ElasticSearch not starting due to low virtual machine memory on the host
• ES was not starting fast enough and the bookbrainz website could not set up correctly


### Solution
• Added environment variable configuration options in docker-compose file to disable ES bootstrap checks
• Added a container to wait for ES and other dependencies to be up before starting bookbrainz-site


### Areas of Impact
Docker-compose file and develop.sh
