### PR TITLE
fix: fix BB-341 disable login and register links when redis is down

### DIFF
--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -166,7 +166,7 @@ class IndexPage extends React.Component {
 
 	renderContent() {
 		const {recent} = this.props;
-		const disableSignUp = this.props.disableSignUp ? {'disabled' : true} : {};
+		const disableSignUp = this.props.disableSignUp ? {disabled: true} : {};
 
 		return (
 			<Grid>
@@ -260,8 +260,11 @@ class IndexPage extends React.Component {
 
 IndexPage.displayName = 'IndexPage';
 IndexPage.propTypes = {
-	recent: PropTypes.array.isRequired,
-	disableSignUp: PropTypes.bool
+	disableSignUp: PropTypes.bool,
+	recent: PropTypes.array.isRequired
+};
+IndexPage.defaultProps = {
+	disableSignUp: false
 };
 
 export default IndexPage;

--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -166,6 +166,7 @@ class IndexPage extends React.Component {
 
 	renderContent() {
 		const {recent} = this.props;
+		const disableSignUp = this.props.disableSignUp ? {'disabled' : true} : {};
 
 		return (
 			<Grid>
@@ -205,7 +206,12 @@ class IndexPage extends React.Component {
 					</Col>
 				</Row>
 				<div className="text-center margin-top-1 margin-bottom-3">
-					<Button bsSize="large" bsStyle="success" href="/register">
+					<Button
+						{...disableSignUp}
+						bsSize="large"
+						bsStyle="success"
+						href="/register"
+					>
 						Register!
 					</Button>
 				</div>
@@ -254,7 +260,8 @@ class IndexPage extends React.Component {
 
 IndexPage.displayName = 'IndexPage';
 IndexPage.propTypes = {
-	recent: PropTypes.array.isRequired
+	recent: PropTypes.array.isRequired,
+	disableSignUp: PropTypes.bool
 };
 
 export default IndexPage;

--- a/src/client/containers/layout.js
+++ b/src/client/containers/layout.js
@@ -109,7 +109,7 @@ class Layout extends React.Component {
 			</span>
 		);
 
-		const disableSignUp = this.props.disableSignUp ? {'disabled' : true} : {};
+		const disableSignUp = this.props.disableSignUp ? {disabled: true} : {};
 
 		return (
 			<Navbar.Collapse id="bs-example-navbar-collapse-1">
@@ -280,15 +280,16 @@ Layout.displayName = 'Layout';
 Layout.propTypes = {
 	alerts: PropTypes.array.isRequired,
 	children: PropTypes.node.isRequired,
+	disableSignUp: PropTypes.bool,
 	hideSearch: PropTypes.bool,
 	homepage: PropTypes.bool,
 	repositoryUrl: PropTypes.string.isRequired,
 	requiresJS: PropTypes.bool,
 	siteRevision: PropTypes.string.isRequired,
-	user: PropTypes.object,
-	disableSignUp: PropTypes.bool
+	user: PropTypes.object
 };
 Layout.defaultProps = {
+	disableSignUp: false,
 	hideSearch: false,
 	homepage: false,
 	requiresJS: false,

--- a/src/client/containers/layout.js
+++ b/src/client/containers/layout.js
@@ -109,6 +109,8 @@ class Layout extends React.Component {
 			</span>
 		);
 
+		const disableSignUp = this.props.disableSignUp ? {'disabled' : true} : {};
+
 		return (
 			<Navbar.Collapse id="bs-example-navbar-collapse-1">
 				{user && user.id ?
@@ -154,7 +156,7 @@ class Layout extends React.Component {
 									name="info"
 								/>{' Profile'}
 							</MenuItem>
-							<MenuItem href="/logout">
+							<MenuItem {...disableSignUp} href="/logout">
 								<FontAwesome
 									fixedWidth
 									name="sign-out-alt"
@@ -163,7 +165,7 @@ class Layout extends React.Component {
 						</NavDropdown>
 					</Nav> :
 					<Nav pullRight>
-						<NavItem href="/auth">
+						<NavItem {...disableSignUp} href="/auth">
 							<FontAwesome name="sign-in-alt"/>{' Sign In / Register'}
 						</NavItem>
 					</Nav>
@@ -283,7 +285,8 @@ Layout.propTypes = {
 	repositoryUrl: PropTypes.string.isRequired,
 	requiresJS: PropTypes.bool,
 	siteRevision: PropTypes.string.isRequired,
-	user: PropTypes.object
+	user: PropTypes.object,
+	disableSignUp: PropTypes.bool
 };
 Layout.defaultProps = {
 	hideSearch: false,

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -39,9 +39,16 @@ The production configuration for webpack needs to be finalized before using this
 /* Modifications to Lobes */
 /* ====================== */
 @brand-secondary: @bookbrainz;
+@disabled-bg: lighten(desaturate(@bookbrainz,10%),42%);
+@disabled-color: lighten(@disabled-bg,15%);
+
 .navbar.BookBrainz {
 	background: rgba(255, 255, 255, 0.9);
 	margin-bottom: 0px;
+	.nav.navbar-nav > .disabled > a {
+		color: @disabled-color;
+		background: @disabled-bg;
+	}
 }
 
 .navbar-collapse {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -128,6 +128,7 @@ app.use((req, res, next) => {
 	res.locals.siteRevision = siteRevision;
 	res.locals.repositoryUrl = repositoryUrl;
 	res.locals.alerts = [];
+	req.signUpDisabled = false;
 
 	if (!req.session || !authInitiated) {
 		res.locals.alerts.push({
@@ -135,6 +136,7 @@ app.use((req, res, next) => {
 			message: `We are currently experiencing technical difficulties;
 				signing in and signing up are disabled until this is resolved.`
 		});
+		req.signUpDisabled = true;
 	}
 
 	// Add user data to every rendered route

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -132,8 +132,8 @@ app.use((req, res, next) => {
 	if (!req.session || !authInitiated) {
 		res.locals.alerts.push({
 			level: 'danger',
-			message: 'We are currently experiencing technical difficulties; ' +
-				'signing in will not work until this is resolved.'
+			message: `We are currently experiencing technical difficulties;
+				signing in and signing up are disabled until this is resolved.`
 		});
 	}
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -52,15 +52,25 @@ router.get('/', async (req, res, next) => {
 			requireJS: Boolean(res.locals.user)
 		});
 
+		const disableSignUp = props.alerts.some(
+			alert => alert.message.includes(
+				'signing in and signing up are disabled'
+			)
+		);
+
 		/*
 		 * Renders react components server side and injects markup into target
 		 * file object spread injects the app.locals variables into React as
 		 * props
 		 */
 		const markup = ReactDOMServer.renderToString(
-			<Layout {...propHelpers.extractLayoutProps(props)}>
+			<Layout
+				{...propHelpers.extractLayoutProps(props)}
+				disableSignUp={disableSignUp}
+			>
 				<Index
 					recent={props.recent}
+					disableSignUp={disableSignUp}
 				/>
 			</Layout>
 		);

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -52,12 +52,6 @@ router.get('/', async (req, res, next) => {
 			requireJS: Boolean(res.locals.user)
 		});
 
-		const disableSignUp = props.alerts.some(
-			alert => alert.message.includes(
-				'signing in and signing up are disabled'
-			)
-		);
-
 		/*
 		 * Renders react components server side and injects markup into target
 		 * file object spread injects the app.locals variables into React as
@@ -66,11 +60,11 @@ router.get('/', async (req, res, next) => {
 		const markup = ReactDOMServer.renderToString(
 			<Layout
 				{...propHelpers.extractLayoutProps(props)}
-				disableSignUp={disableSignUp}
+				disableSignUp={req.signUpDisabled}
 			>
 				<Index
+					disableSignUp={req.signUpDisabled}
 					recent={props.recent}
-					disableSignUp={disableSignUp}
 				/>
 			</Layout>
 		);


### PR DESCRIPTION
Adds support for disabling the login and register links (one in the top menu bar and one in the middle of the homepage) when a user can't login (Redis session missing).
