### PR TITLE
fix: Reassign alias language id safely

### DIFF
--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -105,10 +105,11 @@ router.get(
 );
 
 function authorToFormState(author) {
+	/** The front-end expects a language id rather than the language object. */
 	const aliases = author.aliasSet ?
 		author.aliasSet.aliases.map(({languageId, ...rest}) => ({
-			language: languageId,
-			...rest
+			...rest,
+			language: languageId
 		})) : [];
 
 	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(aliases);

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -33,6 +33,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 import target from '../../templates/target';
 
+
 const router = express.Router();
 
 /* If the route specifies a BBID, load the EditionGroup for it. */
@@ -114,10 +115,11 @@ function getDefaultAliasIndex(aliases) {
 }
 
 function editionGroupToFormState(editionGroup) {
+	/** The front-end expects a language id rather than the language object. */
 	const aliases = editionGroup.aliasSet ?
-		editionGroup.aliasSet.aliases.map(({language, ...rest}) => ({
-			language: language.id,
-			...rest
+		editionGroup.aliasSet.aliases.map(({languageId, ...rest}) => ({
+			...rest,
+			language: languageId
 		})) : [];
 
 	const defaultAliasIndex = getDefaultAliasIndex(aliases);

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -206,10 +206,11 @@ function getDefaultAliasIndex(aliases) {
 }
 
 function editionToFormState(edition) {
+	/** The front-end expects a language id rather than the language object. */
 	const aliases = edition.aliasSet ?
-		edition.aliasSet.aliases.map(({language, ...rest}) => ({
-			language: language.id,
-			...rest
+		edition.aliasSet.aliases.map(({languageId, ...rest}) => ({
+			...rest,
+			language: languageId
 		})) : [];
 
 	const defaultAliasIndex = getDefaultAliasIndex(aliases);

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -122,10 +122,11 @@ router.get(
 );
 
 function publisherToFormState(publisher) {
+	/** The front-end expects a language id rather than the language object. */
 	const aliases = publisher.aliasSet ?
-		publisher.aliasSet.aliases.map(({language, ...rest}) => ({
-			language: language.id,
-			...rest
+		publisher.aliasSet.aliases.map(({languageId, ...rest}) => ({
+			...rest,
+			language: languageId
 		})) : [];
 
 	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(aliases);

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -35,6 +35,7 @@ import {escapeProps} from '../../helpers/props';
 import express from 'express';
 import target from '../../templates/target';
 
+
 const router = express.Router();
 
 /* If the route specifies a BBID, load the Work for it. */
@@ -158,10 +159,11 @@ function getDefaultAliasIndex(aliases) {
 }
 
 function workToFormState(work) {
+	/** The front-end expects a language id rather than the language object. */
 	const aliases = work.aliasSet ?
-		work.aliasSet.aliases.map(({language, ...rest}) => ({
-			language: language.id,
-			...rest
+		work.aliasSet.aliases.map(({languageId, ...rest}) => ({
+			...rest,
+			language: languageId
 		})) : [];
 
 	const defaultAliasIndex = getDefaultAliasIndex(aliases);


### PR DESCRIPTION
Fix issue with language property being reassigned by object destructuring (introduced in PR #308 ).
Also refactor other entities to use the same protection (use languageID instead of language.id in case language is undefined)