### PR TITLE
fix(display): Works with malformed identifier sets throw error.

### DIFF
--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -252,7 +252,7 @@ export function getSortNameOfDefaultAlias(entity) {
 }
 
 export function getISBNOfEdition(entity) {
-	if (entity.identifierSetId) {
+	if (entity.identifierSet && entity.identifierSet.identifiers) {
 		const {identifiers} = entity.identifierSet;
 		return identifiers.find(
 			identifier =>


### PR DESCRIPTION
### Problem
BB-352: Works with malformed identifiers set throw

### Solution
A check on the existence of entity.identifierSet.identifiers.

### Areas of Impact
src/client/helpers/entity.js
