### PR TITLE
Fix issues after entity renaming

### DIFF
--- a/src/client/entity-editor/common/linked-entity.js
+++ b/src/client/entity-editor/common/linked-entity.js
@@ -22,6 +22,7 @@
 import FontAwesome from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {kebabCase as _kebabCase} from 'lodash';
 import {genEntityIconHTMLElement} from '../../helpers/entity';
 
 
@@ -46,7 +47,7 @@ class LinkedEntity extends React.Component {
 		if (type && id) {
 			url = type === 'Area' ?
 				`//musicbrainz.org/area/${id}` :
-				`/${type.toLowerCase()}/${id}`;
+				`/${_kebabCase(type)}/${id}`;
 		}
 		if (url) {
 			window.open(url, '_blank');

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -42,7 +42,6 @@ import ReactSelect from 'react-select';
 import Relationship from './relationship';
 import _ from 'lodash';
 
-
 function isValidRelationship(relationship: _Relationship) {
 	const {relationshipType, sourceEntity, targetEntity} = relationship;
 
@@ -258,7 +257,7 @@ class RelationshipModal
 				label={label}
 				languageOptions={this.props.languageOptions}
 				name="entity"
-				type={types.map(_.toLower)}
+				type={types}
 				value={this.state.targetEntity}
 				onChange={this.handleEntityChange}
 			/>

--- a/src/server/helpers/search.js
+++ b/src/server/helpers/search.js
@@ -175,7 +175,12 @@ export function autocomplete(orm, query, collection) {
 	};
 
 	if (collection) {
-		dslQuery.type = _.snakeCase(collection);
+		if (Array.isArray(collection)) {
+			dslQuery.type = collection.map(_.snakeCase);
+		}
+		else {
+			dslQuery.type = _.snakeCase(collection);
+		}
 	}
 
 	return _searchForEntities(orm, dslQuery);
@@ -410,7 +415,12 @@ export function searchByName(orm, name, collection, size, from) {
 	};
 
 	if (collection) {
-		dslQuery.type = _.snakeCase(collection);
+		if (Array.isArray(collection)) {
+			dslQuery.type = collection.map(_.snakeCase);
+		}
+		else {
+			dslQuery.type = _.snakeCase(collection);
+		}
 	}
 
 	return _searchForEntities(orm, dslQuery);

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -102,7 +102,7 @@ router.get('/autocomplete', (req, res) => {
 	const query = req.query.q;
 	const collection = req.query.collection || null;
 
-	const searchPromise = search.autocomplete(orm, query, _snakeCase(collection));
+	const searchPromise = search.autocomplete(orm, query, collection);
 
 	handler.sendPromiseResult(res, searchPromise);
 });


### PR DESCRIPTION
### Problem
Some lingering issues with entity names and case after merging PR #271.
Mainly ElasticSearch was broken when searching for multiple types (eg for relationship editor autocomplete) and the clickable link dropdown options from PR #261 