### PR TITLE
Fix- #BB-396 : drop down not working for error page

### DIFF
--- a/scripts/build-client-js.sh
+++ b/scripts/build-client-js.sh
@@ -7,6 +7,7 @@ cross-env BABEL_ENV="browser" browserify -t [babelify] \
 		editor/achievement.js \
 		editor/editor.js \
 		entity/entity.js \
+		error.js \
 		deletion.js \
 		index.js \
 		registrationDetails.js \
@@ -19,6 +20,7 @@ cross-env BABEL_ENV="browser" browserify -t [babelify] \
 		-o ../../../static/js/editor/achievement.js \
 		-o ../../../static/js/editor/editor.js \
 		-o ../../../static/js/entity/entity.js \
+		-o ../../../static/js/error.js \
 		-o ../../../static/js/deletion.js \
 		-o ../../../static/js/index.js \
 		-o ../../../static/js/registrationDetails.js \
@@ -26,12 +28,13 @@ cross-env BABEL_ENV="browser" browserify -t [babelify] \
 		-o ../../../static/js/search.js \
 		-o ../../../static/js/statistics.js \
 	] > ../../../static/js/bundle.js
-	
+
 	uglifyjs -cm -- ../../../static/js/entity-editor.js  	  | gzip --best > ../../../static/js/entity-editor.js.gz
 	uglifyjs -cm -- ../../../static/js/editor/edit.js 	  | gzip --best > ../../../static/js/editor/edit.js.gz
 	uglifyjs -cm -- ../../../static/js/editor/achievement.js  | gzip --best > ../../../static/js/editor/achievement.js.gz
 	uglifyjs -cm -- ../../../static/js/editor/editor.js 	  | gzip --best > ../../../static/js/editor/editor.js.gz
 	uglifyjs -cm -- ../../../static/js/entity/entity.js	  | gzip --best > ../../../static/js/entity/entity.gz
+	uglifyjs -cm -- ../../../static/js/error.js	  | gzip --best > ../../../static/js/error.js.gz
 	uglifyjs -cm -- ../../../static/js/deletion.js 		  | gzip --best > ../../../static/js/deletion.js.gz
 	uglifyjs -cm -- ../../../static/js/index.js 		  | gzip --best > ../../../static/js/index.js.gz
 	uglifyjs -cm -- ../../../static/js/registrationDetails.js | gzip --best > ../../../static/js/registrationDetails.js.gz

--- a/src/client/controllers/error.js
+++ b/src/client/controllers/error.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Prabal Singh
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {AppContainer} from 'react-hot-loader';
+import ErrorPage from '../components/pages/error';
+import Layout from '../containers/layout';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {extractLayoutProps} from '../helpers/props';
+
+
+const propsTarget = document.getElementById('props');
+const props = propsTarget ? JSON.parse(propsTarget.innerHTML) : {};
+const markup = (
+	<AppContainer>
+		<Layout {...extractLayoutProps(props)}>
+			<ErrorPage
+				error={props.error}
+			/>
+		</Layout>
+	</AppContainer>
+);
+
+ReactDOM.hydrate(markup, document.getElementById('target'));
+
+/*
+ * As we are not exporting a component,
+ * we cannot use the react-hot-loader module wrapper,
+ * but instead directly use webpack Hot Module Replacement API
+ */
+
+if (module.hot) {
+	module.hot.accept();
+}

--- a/src/server/helpers/error.js
+++ b/src/server/helpers/error.js
@@ -18,11 +18,11 @@
 
 import * as error from '../../common/helpers/error';
 import * as propHelpers from '../../client/helpers/props';
+import {escapeProps, generateProps} from './props';
 import ErrorPage from '../../client/components/pages/error';
 import Layout from '../../client/containers/layout';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import {generateProps} from './props';
 import status from 'http-status';
 import target from '../templates/target';
 
@@ -40,5 +40,10 @@ export function renderError(req, res, err) {
 	);
 	res.status(
 		errorToSend.status || status.INTERNAL_SERVER_ERROR
-	).send(target({markup}));
+	).send(target({
+		markup,
+		page: 'Error',
+		props: escapeProps(props),
+		script: '/js/error.js'
+	}));
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-396
Dropdown do not work for error page


### Solution
I added error.js in src/client/controller and made corresponding changing in script/build-client-less-js.sh
![Screenshot from 2020-01-21 07-52-31](https://user-images.githubusercontent.com/45737735/72770164-0abe7f80-3c23-11ea-8fc9-1c5bcb6b6d5f.png)

