### PR TITLE
fix(edition): Fix BB-325 Protect against missing edition properties (eg deleted entities)

### DIFF
--- a/src/client/components/pages/entities/edition.js
+++ b/src/client/components/pages/entities/edition.js
@@ -27,7 +27,6 @@ import Icon from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-
 const {
 	extractAttribute, getEditionPublishers, getEditionReleaseDate, getEntityUrl,
 	getLanguageAttribute, ENTITY_TYPE_ICONS, getSortNameOfDefaultAlias
@@ -110,12 +109,14 @@ function EditionDisplayPage({entity, identifierTypes}) {
 				<Col md={10}>
 					<EntityTitle entity={entity}/>
 					<EditionAttributes edition={entity}/>
+					{entity.publication &&
 					<div className="margin-bottom-d15">
 						<a href={`/publication/${entity.publication.bbid}`}>
 							<Icon name="external-link"/>
 							<span>&nbsp;See all similar editions</span>
 						</a>
 					</div>
+					}
 				</Col>
 			</Row>
 			<Button

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -23,7 +23,6 @@ import FontAwesome from 'react-fontawesome';
 import React from 'react';
 import _ from 'lodash';
 
-
 const {Button, Table} = bootstrap;
 
 export function extractAttribute(attr, path) {
@@ -208,7 +207,7 @@ export function genEntityIconHTMLElement(entityType, size = '', margin = true) {
 }
 
 export function getSortNameOfDefaultAlias(entity) {
-	return entity.defaultAlias.sortName;
+	return entity.defaultAlias ? entity.defaultAlias.sortName : '?';
 }
 
 export function getISBNOfEdition(entity) {


### PR DESCRIPTION
### Problem
Edition display page was breaking when loading an edition with deleted edition group or missing sort name 


### Solution
Protect against missing properties

