### PR TITLE
fix(client-side): reset state if uncheck the checkbox on publisher and creator page.

### DIFF
--- a/src/client/entity-editor/creator-section/reducer.js
+++ b/src/client/entity-editor/creator-section/reducer.js
@@ -52,7 +52,9 @@ function reducer(
 		case UPDATE_END_DATE:
 			return state.set('endDate', payload);
 		case UPDATE_ENDED:
-			return state.set('ended', payload);
+			return state.set('ended', payload)
+				.set('endArea', null)
+				.set('endDate', '');
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/publisher-section/reducer.js
+++ b/src/client/entity-editor/publisher-section/reducer.js
@@ -47,7 +47,8 @@ function reducer(
 		case UPDATE_END_DATE:
 			return state.set('endDate', payload);
 		case UPDATE_ENDED:
-			return state.set('ended', payload);
+			return state.set('ended', payload)
+				.set('endDate', '');
 		// no default
 	}
 	return state;


### PR DESCRIPTION


<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
On the creator page if we add an invalid date then uncheck the died checkbox, the value will be taken from that date. Same for publisher page.

### Solution
<!-- What does this PR do to fix the problem? -->
If uncheck the checkbox then the value also reset to empty.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
`src/client/entity-editor/creator-section/reducer.js`
`src/client/entity-editor/publisher-section/reducer.js`

