### PR TITLE
Refactor deleted entity display

### DIFF
--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -22,11 +22,12 @@
 import * as bootstrap from 'react-bootstrap';
 import * as utilsHelper from '../../helpers/utils';
 
+import {genEntityIconHTMLElement, getEntityLabel} from '../../helpers/entity';
+
 import FontAwesome from 'react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {isNil as _isNil} from 'lodash';
-import {genEntityIconHTMLElement} from '../../helpers/entity';
 
 const {Alert, Button, Col, Grid, ListGroup, ListGroupItem, Row} = bootstrap;
 const {formatDate} = utilsHelper;
@@ -215,27 +216,23 @@ class IndexPage extends React.Component {
 							<Col md={12}>
 								<h2 className="text-center">Recent Activity</h2>
 								<ListGroup>
-									{recent.map((entity, index) => {
-										const name = entity.defaultAliasName || entity.parentAliasName || '(unnamed)';
-										const isDeleted = _isNil(entity.dataId);
-										return (
-											<ListGroupItem
-												href={`/revision/${entity.revisionId}`}
-												key={entity.revisionId}
-											>
-												<Row>
-													<Col md={2}>{`r${entity.revisionId}`}</Col>
-													<Col className={isDeleted ? 'text-muted deleted' : null} md={6}>
-														{genEntityIconHTMLElement(entity.type)}
-														<span className="margin-left-1">{name}</span>
-													</Col>
-													<Col md={4}>
-														{formatDate(new Date(entity.createdAt))}
-													</Col>
-												</Row>
-											</ListGroupItem>
-										);
-									})}
+									{recent.map((entity) => (
+										<ListGroupItem
+											href={`/revision/${entity.revisionId}`}
+											key={entity.revisionId}
+										>
+											<Row>
+												<Col md={2}>{`r${entity.revisionId}`}</Col>
+												<Col md={6}>
+													{genEntityIconHTMLElement(entity.type)}
+													{getEntityLabel(entity)}
+												</Col>
+												<Col md={4}>
+													{formatDate(new Date(entity.createdAt))}
+												</Col>
+											</Row>
+										</ListGroupItem>
+									))}
 								</ListGroup>
 							</Col>
 						</Row>

--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -216,21 +216,21 @@ class IndexPage extends React.Component {
 								<h2 className="text-center">Recent Activity</h2>
 								<ListGroup>
 									{recent.map((entity, index) => {
-										const name = entity.default_alias_name || entity.parent_default_alias_name || '(unnamed)';
-										const isDeleted = _isNil(entity.default_alias_name);
+										const name = entity.defaultAliasName || entity.parentAliasName || '(unnamed)';
+										const isDeleted = _isNil(entity.dataId);
 										return (
 											<ListGroupItem
-												href={`/revision/${entity.revision_id}`}
-												key={entity.revision_id}
+												href={`/revision/${entity.revisionId}`}
+												key={entity.revisionId}
 											>
 												<Row>
-													<Col md={2}>{`r${entity.revision_id}`}</Col>
+													<Col md={2}>{`r${entity.revisionId}`}</Col>
 													<Col className={isDeleted ? 'text-muted deleted' : null} md={6}>
 														{genEntityIconHTMLElement(entity.type)}
 														<span className="margin-left-1">{name}</span>
 													</Col>
 													<Col md={4}>
-														{formatDate(new Date(entity.created_at))}
+														{formatDate(new Date(entity.createdAt))}
 													</Col>
 												</Row>
 											</ListGroupItem>

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -125,15 +125,16 @@ export function getEntityLabel(entity) {
 		return `${entity.defaultAlias.name} `;
 	}
 
-	if (entity.parentAlias) {
-		return <span className="text-muted deleted" title={`Deleted ${entity.type}`}>{entity.parentAlias.name}</span>;
+	// Deleted entities
+	if (!entity.dataId) {
+		let deletedEntityName = `Deleted ${entity.type} ${entity.bbid}`;
+		if (entity.parentAlias) {
+			deletedEntityName = entity.parentAlias.name;
+		}
+		return <span className="text-muted deleted" title={`Deleted ${entity.type}`}>{deletedEntityName}</span>;
 	}
 
-	if (entity.type && entity.bbid) {
-		return `Deleted ${entity.type} ${entity.bbid}`;
-	}
-
-	return '(unnamed)';
+	return <span title={`Unnamed ${entity.type} ${entity.bbid}`}>(unnamed)</span>;
 }
 
 export function getEditionReleaseDate(edition) {


### PR DESCRIPTION
• Fix issues with deleted and unnamed entities' display name introduced in PR #280
• Improve code quality of index page recent entities and related SQL query
• Use getEntityLabel utility on index page to ensure displaying of deleted entities is defined only once