### PR TITLE
feat(edition detail): add format and isbn in edition table to fix #BB-229

### DIFF
--- a/src/client/components/pages/entities/edition-table.js
+++ b/src/client/components/pages/entities/edition-table.js
@@ -25,7 +25,8 @@ import React from 'react';
 
 
 const {
-	getEditionReleaseDate, getEntityLabel, getEntityDisambiguation
+	getEditionReleaseDate, getEntityLabel, getEntityDisambiguation,
+	getISBNOfEdition, getEditionFormat
 } = entityHelper;
 const {Button, Table} = bootstrap;
 
@@ -33,12 +34,27 @@ function EditionTableRow({edition}) {
 	const name = getEntityLabel(edition);
 	const disambiguation = getEntityDisambiguation(edition);
 	const releaseDate = getEditionReleaseDate(edition);
+	const isbn = getISBNOfEdition(edition);
+	const editionFormat = getEditionFormat(edition);
 
 	return (
 		<tr>
 			<td>
 				<a href={`/edition/${edition.bbid}`}>{name}</a>
 				{disambiguation}
+			</td>
+			<td>{editionFormat}</td>
+			<td>
+				{
+					isbn ?
+						<a
+							href={`https://isbnsearch.org/isbn/${isbn.value}`}
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							{isbn.value}
+						</a> : '?'
+				}
 			</td>
 			<td>
 				{releaseDate}
@@ -59,6 +75,8 @@ function EditionTable({entity}) {
 				<thead>
 					<tr>
 						<th>Name</th>
+						<th>Format</th>
+						<th>ISBN</th>
 						<th>Release Date</th>
 					</tr>
 				</thead>

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -214,19 +214,14 @@ export function getSortNameOfDefaultAlias(entity) {
 export function getISBNOfEdition(entity) {
 	if (entity.identifierSetId) {
 		const {identifiers} = entity.identifierSet;
-		let isbn = null;
-		isbn = identifiers.find(identifier => identifier.type.label === 'ISBN-13');
-		if (!isbn) {
-			isbn = identifiers.find(identifier => identifier.type.label === 'ISBN-10');
-		}
-		return isbn;
+		return identifiers.find(
+			identifier =>
+				identifier.type.label === 'ISBN-13' || identifier.type.label === 'ISBN-10'
+		);
 	}
 	return null;
 }
 
 export function getEditionFormat(entity) {
-	if (entity.formatId) {
-		return entity.editionFormat.label;
-	}
-	return '?';
+	return (entity.editionFormat && entity.editionFormat.label) || '?';
 }

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -210,3 +210,23 @@ export function genEntityIconHTMLElement(entityType, size = '', margin = true) {
 export function getSortNameOfDefaultAlias(entity) {
 	return entity.defaultAlias.sortName;
 }
+
+export function getISBNOfEdition(entity) {
+	if (entity.identifierSetId) {
+		const {identifiers} = entity.identifierSet;
+		let isbn = null;
+		isbn = identifiers.find(identifier => identifier.type.label === 'ISBN-13');
+		if (!isbn) {
+			isbn = identifiers.find(identifier => identifier.type.label === 'ISBN-10');
+		}
+		return isbn;
+	}
+	return null;
+}
+
+export function getEditionFormat(entity) {
+	if (entity.formatId) {
+		return entity.editionFormat.label;
+	}
+	return '?';
+}

--- a/src/server/routes/entity/publication.js
+++ b/src/server/routes/entity/publication.js
@@ -43,7 +43,9 @@ router.param(
 			'publicationType',
 			'editions.defaultAlias',
 			'editions.disambiguation',
-			'editions.releaseEventSet.releaseEvents'
+			'editions.releaseEventSet.releaseEvents',
+			'editions.identifierSet.identifiers.type',
+			'editions.editionFormat'
 		],
 		'Publication not found'
 	)

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -57,7 +57,11 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 	// Fetch editions
 	const {Publisher} = req.app.locals.orm;
 	const editionRelationsToFetch = [
-		'defaultAlias', 'disambiguation', 'releaseEventSet.releaseEvents'
+		'defaultAlias',
+		'disambiguation',
+		'releaseEventSet.releaseEvents',
+		'identifierSet.identifiers.type',
+		'editionFormat'
 	];
 	const editionsPromise =
 		Publisher.forge({bbid: res.locals.entity.bbid})


### PR DESCRIPTION

In the edition group page and publisher page a table of edition was showing.
But in this table only edition name and release date was showing which not sufficient to distinguish between editions.
to solve above problem, add format of edition and isbn with his link by this commit.

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Less information in edition to distinguish bw them.

### Solution
<!-- What does this PR do to fix the problem? -->
Add isbn and format of an edition in the table.
Now  publisher page:  
![publisher](https://user-images.githubusercontent.com/15086865/51550930-6f6dbf80-1e93-11e9-9c4d-a722bc616a68.png)
Publication page:  
![publication](https://user-images.githubusercontent.com/15086865/51550947-74cb0a00-1e93-11e9-9c45-3d9555d5172b.png)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
**Client-side**  
`src/client/components/pages/entities/edition-table.js`
`src/client/helpers/entity.js`
**Server-side**  
`src/server/routes/entity/publication.js`
`src/server/routes/entity/publisher.js`

