### PR TITLE
feat(configuration): allow overwriting config file path | BB-366

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /src/client/stylesheets/react-select
 /reports
 /config/config.json
+/config/config.local.json
 
 # react-hot-loader files
 /static/**/*.hot-update.js

--- a/NODEJS_SETUP.md
+++ b/NODEJS_SETUP.md
@@ -20,11 +20,10 @@ This command will also compile the site LESS and JavaScript source files.
 
 ## Configuration
 
-Our `config.example.json` is set up to work out of the box running everything in Docker. Adresses for the dependencies refer to docker container names, so that containers can communicate with each other.
-You will need to modify the `config/config.json` file* to point to the dependencies from outside the Docker network.
-For example, set `session.redis.host`, `database.connection.host` and `search.search` to point to `localhost` (or wherever your dependencies are running) and adjust the ports accordingly.
+Our `config.example.json` is set up to work out of the box running everything in Docker. Addresses for the dependencies refer to docker container names, so that containers can communicate with each other.
 
-*If it doesn't exist, make a copy of `config.example.json` and rename it) 
+For local development (run outside of Docker), make a copy of `config/config.local.json.example` and [fill up the musicbrainz tokens](README.md#configuration). You can then pass this configuration file when running the server locally using `--config` flag.
+For example, `npm start -- --config ./config/config.local.json` will use `./config/config.local.json` config instead of the Default config (`config.json` for Docker).
 
 ## Building and running
 A number of subcommands exist to manage the installation and run the server.

--- a/config/config.local.json.example
+++ b/config/config.local.json.example
@@ -1,0 +1,37 @@
+{
+	"site": {
+		"proxyTrust": true,
+		"log": "debug",
+		"forceExitAfterMs": 5000
+	},
+	"musicbrainz": {
+		"clientID": null,
+		"clientSecret": null,
+		"callbackURL": "http://localhost:9099/cb"
+	},
+	"session": {
+		"maxAge": 2592000000,
+		"secret": "Something here!",
+		"secure": false,
+		"redis": {
+			"host": "localhost",
+			"port": 6379
+		}
+	},
+	"database": {
+		"client": "pg",
+		"connection": {
+			"host": "localhost",
+			"database": "bookbrainz",
+			"user": "postgres",
+			"password": ""
+		}
+	},
+	"search": {
+		"host": "localhost:9200",
+		"httpAuth": "elastic:changeme",
+		"apiVersion": "5.5",
+		"maxRetries": -1,
+		"deadTimeout": 2000
+	}
+}


### PR DESCRIPTION
### Problem
<!-- What are you trying to solve? -->
[BB-366](https://tickets.metabrainz.org/browse/BB-366) Allow overwriting config file path when running local server 

### Solution
<!-- What does this PR do to fix the problem? -->
Added functionality to pass config file path with `--config` flag.
`npm start -- --config ./config/config.local.json`

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/common/helpers/config.js