### PR TITLE
Hide deprecated relationships in relationship editor

### DIFF
--- a/sql/migrations/2019-05-09/up.sql
+++ b/sql/migrations/2019-05-09/up.sql
@@ -1,0 +1,39 @@
+-- Replace deprecated relationships of type 3 ("Edition is an edition of EditionGroup")
+-- with edition_data.edition_group_bbid column
+-- and remove relationships from entity's current relationship set
+
+CREATE TEMPORARY TABLE IF NOT EXISTS rels_to_fix
+AS
+SELECT
+    relationship.id AS relationship_id,
+    relationship_set_id,
+    source_bbid,
+    target_bbid,
+    edition_group_bbid,
+    data_id
+FROM
+    bookbrainz.relationship
+    LEFT JOIN bookbrainz.edition ON bbid = source_bbid AND master = TRUE
+WHERE
+    type_id = 3
+    AND edition.bbid IS NOT NULL
+    AND edition.data_id IS NOT NULL
+;
+
+BEGIN TRANSACTION;
+
+    -- make sure edition_data has edition_group_bbid set
+    UPDATE bookbrainz.edition_data
+    SET edition_group_bbid = target_bbid
+    FROM rels_to_fix
+    WHERE edition_data.id = data_id
+        AND edition_data.edition_group_bbid IS NULL;
+
+    -- delete row that sets the obsolete relationship in that entity's current relationship set
+    DELETE FROM bookbrainz.relationship_set__relationship
+    USING rels_to_fix
+    WHERE relationship_set__relationship.relationship_id = rels_to_fix.relationship_id;
+
+    DROP TABLE IF EXISTS rels_to_fix;
+
+COMMIT TRANSACTION;

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -248,6 +248,9 @@ class RelationshipModal
 	renderEntitySelect() {
 		const {baseEntity, relationshipTypes} = this.props;
 		const types = getValidOtherEntityTypes(relationshipTypes, baseEntity);
+		if (!types.length) {
+			return null;
+		}
 		const typesForDisplay = types.map(_.startCase);
 		const lastType = _.last(typesForDisplay);
 		const otherTypes = _.join(typesForDisplay.slice(0, -1), ', ');
@@ -302,8 +305,31 @@ class RelationshipModal
 
 	render() {
 		const {onCancel, onClose, baseEntity} = this.props;
-
+		const baseEntityTypeForDisplay = _.startCase(baseEntity.type);
 		const submitDisabled = this.calculateProgressAmount() < 100;
+		const entitySelect = this.renderEntitySelect();
+
+		// If there are no possible relationships for this entity type,
+		// display a helpful message instead of empty selects
+		if (entitySelect === null) {
+			return (
+				<Modal show bsSize="large" onHide={onClose}>
+					<Modal.Header>
+						<Modal.Title>Add a relationship</Modal.Title>
+					</Modal.Header>
+					<Modal.Body>
+						<p>
+							<strong>
+								{baseEntityTypeForDisplay}s have no possible relationships with other entities at the moment.
+							</strong>
+						</p>
+					</Modal.Body>
+					<Modal.Footer>
+						<Button bsStyle="danger" onClick={onCancel}>Cancel</Button>
+					</Modal.Footer>
+				</Modal>
+			);
+		}
 
 		return (
 			<Modal show bsSize="large" onHide={onClose} onKeyUp={this.handleKeyPress}>
@@ -314,7 +340,7 @@ class RelationshipModal
 					<p>
 						<strong>
 							Use this form to add links between this{' '}
-							{baseEntity.type}
+							{baseEntityTypeForDisplay}
 							{' '}and other entities.
 						</strong>
 						{' '}For example, you can link an author
@@ -326,7 +352,7 @@ class RelationshipModal
 						<Col md={10} mdOffset={1}>
 							<form>
 								<div>
-									{this.renderEntitySelect()}
+									{entitySelect}
 								</div>
 								<div>
 									{this.renderRelationshipSelect()}

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -46,6 +46,7 @@ function isValidRelationship(relationship: _Relationship) {
 	const {relationshipType, sourceEntity, targetEntity} = relationship;
 
 	return (
+		relationshipType.deprecated !== false &&
 		(relationshipType.sourceEntityType === sourceEntity.type) &&
 		(relationshipType.targetEntityType === targetEntity.type)
 	);
@@ -86,6 +87,9 @@ function getValidOtherEntityTypes(
 	baseEntity: Entity
 ) {
 	const validEntityTypes = relationshipTypes.map((relationshipType) => {
+		if (relationshipType.deprecated === true) {
+			return null;
+		}
 		if (relationshipType.sourceEntityType === baseEntity.type) {
 			return relationshipType.targetEntityType;
 		}


### PR DESCRIPTION
Like it says on the tin !

A cleanup SQL script is needed to convert those Edition-Edition Group relationships to the Edition Group property of an Edition