### PR TITLE
feat(contribution flow): add edition from work page and add work from edition page. Fix #BB-326 and #BB-328

### DIFF
--- a/src/client/components/pages/entities/edition.js
+++ b/src/client/components/pages/entities/edition.js
@@ -32,7 +32,7 @@ const {
 	extractAttribute, getEditionPublishers, getEditionReleaseDate, getEntityUrl,
 	getLanguageAttribute, ENTITY_TYPE_ICONS, getSortNameOfDefaultAlias
 } = entityHelper;
-const {Col, Row} = bootstrap;
+const {Button, Col, Row} = bootstrap;
 
 function EditionAttributes({edition}) {
 	const status = extractAttribute(edition.editionStatus, 'label');
@@ -118,6 +118,14 @@ function EditionDisplayPage({entity, identifierTypes}) {
 					</div>
 				</Col>
 			</Row>
+			<Button
+				bsStyle="success"
+				className="margin-top-d15"
+				href={`/work/create?${
+					entity.type.toLowerCase()}=${entity.bbid}`}
+			>
+				<Icon className="margin-right-0-5" name="plus"/>Add Work
+			</Button>
 			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}

--- a/src/client/components/pages/entities/work.js
+++ b/src/client/components/pages/entities/work.js
@@ -25,13 +25,14 @@ import EntityImage from './image';
 import EntityLinks from './links';
 import EntityRelationships from './relationships';
 import EntityTitle from './title';
+import Icon from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 
 const {getLanguageAttribute, getTypeAttribute, getEntityUrl,
 	ENTITY_TYPE_ICONS, getSortNameOfDefaultAlias} = entityHelper;
-const {Col, Row} = bootstrap;
+const {Button, Col, Row} = bootstrap;
 
 
 function WorkAttributes({work}) {
@@ -85,6 +86,14 @@ function WorkDisplayPage({entity, identifierTypes}) {
 					<WorkAttributes work={entity}/>
 				</Col>
 			</Row>
+			<Button
+				bsStyle="success"
+				className="margin-top-d15"
+				href={`/edition/create?${
+					entity.type.toLowerCase()}=${entity.bbid}`}
+			>
+				<Icon className="margin-right-0-5" name="plus"/>Add Edition
+			</Button>
 			<EntityLinks
 				entity={entity}
 				identifierTypes={identifierTypes}

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -216,8 +216,8 @@ export function addInitialRelationship(props, relationshipTypeId, relationshipIn
 		label: relationship.linkPhrase,
 		relationshipType: relationship,
 		rowID: rowId,
-		sourceEntity: targetEntity.type === 'Publication' ? sourceEntityDetail : targetEntityDetail,
-		targetEntity: targetEntity.type === 'Publication' ? targetEntityDetail : sourceEntityDetail
+		sourceEntity: targetEntity.type === 'Publication' || targetEntity.type === 'Work' ? sourceEntityDetail : targetEntityDetail,
+		targetEntity: targetEntity.type === 'Publication' || targetEntity.type === 'Work' ? targetEntityDetail : sourceEntityDetail
 	};
 
 	if (!props.initialState.relationshipSection) {

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -100,7 +100,7 @@ router.get(
 	middleware.loadLanguages, middleware.loadWorkTypes,
 	middleware.loadRelationshipTypes,
 	(req, res, next) => {
-		const {Creator} = req.app.locals.orm;
+		const {Creator, Edition} = req.app.locals.orm;
 		let relationshipTypeId;
 		let initialRelationshipIndex;
 		const propsPromise = generateEntityProps(
@@ -114,12 +114,26 @@ router.get(
 					.then((data) => entityToOption(data.toJSON()));
 		}
 
+		if (req.query.edition) {
+			propsPromise.edition =
+				Edition.forge({bbid: req.query.edition})
+					.fetch({withRelated: 'defaultAlias'})
+					.then((data) => entityToOption(data.toJSON()));
+		}
+
 		function render(props) {
 			if (props.creator) {
-				// add initial ralationship with relationshipTypeId = 8 (<Author> wrote <Work>)
+				// add initial ralationship with relationshipTypeId = 8 (<Work> is written by <Author>)
 				relationshipTypeId = 8;
 				initialRelationshipIndex = 0;
 				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex, props.creator);
+			}
+
+			if (props.edition) {
+				// add initial ralationship with relationshipTypeId = 10 (<Work> is contained in <Edition>)
+				relationshipTypeId = 10;
+				initialRelationshipIndex = 1;
+				addInitialRelationship(props, relationshipTypeId, initialRelationshipIndex, props.edition);
 			}
 
 			const editorMarkup = entityEditorMarkup(props);


### PR DESCRIPTION

1. Add a button called 'Add Edition' in work page to create edition from work page with a preloaded relationship.
2. Add a button called 'Add Work' in edition page to create work from edition page with a preloaded relationship.

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Implement feature explained in #BB-326 and #BB-328

### Solution
<!-- What does this PR do to fix the problem? -->
1. Add a button called 'Add Edition' in work page to create edition from work page with a preloaded relationship.
2. Add a button called 'Add Work' in edition page to create work from edition page with a preloaded relationship.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
**Client-side**  
`src/client/components/pages/entities/edition.js`
`src/client/components/pages/entities/work.js`

**Server-side**  
`src/server/helpers/entityRouteUtils.js`
`src/server/routes/entity/edition.js`
`src/server/routes/entity/work.js`
