### PR TITLE
Use metabrainz node image which has runit and consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:10
+FROM metabrainz/node:10
 
 ARG BUILD_DEPS=" \
-    build-essential"
+    build-essential \
+    git \
+    python-dev \
+    libpq-dev"
 
 ARG RUN_DEPS=" \
     nodejs"


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
The docker image didn't have consul and other stuff such as runit needed to run this on hetzner.

### Solution
<!-- What does this PR do to fix the problem? -->
Create a new docker image for node (https://github.com/metabrainz/docker-node/blob/master/10/Dockerfile) and use it instead.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

Ideally, no behaviour should change, I haven't tested it very thoroughly though.