### PR TITLE
DatePicker fix

### DIFF
--- a/src/client/entity-editor/common/new-date-field.js
+++ b/src/client/entity-editor/common/new-date-field.js
@@ -134,7 +134,7 @@ class DateField extends React.Component {
 		});
 		const selectedDate = parseISO(dateString);
 		const groupClassName = classNames({hidden: !this.props.show});
-		const isCommonEraDate = Math.sign(this.state.year) === 1;
+		const isCommonEraDate = Math.sign(this.state.year) === 1 || Math.sign(this.state.year) === 0;
 		return (
 			<div>
 				<CustomInput


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
DatePicker disabled by default when date-input-field is empty

### Solution
<!-- What does this PR do to fix the problem? -->
isCommonEraDate value checking fix, so that it evaluates to 'true' for both '1' & '0'

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Frontend: DatePickers