### PR TITLE
fix(core): Fixed the IndexOutOfBoundsException of SchemaSpy.sh

### DIFF
--- a/sql/scripts/SchemaSpy.sh
+++ b/sql/scripts/SchemaSpy.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-if [ $# -ne 4 ]; then
-  echo 'Usage: SchemaSpy.sh [username] [password] [database] [host]';
-fi
+throw_error () {
+  echo "Error, Please provide ${1}" >&2
+  exit 1
+}
 
 if [ ! -e "schemaSpy.jar" ]; then
   wget http://sourceforge.net/projects/schemaspy/files/latest/download?source=files -O schemaSpy.jar;
@@ -12,4 +13,42 @@ if [ ! -e "postgresql-9.4-1202.jdbc41.jar" ]; then
   wget https://jdbc.postgresql.org/download/postgresql-9.4-1202.jdbc41.jar;
 fi
 
-java -jar schemaSpy.jar -t pgsql -host $4 -s bookbrainz -db $3 -u $1 -p $2 -o _build -dp postgresql-9.4-1202.jdbc41.jar;
+while getopts "d:h:p:u:" opt; do
+  case $opt in
+    d)  DATABASE=$OPTARG;;
+    h)  HOST=$OPTARG;;
+    p)  PASSWORD=$OPTARG;;
+    u)  _USERNAME=$OPTARG;;
+    *) echo "Error Occurred, Usage: SchemaSpy.sh -u [username] -p [password] -d [database] -h [host]" >&2
+       exit 1
+  esac
+done
+
+CMD="java -jar schemaSpy.jar -t pgsql -s bookbrainz "
+
+if [ ! -z "$HOST" ]
+then
+  CMD+="-host ${HOST} "
+else
+  throw_error "host: -h [host]"
+fi
+
+if [ ! -z "$DATABASE" ]
+then
+  CMD+="-db ${DATABASE} "
+else
+  throw_error "database: -d [database]"
+fi
+
+if [ ! -z "$_USERNAME" ]
+then
+  CMD+="-u ${_USERNAME} "
+else
+  throw_error "username: -u [username]"
+fi
+
+CMD+="-p '${PASSWORD}' "
+CMD+="-o _build -dp postgresql-9.4-1202.jdbc41.jar;"
+
+echo $CMD
+eval $CMD


### PR DESCRIPTION
### Problem
#BB-359 The SchemaSpy.sh script doesn't work as expected. If an empty string is passed as one of the arguments from the terminal, the script fails with IndexOutOfBoundsException.

### Solution
All the args variables are surrounded by double quotes to accept empty string args properly

### Areas of Impact
sql/script/SchemaSpy.sh