### PR TITLE
fix(deduplication): Don't initially run name deduplication on entity edit

### DIFF
--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -88,7 +88,7 @@ class NameSection extends React.Component {
 		When Component is first loaded, manually trigger "handleNameChange" mechanism.
 	*/
 	componentDidMount() {
-		if (!_.isNil(this.nameInputRef)) {
+		if (this.props.action !== 'edit' && !_.isNil(this.nameInputRef)) {
 			this.handleNameChange({target: {value: this.nameInputRef.value}});
 		}
 	}
@@ -241,6 +241,7 @@ class NameSection extends React.Component {
 }
 NameSection.displayName = 'NameSection';
 NameSection.propTypes = {
+	action: PropTypes.string,
 	disambiguationDefaultValue: PropTypes.string,
 	disambiguationVisible: PropTypes.bool.isRequired,
 	entityType: entityTypeProperty.isRequired, // eslint-disable-line react/no-typos, max-len
@@ -258,6 +259,7 @@ NameSection.propTypes = {
 	sortNameValue: PropTypes.string.isRequired
 };
 NameSection.defaultProps = {
+	action: 'create',
 	disambiguationDefaultValue: null,
 	exactMatches: null,
 	languageValue: null,

--- a/src/server/helpers/entityRouteUtils.js
+++ b/src/server/helpers/entityRouteUtils.js
@@ -24,6 +24,7 @@ import * as entityRoutes from '../routes/entity/entity';
 import * as error from './error';
 import * as propHelpers from '../../client/helpers/props';
 import * as utils from './utils';
+
 import EntityEditor from '../../client/entity-editor/entity-editor';
 import Layout from '../../client/containers/layout';
 import {Provider} from 'react-redux';
@@ -33,7 +34,6 @@ import _ from 'lodash';
 import {createStore} from 'redux';
 import express from 'express';
 import {generateProps} from './props';
-
 
 const {createRootReducer, getEntitySection, getValidator} = entityEditorHelpers;
 
@@ -60,7 +60,8 @@ export function generateEntityProps(
 	req: express.request, res: express.response,
 	additionalProps: Object,
 	initialStateCallback: (entity: ?Object) => Object =
-	(entity) => new Object()): Object {
+	(entity) => new Object()
+): Object {
 	const entityName = _.capitalize(entityType);
 	const {entity} = res.locals;
 	const isEdit = Boolean(entity);
@@ -76,7 +77,10 @@ export function generateEntityProps(
 		`/${entityType}/${entity.bbid}/edit/handler` :
 		`/${entityType}/create/handler`;
 
+	const action: EntityAction = isEdit ? 'edit' : 'create';
+
 	const props = Object.assign({
+		action,
 		entityType,
 		heading: isEdit ?
 			`Edit ${entityName}` :
@@ -103,7 +107,8 @@ export function generateEntityProps(
  */
 export function entityEditorMarkup(
 	props: { initialState: Object,
-			 entityType: string }) {
+			 entityType: string }
+) {
 	const {initialState, ...rest} = props;
 	const rootReducer = createRootReducer(props.entityType);
 	const store = createStore(rootReducer, Immutable.fromJS(initialState));


### PR DESCRIPTION
### Problem

Since addition of running deduplication on componentDidMount in the name section, deduplication warning appears when editing an existing entity, which is undesirable.

### Solution
Pass the action type ('create' or 'edit'), and if the action is 'edit', don't run deduplication in componenetDidMount


### Areas of Impact
NameSection component and the props passed to it
