### PR TITLE
add passing warnMessage from new-date-field

### DIFF
--- a/src/client/entity-editor/common/new-date-field.js
+++ b/src/client/entity-editor/common/new-date-field.js
@@ -115,11 +115,13 @@ class DateField extends React.Component {
 	};
 
 	render() {
+		const warnMessage = "Are you sure? You entered a date in the future!";
 		const labelElement = (
 			<ValidationLabel
 				empty={this.props.empty}
 				error={this.props.error}
 				errorMessage={this.props.errorMessage}
+				warnMessage={warnMessage}
 				warn={this.state.warn}
 			>
 				{this.props.label}

--- a/src/client/entity-editor/common/new-date-field.js
+++ b/src/client/entity-editor/common/new-date-field.js
@@ -115,14 +115,14 @@ class DateField extends React.Component {
 	};
 
 	render() {
-		const warnMessage = "Are you sure? You entered a date in the future!";
+		const warnMessage = 'Are you sure? You entered a date in the future!';
 		const labelElement = (
 			<ValidationLabel
 				empty={this.props.empty}
 				error={this.props.error}
 				errorMessage={this.props.errorMessage}
-				warnMessage={warnMessage}
 				warn={this.state.warn}
+				warnMessage={warnMessage}
 			>
 				{this.props.label}
 			</ValidationLabel>

--- a/src/client/entity-editor/common/validation-label.js
+++ b/src/client/entity-editor/common/validation-label.js
@@ -85,10 +85,11 @@ function ValidationLabel({
 	empty,
 	error,
 	errorMessage,
+	warnMessage,
 	warn
 }: Props) {
-	const warnElement = (warn && !empty && !error) &&
-		<span className={contextualColor(empty, error, warn)}> Are you sure? You entered a date in the future!</span>;
+	const warnElement = (warn && warnMessage && !empty && !error) &&
+		<span className={contextualColor(empty, error, warn)}> {warnMessage} </span>;
 	const errorElement = errorMessage &&
 		<span className={contextualColor(empty, error, warn)}> {errorMessage} </span>;
 	const iconElement = icon(empty, error, warn) &&

--- a/src/client/entity-editor/common/validation-label.js
+++ b/src/client/entity-editor/common/validation-label.js
@@ -63,6 +63,7 @@ type Props = {
 	empty?: boolean,
 	error?: boolean,
 	errorMessage?: '',
+	warnMessage?: '',
 	warn?: boolean,
 };
 
@@ -88,7 +89,7 @@ function ValidationLabel({
 	warnMessage,
 	warn
 }: Props) {
-	const warnElement = (warn && warnMessage && !empty && !error) &&
+	const warnElement = (warn && !empty && !error) &&
 		<span className={contextualColor(empty, error, warn)}> {warnMessage} </span>;
 	const errorElement = errorMessage &&
 		<span className={contextualColor(empty, error, warn)}> {errorMessage} </span>;
@@ -110,6 +111,7 @@ ValidationLabel.defaultProps = {
 	empty: false,
 	error: false,
 	errorMessage: '',
+	warnMessage: '',
 	warn: false
 };
 

--- a/src/client/entity-editor/common/validation-label.js
+++ b/src/client/entity-editor/common/validation-label.js
@@ -63,8 +63,8 @@ type Props = {
 	empty?: boolean,
 	error?: boolean,
 	errorMessage?: '',
-	warnMessage?: '',
 	warn?: boolean,
+	warnMessage?: ''
 };
 
 /**
@@ -86,8 +86,8 @@ function ValidationLabel({
 	empty,
 	error,
 	errorMessage,
-	warnMessage,
-	warn
+	warn,
+	warnMessage
 }: Props) {
 	const warnElement = (warn && !empty && !error) &&
 		<span className={contextualColor(empty, error, warn)}> {warnMessage} </span>;
@@ -111,8 +111,8 @@ ValidationLabel.defaultProps = {
 	empty: false,
 	error: false,
 	errorMessage: '',
-	warnMessage: '',
-	warn: false
+	warn: false,
+	warnMessage: ''
 };
 
 export default ValidationLabel;


### PR DESCRIPTION
### Problem
**Validation text for name (defaultAlias) shows the one for dates**
Issue [BB-354](https://tickets.metabrainz.org/browse/BB-354) 

### Solution
From **new-date-field**, passed `warnMessage` as a prop to **validation-label** 

### Areas of Impact
Changes in **new-date-field** and **validation-label** 