### PR TITLE
fix(propType warnings): remove isRequired and set default props to fix propType warnings.

### DIFF
--- a/src/client/components/pages/entities/identifiers.js
+++ b/src/client/components/pages/entities/identifiers.js
@@ -56,8 +56,13 @@ function EntityIdentifiers({identifierSet, identifierTypes}) {
 
 EntityIdentifiers.displayName = 'EntityIdentifiers';
 EntityIdentifiers.propTypes = {
-	identifierSet: PropTypes.object.isRequired,
-	identifierTypes: PropTypes.array.isRequired
+	identifierSet: PropTypes.object,
+	identifierTypes: PropTypes.array
+};
+
+EntityIdentifiers.defaultProps = {
+	identifierSet: {},
+	identifierTypes: []
 };
 
 export default EntityIdentifiers;

--- a/src/client/components/pages/entities/image.js
+++ b/src/client/components/pages/entities/image.js
@@ -47,7 +47,10 @@ function EntityImage({backupIcon, imageUrl}) {
 EntityImage.displayName = 'EntityImage';
 EntityImage.propTypes = {
 	backupIcon: PropTypes.string.isRequired,
-	imageUrl: PropTypes.string.isRequired
+	imageUrl: PropTypes.string
 };
 
+EntityImage.defaultProps = {
+	imageUrl: ''
+};
 export default EntityImage;


### PR DESCRIPTION


<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
The warning occurs if propType marked as isRequire and value is null or undefined. 

### Solution
<!-- What does this PR do to fix the problem? -->
Remove isRequired from propTypes and set the default props.

