### PR TITLE
chore: Fix SEC-16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,9 +2736,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserify": {
@@ -4080,9 +4080,9 @@
       }
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -8845,15 +8845,15 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.3.tgz",
+      "integrity": "sha512-oi0ylWkmIR+IG8OcQkLGPMWhxu/Gfz9EBW7Mztr6FY4JbrPDDi5y9rb2ncNnajZtr2XHfBP+G5pzS6gEzdAcVQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
+        "browser-stdout": "1.3.1",
         "commander": "2.11.0",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
         "growl": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "less-loader": "^4.1.0",
     "lint-staged": "^6.0.0",
     "mini-css-extract-plugin": "^0.4.1",
-    "mocha": "^4.1.0",
+    "mocha": "^5.0.3",
     "nodemon": "^1.18.4",
     "nyc": "^14.1.1",
     "react-hot-loader": "^4.3.4",


### PR DESCRIPTION
Update Mocha for a sub-dependency security risk (diff package)
