### PR TITLE
fix(edition) : Cannot read property 'year' of undefined

### DIFF
--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -339,7 +339,7 @@ function transformNewForm(data) {
 	);
 
 	let releaseEvents = [];
-	if (data.editionSection.releaseDate.year) {
+	if (data.editionSection.releaseDate && data.editionSection.releaseDate.year) {
 		releaseEvents = [{date: dateObjectToISOString(data.editionSection.releaseDate)}];
 	}
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-395
Cannot read property 'year' of undefined


### Solution
Now it checks if data.editionSection.releaseDate exists or not


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
