### PR TITLE
fix(deletion): Delete page improvements

### DIFF
--- a/src/client/components/forms/deletion.js
+++ b/src/client/components/forms/deletion.js
@@ -107,7 +107,6 @@ class EntityDeletionForm extends React.Component {
 				<Row className="margin-top-2">
 					{loadingComponent}
 					<Col md={6} mdOffset={3}>
-						{errorComponent}
 						<form onSubmit={this.handleSubmit}>
 							<Panel
 								bsStyle="danger"
@@ -141,6 +140,7 @@ class EntityDeletionForm extends React.Component {
 									type="textarea"
 									wrapperClassName="margin-top-1"
 								/>
+								{errorComponent}
 							</Panel>
 						</form>
 					</Col>

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -303,10 +303,12 @@ export function handleDelete(
 				masterRevisionId: entityRevision.get('id')
 			}).save(null, {transacting}));
 
+		const searchDeleteEntityPromise = search.deleteEntity(entity)
+			.catch(err => { log.error(err); });
 		return Promise.join(
 			editorUpdatePromise, newRevisionPromise, notePromise,
 			newEntityRevisionPromise, entityHeaderPromise, parentAddedPromise,
-			search.deleteEntity(entity)
+			searchDeleteEntityPromise
 		);
 	});
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
If for some reason there is a communication issue with ElasticSearch (or if it is not running), deleting an entity fails.
The reason is that we use `Promise.all` to resolve the async function `search.deleteEntity` along with the other steps.
Promise.all rejects if any of the promises rejects.

The error messages when submitting on the deletion page itself were appearing at the top of the page, rather than above the submit button

### Solution
Catch errors on `search.deleteEntity` to prevent Promise.all from rejecting because of a search related issue.

Move the error messages  above the submit button on the front-end page.

### Areas of Impact

- src/server/routes/entity/entity.js
- src/client/components/forms/deletion.js