### PR TITLE
Update last login time in database to fix issue #BB-311

### DIFF
--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -102,7 +102,7 @@ class EditorProfileTab extends React.Component {
 					<dd>0</dd>
 					<dt>Joined</dt>
 					<dd>{createdAtDate}</dd>
-					<dt>Last Active</dt>
+					<dt>Last login</dt>
 					<dd>{lastActiveDate}</dd>
 					<dt>Bio</dt>
 					<dd>{editor.bio ? editor.bio : '-'}</dd>

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -46,6 +46,13 @@ router.get('/cb', (req, res, next) => {
 				return next(loginErr);
 			}
 
+			const {Editor} = req.app.locals.orm;
+			const lastLoginDate = new Date().toISOString();
+			(() => {
+			  Editor
+			    .where({id: req.user.id})
+			    .save({activeAt: lastLoginDate}, {patch: true});
+			})();
 			const redirectTo =
 				req.session.redirectTo ? req.session.redirectTo : '/';
 			req.session.redirectTo = null;

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -41,18 +41,17 @@ router.get('/cb', (req, res, next) => {
 			return res.redirect('/register/details');
 		}
 
-		return req.logIn(user, (loginErr) => {
+		return req.logIn(user, async (loginErr) => {
 			if (loginErr) {
 				return next(loginErr);
 			}
 
 			const {Editor} = req.app.locals.orm;
+			//  lastLoginDate is current login date with time in ISO foramt
 			const lastLoginDate = new Date().toISOString();
-			(() => {
-			  Editor
-			    .where({id: req.user.id})
-			    .save({activeAt: lastLoginDate}, {patch: true});
-			})();
+			//  Query for update activeAt with current login timestamp
+			await Editor.where({id: req.user.id}).save({activeAt: lastLoginDate}, {patch: true});
+
 			const redirectTo =
 				req.session.redirectTo ? req.session.redirectTo : '/';
 			req.session.redirectTo = null;

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -50,7 +50,12 @@ router.get('/cb', (req, res, next) => {
 			//  lastLoginDate is current login date with time in ISO foramt
 			const lastLoginDate = new Date().toISOString();
 			//  Query for update activeAt with current login timestamp
-			await Editor.where({id: req.user.id}).save({activeAt: lastLoginDate}, {patch: true});
+			try {
+				await Editor.where({id: req.user.id}).save({activeAt: lastLoginDate}, {patch: true});
+			}
+			catch (error) {
+				return next(error);
+			}
 
 			const redirectTo =
 				req.session.redirectTo ? req.session.redirectTo : '/';


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
The timestamp is same for Joined and Last Active in user's detail.
![problem](https://user-images.githubusercontent.com/15086865/51304370-fe2aa880-1a5d-11e9-8b6d-a8ecef09bc51.png)



### Solution
<!-- What does this PR do to fix the problem? -->
The database is updated for last login time.
Update label Last Active to Last login same as MusicBrainz.
![solution](https://user-images.githubusercontent.com/15086865/51304537-77c29680-1a5e-11e9-88fd-337728f21cce.png)


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Client-side: `src/client/components/pages/parts/editor-profile.js`
Server-side: `src/server/routes/auth.js`
