### PR TITLE
fix: Update bookbrainz-data ORM package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2058,9 +2058,9 @@
       }
     },
     "bookbrainz-data": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bookbrainz-data/-/bookbrainz-data-2.1.0.tgz",
-      "integrity": "sha512-U0xGqqqvX8U8Ocj1Bc/1JT3Xo+VWJ7iVmL4Wd7IJhTFR7t58q40GDEqZu0yQs/138gM43B8U5UfzTRMYHwJVQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bookbrainz-data/-/bookbrainz-data-2.1.1.tgz",
+      "integrity": "sha512-bCZUY13C9Vj0NratIFJN0O+MMq8/dtOVX009wms1SqrOFQnv8ofHduM1auX4JiAUt//joxb2UTxMkqGJkYYYdA==",
       "requires": {
         "bluebird": "^3.5.1",
         "bookshelf": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-runtime": "^6.23.0",
     "bluebird": "^3.5.1",
     "body-parser": "^1.14.1",
-    "bookbrainz-data": "^2.1.0",
+    "bookbrainz-data": "^2.1.1",
     "browserify": "^14.5.0",
     "classnames": "^2.2.5",
     "compression": "^1.7.1",


### PR DESCRIPTION
Patching issue with entity table name in bookbrainz-data-js ORM
Updating to version 2.1.1