### PR TITLE
fix(profile,achievement): fix accessing req.user.id when user not logged-in

### DIFF
--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -299,7 +299,7 @@ router.get('/:id/achievements', (req, res, next) => {
 		AchievementType, AchievementUnlock
 	} = req.app.locals.orm;
 	const userId = parseInt(req.params.id, 10);
-	const isOwner = userId === req.user.id;
+	const isOwner = userId === (req.user && req.user.id);
 
 	const editorJSONPromise = getIdEditorJSONPromise(userId, req)
 		  .catch(next);


### PR DESCRIPTION

### Problem
<!-- What are you trying to solve? -->
Visiting Editor Achievements page gives 500 error when user is not logged-in (commented [here](https://github.com/bookbrainz/bookbrainz-site/pull/315#issuecomment-550389833))
### Solution
<!-- What does this PR do to fix the problem? -->
Check if req.user is undefined, then access req.user.id
**Verified it works now.**
### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
- src/server/routes/editor.js