### PR TITLE
fix(display): add 'Revision History not found' message

### DIFF
--- a/src/client/components/pages/parts/call-to-action.js
+++ b/src/client/components/pages/parts/call-to-action.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015  Ohm Patel
+ *               2016  Sean Burke
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as bootstrap from 'react-bootstrap';
+
+import React from 'react';
+import {genEntityIconHTMLElement} from '../../../helpers/entity';
+
+
+const {Button, ButtonGroup, Col} = bootstrap;
+
+function CallToAction() {
+	return (
+		<div className="text-center">
+			<p>
+				Help us and click on the right entity below to create a new entry.
+				<br/><small>Not sure what to do? Visit the <a href="/help">help page</a> to get started.</small>
+			</p>
+			<Col md={8} mdOffset={2}>
+				<ButtonGroup id="searchpage-button-group">
+					<Button
+						className="padding-bottom-1 padding-sides-2 padding-top-1"
+						href="/author/create"
+					>
+						{genEntityIconHTMLElement('Author', '3x', false)}
+						<div className="margin-top-d4">Author</div>
+					</Button>
+					<Button
+						className="padding-bottom-1 padding-sides-2 padding-top-1"
+						href="/work/create"
+					>
+						{genEntityIconHTMLElement('Work', '3x', false)}
+						<div className="margin-top-d4">Work</div>
+					</Button>
+					<Button
+						className="padding-bottom-1 padding-sides-2 padding-top-1"
+						href="/edition/create"
+					>
+						{genEntityIconHTMLElement('Edition', '3x', false)}
+						<div className="margin-top-d4">Edition</div>
+					</Button>
+					<Button
+						className="padding-bottom-1 padding-sides-2 padding-top-1"
+						href="/edition-group/create"
+					>
+						{genEntityIconHTMLElement('EditionGroup', '3x', false)}
+						<div className="margin-top-d4">Edition Group</div>
+					</Button>
+					<Button
+						className="padding-bottom-1 padding-sides-2 padding-top-1"
+						href="/publisher/create"
+					>
+						{genEntityIconHTMLElement('Publisher', '3x', false)}
+						<div className="margin-top-d4">Publisher</div>
+					</Button>
+				</ButtonGroup>
+			</Col>
+		</div>
+	);
+}
+
+CallToAction.displayName = 'CallToAction';
+export default CallToAction;

--- a/src/client/components/pages/parts/call-to-action.js
+++ b/src/client/components/pages/parts/call-to-action.js
@@ -25,6 +25,11 @@ import {genEntityIconHTMLElement} from '../../../helpers/entity';
 
 const {Button, ButtonGroup, Col} = bootstrap;
 
+/**
+ * Renders the document and displays 'CallToAction' component.
+ * @returns {ReactElement} a HTML document which displays
+ * the 'CallToAction' component.
+ */
 function CallToAction() {
 	return (
 		<div className="text-center">
@@ -76,4 +81,5 @@ function CallToAction() {
 }
 
 CallToAction.displayName = 'CallToAction';
+
 export default CallToAction;

--- a/src/client/components/pages/parts/editor-revisions.js
+++ b/src/client/components/pages/parts/editor-revisions.js
@@ -30,10 +30,24 @@ import React from 'react';
 const {ListGroup, ListGroupItem} = bootstrap;
 const {formatDate, isWithinDayFromNow} = utilsHelper;
 
+/**
+ * Renders the document and displays the 'EditorRevisionsTab' component.
+ * @returns {ReactElement} a HTML document which displays the 'EditorRevisionTab'.
+ * @param {object} props - Properties passed to the component.
+ */
 function EditorRevisionsTab(props) {
 	const {editor} = props;
 	const {revisions} = editor;
 
+	/**
+	 * Renders the data related to Revision such as 'author' and 'date'.
+	 * It also displays the revison note which is a summary of the changes
+	 * made in the revision.
+	 * @param {object} revision - The revision to be represented by the
+	 * rendered component.
+	 * @returns {ReactElement} a HTML document which is a part of the Revision
+	 * history.
+	 */
 	function renderRevision(revision) {
 		const createdDate = new Date(revision.createdAt);
 		const dateLabel =

--- a/src/client/components/pages/parts/editor-revisions.js
+++ b/src/client/components/pages/parts/editor-revisions.js
@@ -21,6 +21,8 @@
 
 import * as bootstrap from 'react-bootstrap';
 import * as utilsHelper from '../../../helpers/utils';
+
+import CallToAction from './call-to-action';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -32,34 +34,44 @@ function EditorRevisionsTab(props) {
 	const {editor} = props;
 	const {revisions} = editor;
 
+	function renderRevision(revision) {
+		const createdDate = new Date(revision.createdAt);
+		const dateLabel =
+			formatDate(createdDate,
+				isWithinDayFromNow(createdDate));
+		const header = (
+			<h4 className="list-group-item-heading">
+				<small className="pull-right">
+					{`${editor.name} - ${dateLabel}`}
+				</small>
+				{`r${revision.id}`}
+			</h4>
+		);
+
+		return (
+			<ListGroupItem
+				href={`/revision/${revision.id}`}
+				key={`${editor.id}${revision.id}`}
+			>
+				{header}
+				{revision.note}
+			</ListGroupItem>
+		);
+	}
+
 	return (
 		<div>
 			<h2>Revision History</h2>
-			<ListGroup>
-				{revisions.map((revision) => {
-					const createdDate = new Date(revision.createdAt);
-					const dateLabel =
-						formatDate(createdDate,
-							isWithinDayFromNow(createdDate));
-					const header = (
-						<h4 className="list-group-item-heading">
-							<small className="pull-right">
-								{`${editor.name} - ${dateLabel}`}
-							</small>
-							{`r${revision.id}`}
-						</h4>
-					);
-					return (
-						<ListGroupItem
-							href={`/revision/${revision.id}`}
-							key={`${editor.id}${revision.id}`}
-						>
-							{header}
-							{revision.note}
-						</ListGroupItem>
-					);
-				})}
-			</ListGroup>
+			{revisions.length > 0 ?
+				<ListGroup>
+					{revisions.map(renderRevision)}
+				</ListGroup> :
+				<div>
+					<h4> No revisions to show</h4>
+					<hr className="wide"/>
+					<CallToAction/>
+				</div>
+			}
 		</div>
 	);
 }

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -21,11 +21,13 @@ import * as bootstrap from 'react-bootstrap';
 
 import {differenceBy as _differenceBy, kebabCase as _kebabCase, startCase as _startCase} from 'lodash';
 
+import CallToAction from './call-to-action';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {genEntityIconHTMLElement} from '../../../helpers/entity';
 
-const {Button, ButtonGroup, Col, Row, Table} = bootstrap;
+
+const {Row, Table} = bootstrap;
 
 function SearchResults(props) {
 	const noResults = !props.results || props.results.length === 0;
@@ -42,49 +44,7 @@ function SearchResults(props) {
 						<small>Make sure the spelling is correct, and that you have selected the correct type in the search bar.</small>
 						<hr className="wide"/>
 						<h3>Are we missing an entry?</h3>
-						<p>
-							Help us and click on the right entity below to create a new entry.
-							<br/><small>Not sure what to do? Visit the <a href="/help">help page</a> to get started.</small>
-						</p>
-						<Col md={8} mdOffset={2}>
-							<ButtonGroup id="searchpage-button-group">
-								<Button
-									className="padding-bottom-1 padding-sides-2 padding-top-1"
-									href="/author/create"
-								>
-									{genEntityIconHTMLElement('Author', '3x', false)}
-									<div className="margin-top-d4">Author</div>
-								</Button>
-								<Button
-									className="padding-bottom-1 padding-sides-2 padding-top-1"
-									href="/work/create"
-								>
-									{genEntityIconHTMLElement('Work', '3x', false)}
-									<div className="margin-top-d4">Work</div>
-								</Button>
-								<Button
-									className="padding-bottom-1 padding-sides-2 padding-top-1"
-									href="/edition/create"
-								>
-									{genEntityIconHTMLElement('Edition', '3x', false)}
-									<div className="margin-top-d4">Edition</div>
-								</Button>
-								<Button
-									className="padding-bottom-1 padding-sides-2 padding-top-1"
-									href="/edition-group/create"
-								>
-									{genEntityIconHTMLElement('EditionGroup', '3x', false)}
-									<div className="margin-top-d4">Edition Group</div>
-								</Button>
-								<Button
-									className="padding-bottom-1 padding-sides-2 padding-top-1"
-									href="/publisher/create"
-								>
-									{genEntityIconHTMLElement('Publisher', '3x', false)}
-									<div className="margin-top-d4">Publisher</div>
-								</Button>
-							</ButtonGroup>
-						</Col>
+						<CallToAction/>
 					</Row>
 				}
 			</div>

--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -29,6 +29,12 @@ import {genEntityIconHTMLElement} from '../../../helpers/entity';
 
 const {Row, Table} = bootstrap;
 
+/**
+ * Renders the document and displays the 'SearchResults' page.
+ * @returns {ReactElement} a HTML document which displays the SearchResults.
+ * @param {object} props - Properties passed to the component.
+ */
+
 function SearchResults(props) {
 	const noResults = !props.results || props.results.length === 0;
 	if (noResults) {


### PR DESCRIPTION

### Problem
<!-- What are you trying to solve? -->
To show meaningful message when User Revision history is empty.

### Solution
<!-- What does this PR do to fix the problem? -->
Add 'Revision History not found' message if revision history is empty.
Also add "call to action".
### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
- src/client/components/pages/parts/call-to-action.js
- src/client/components/pages/parts/editor-revisions.js
- src/client/components/pages/parts/search-results.js