### PR TITLE
fix(core): BB-244 Error due to promise not being returned in server/helpers/middleware.js

### DIFF
--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -34,6 +34,7 @@ function makeLoader(modelName, propName, sortFunc) {
 					sortFunc ? resultsSerial.sort(sortFunc) : resultsSerial;
 
 				next();
+				return null;
 			})
 			.catch(next);
 	};

--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -123,6 +123,7 @@ export function loadEntityRelationships(req, res, next) {
 			});
 
 			next();
+			return null;
 		})
 		.catch(next);
 }
@@ -146,6 +147,7 @@ export function makeEntityLoader(modelName, additionalRels, errMessage) {
 				.then((entity) => {
 					res.locals.entity = entity;
 					next();
+					return null;
 				})
 				.catch(model.NotFoundError, () => {
 					throw new error.NotFoundError(errMessage, req);

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -72,7 +72,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 			res.locals.entity.editions = editions.toJSON();
 			_setPublisherTitle(res);
 			res.locals.entity.editions.sort(entityRoutes.compareEntitiesByDate);
-			entityRoutes.displayEntity(req, res);
+			return entityRoutes.displayEntity(req, res);
 		})
 		.catch(next);
 });


### PR DESCRIPTION
### Problem
Fixes issue [BB-224](https://tickets.metabrainz.org/browse/BB-244?jql=project%20%3D%20BB%20AND%20issuetype%20in%20(Bug%2C%20Improvement)%20AND%20labels%3Dgood-first-bug)
bluebird warning popping up on stdout when makeLoader middleware function located in src/server/helpers/middleware.js executes between route calls.


### Solution
Explicitly returned null which was returning undefined on next() yield.


### Areas of Impact
- bookbrainz-site/src/server/helpers/middleware.js
- bookbrainz-site/src/server/routes/entity/publisher.js