### PR TITLE
Fix button layout and input margin on search page

### DIFF
--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -47,7 +47,7 @@ function SearchResults(props) {
 							<br/><small>Not sure what to do? Visit the <a href="/help">help page</a> to get started.</small>
 						</p>
 						<Col lg={6} lgOffset={3} md={8} mdOffset={2}>
-							<ButtonGroup justified>
+							<ButtonGroup justified id="searchpage-button-group">
 								<Button
 									className="padding-bottom-1 padding-sides-2 padding-top-1"
 									href="/creator/create"

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -35,7 +35,7 @@ The production configuration for webpack needs to be finalized before using this
 @import "~react-virtualized/styles.css";
 @import "~react-virtualized-select/styles.css";
  */
- 
+
 /* Modifications to Lobes */
 /* ====================== */
 @brand-secondary: @bookbrainz;
@@ -246,7 +246,7 @@ html {
 	border-radius: @input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
 	.transition(~"border-color ease-in-out .15s, box-shadow ease-in-out .15s");
 	.form-control-focus();
-	
+
 }
 
 .Select-placeholder {
@@ -325,11 +325,26 @@ hr.wide {
 		border: none;
 		border-radius: 0;
 	  }
-  
+
 	  > a:hover,
 	  > a:focus {
 		text-decoration: none;
 		background-color:@dropdown-link-hover-bg;
 	  }
 	}
+}
+
+@media only screen and (max-width: 600px) {
+	#searchpage-button-group {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	#searchpage-button-group .btn {
+		width: 90%;
+	}
+}
+
+.input-group {
+	padding:10px;
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->


### Problem
<!-- What are you trying to solve? -->
[BB-92](https://tickets.metabrainz.org/browse/BB-92?jql=project%20%3D%20BB%20AND%20resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(EMPTY)%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)

### Solution
<!-- What does this PR do to fix the problem? -->
Stack the buttons on the search page vertically when on mobile to prevent text from cutting off.  
Add some margin to the search input on mobile.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Search page