### PR TITLE
fix(search): Fixes BB-392: update search server with aliases

### DIFF
--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -737,7 +737,7 @@ export function handleCreateOrEditEntity(
 
 		const refreshedEntity = await savedMainEntity.refresh({
 			transacting,
-			withRelated: ['defaultAlias']
+			withRelated: ['defaultAlias', 'aliasSet.aliases']
 		});
 
 		return refreshedEntity.toJSON();


### PR DESCRIPTION
### Problem
Newly created entities did not seem to be indexed by the search server.
Issue was introduced indirectly in PR #313 

### Solution
Load/refresh the newly saved entity with all aliases rather than just defaultAlias, since we now index entites by all aliases.


### Areas of Impact
src/server/routes/entity/entity.js
