### PR TITLE
refactor(achievement): refactor renderAchievements

### DIFF
--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -29,7 +29,15 @@ import request from 'superagent-bluebird-promise';
 const {Row} = bootstrap;
 const {Sticky, StickyContainer} = ReactSticky;
 
+/**
+ * Renders the document and displays the 'Editor Achievements Tab'.
+ */
 class EditorAchievementTab extends React.Component {
+	/**
+	 * Initializes the component state.
+	 * @constructor
+	 * @param {object} props - Properties passed to the component.
+	 */
 	constructor(props) {
 		super(props);
 		this.state = {
@@ -38,6 +46,11 @@ class EditorAchievementTab extends React.Component {
 		};
 	}
 
+	/**
+	 * Handles the 'Update Ranks' form submission, by making
+	 * a POST request with updated ranks to the server.
+	 * @param {object} event - The Form submit event.
+	 */
 	handleSubmit(event) {
 		event.preventDefault();
 
@@ -62,6 +75,12 @@ class EditorAchievementTab extends React.Component {
 			});
 	}
 
+	/**
+	 * Renders the Editor Achievements list. Also splits the
+	 * achievements into Unlocked and Locked achievements.
+	 * @returns {Array} - An array containing rendered achievements
+	 * list split into Unlocked and Locked.
+	 */
 	renderAchievements() {
 		const achievements = [];
 		const locked = [];
@@ -83,6 +102,12 @@ class EditorAchievementTab extends React.Component {
 		return [achievements, locked];
 	}
 
+	/**
+	 * Renders the EditorAchievements page, which displays all the achievements
+	 * (both unlocked and locked) of the editor, along with a RankUpdate form.
+	 * @returns {ReactElement} a HTML document which displays the
+	 * EditorAchievements page.
+	 */
 	render() {
 		const [achievements, locked] = this.renderAchievements();
 

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -62,25 +62,29 @@ class EditorAchievementTab extends React.Component {
 			});
 	}
 
-	renderAchievements(unlocked) {
-		return this.state.achievement.model.map((achievement) => {
-			let achievementHTML;
-			if (achievement.unlocked === unlocked) {
-				achievementHTML = (
-					<Achievement
-						achievement={achievement}
-						key={`${this.state.editor.id}${achievement.id}`}
-						unlocked={unlocked}
-					/>
-				);
+	renderAchievements() {
+		const achievements = [];
+		const locked = [];
+		this.state.achievement.model.forEach(achievement => {
+			const achievementHTML = (
+				<Achievement
+					achievement={achievement}
+					key={`${this.state.editor.id}${achievement.id}`}
+					unlocked={achievement.unlocked}
+				/>
+			);
+			if (achievement.unlocked) {
+				achievements.push(achievementHTML);
 			}
-			return achievementHTML;
+			else {
+				locked.push(achievementHTML);
+			}
 		});
+		return [achievements, locked];
 	}
 
 	render() {
-		const achievements = this.renderAchievements(true);
-		const locked = this.renderAchievements(false);
+		const [achievements, locked] = this.renderAchievements();
 
 		let rankUpdate;
 		if (this.state.editor.authenticated) {


### PR DESCRIPTION

### Problem
<!-- What are you trying to solve? -->
Rendering Editor Achievements iterates 2 times for splitting into locked & unlocked, which can be optimized

### Solution
<!-- What does this PR do to fix the problem? -->
Using single iteration to split achievements into unlocked & locked.
I have kept **Don't prematurely optimize**, **Use ES6/ES7 features** in mind and thought of below codes:

**Using Array.reduce():**
```
reducer(splitAchievements, achievement) {
	splitAchievements[achievement.unlocked ? 'achievements' : 'locked'].push(
		<Achievement
			achievement={achievement}
			key={`${this.state.editor.id}${achievement.id}`}
			unlocked={achievement.unlocked}
		/>
	);
	return splitAchievements;
}

renderAchievements() {
	return this.state.achievement.model.reduce(this.reducer, {achievements: [], locked: []});
}

render() {
	const {achievements, locked} = this.renderAchievements();
```

**Using Array.forEach():**
```
renderAchievements() {
	const achievements = [];
	const locked = [];
	this.state.achievement.model.forEach(achievement => {
		const achievementHTML = (
			<Achievement
				achievement={achievement}
				key={`${this.state.editor.id}${achievement.id}`}
				unlocked={achievement.unlocked}
			/>
		);
		if (achievement.unlocked) {
			achievements.push(achievementHTML);
		}
		else {
			locked.push(achievementHTML);
		}
	});
	return [achievements, locked];
}

render() {
	const [achievements, locked] = this.renderAchievements();

```

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/client/components/pages/parts/editor-achievements.js