### PR TITLE
BB-409: Fix XSS vulnerability in relationship display

### DIFF
--- a/src/client/components/pages/entities/links.js
+++ b/src/client/components/pages/entities/links.js
@@ -36,7 +36,7 @@ function EntityLinks({entity, identifierTypes, urlPrefix}) {
 		<Row>
 			<Col md={8}>
 				<EntityRelationships
-					contextEntity={entity.bbid}
+					contextEntity={entity}
 					entityUrl={urlPrefix}
 					relationships={relationships}
 				/>

--- a/src/client/components/pages/entities/links.js
+++ b/src/client/components/pages/entities/links.js
@@ -36,6 +36,7 @@ function EntityLinks({entity, identifierTypes, urlPrefix}) {
 		<Row>
 			<Col md={8}>
 				<EntityRelationships
+					contextEntity={entity.bbid}
 					entityUrl={urlPrefix}
 					relationships={relationships}
 				/>

--- a/src/client/components/pages/entities/relationships.js
+++ b/src/client/components/pages/entities/relationships.js
@@ -18,9 +18,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import Relationship from '../../../entity-editor/relationship-editor/relationship';
 
 
-function EntityRelationships({relationships}) {
+function EntityRelationships({contextEntity, relationships}) {
 	return (
 		<div>
 			<h2>Relationships</h2>
@@ -28,11 +29,16 @@ function EntityRelationships({relationships}) {
 			<ul className="list-unstyled">
 				{relationships.map((relationship) => (
 					<li
-						dangerouslySetInnerHTML={{
-							__html: relationship.rendered
-						}}
 						key={relationship.id}
-					/>
+					>
+						<Relationship
+							link
+							contextEntity={contextEntity}
+							relationshipType={relationship.type}
+							sourceEntity={relationship.source}
+							targetEntity={relationship.target}
+						/>
+					</li>
 				))}
 			</ul>
 			}
@@ -41,6 +47,7 @@ function EntityRelationships({relationships}) {
 }
 EntityRelationships.displayName = 'EntityRelationships';
 EntityRelationships.propTypes = {
+	contextEntity: PropTypes.string.isRequired,
 	relationships: PropTypes.array.isRequired
 };
 

--- a/src/client/components/pages/entities/relationships.js
+++ b/src/client/components/pages/entities/relationships.js
@@ -47,7 +47,7 @@ function EntityRelationships({contextEntity, relationships}) {
 }
 EntityRelationships.displayName = 'EntityRelationships';
 EntityRelationships.propTypes = {
-	contextEntity: PropTypes.string.isRequired,
+	contextEntity: PropTypes.object.isRequired,
 	relationships: PropTypes.array.isRequired
 };
 

--- a/src/client/entity-editor/common/entity.js
+++ b/src/client/entity-editor/common/entity.js
@@ -44,11 +44,11 @@ function Entity(
 			{nameComponent}
 			{
 				disambiguation &&
-				<span className="disambig"><small>({disambiguation})</small></span>
+				<span className="disambig margin-left-0-3"><small>({disambiguation})</small></span>
 			}
 			{
 				language &&
-				<span className="text-muted small">{language}</span>
+				<span className="text-muted small margin-left-0-3">{language}</span>
 			}
 		</span>
 	);
@@ -60,7 +60,7 @@ function Entity(
 	return contents;
 }
 
-// Entity.displayName = 'Entity';
+Entity.displayName = 'Entity';
 Entity.defaultProps = {
 	disambiguation: null,
 	link: false,

--- a/src/client/entity-editor/common/entity.js
+++ b/src/client/entity-editor/common/entity.js
@@ -22,6 +22,7 @@
 import React from 'react';
 import {genEntityIconHTMLElement} from '../../helpers/entity';
 
+
 type EntityProps = {
 	disambiguation?: ?string,
 	language: string,
@@ -40,14 +41,15 @@ function Entity(
 			{
 				type && genEntityIconHTMLElement(type)
 			}
-			{' '}
 			{nameComponent}
-			{' '}
 			{
 				disambiguation &&
 				<span className="disambig"><small>({disambiguation})</small></span>
 			}
-			<span className="text-muted small">{language}</span>
+			{
+				language &&
+				<span className="text-muted small">{language}</span>
+			}
 		</span>
 	);
 

--- a/src/client/entity-editor/relationship-editor/relationship.js
+++ b/src/client/entity-editor/relationship-editor/relationship.js
@@ -28,7 +28,9 @@ import {getEntityLink} from '../../../server/helpers/utils';
 function getEntityObjectForDisplay(entity: _Entity, makeLink: boolean) {
 	const link = makeLink && entity.bbid &&
 		getEntityLink({bbid: entity.bbid, type: entity.type});
+	const disambiguation = _.get(entity, ['disambiguation', 'comment']);
 	return {
+		disambiguation,
 		link,
 		text: _.get(entity, ['defaultAlias', 'name']),
 		type: entity.type,

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -240,7 +240,7 @@ export function genEntityIconHTMLElement(entityType, size = '1x', margin = true)
 	if (!ENTITY_TYPE_ICONS[entityType]) { return null; }
 	return (
 		<FontAwesomeIcon
-			className={margin ? 'margin-right-0-5' : ''}
+			className={margin ? 'margin-right-0-3' : ''}
 			icon={ENTITY_TYPE_ICONS[entityType]}
 			size={size}
 			title={entityType}

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -135,6 +135,8 @@ body {
 .generate-margins(6);
 .margin-right-0-5 {margin-right: unit(0.5, em) !important};
 .margin-left-0-5 {margin-left: unit(0.5, em) !important};
+.margin-right-0-3 {margin-right: unit(0.3, em) !important};
+.margin-left-0-3 {margin-left: unit(0.3, em) !important};
 
 .generate-margins-d(@n, @i: 0) when (@i =< @n) {
 	.margin-top-d@{i} {

--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -120,11 +120,6 @@ export function loadEntityRelationships(req, res, next) {
 			);
 		})
 		.then((relationships) => {
-			// Set rendered relationships on relationship objects
-			relationships.forEach((relationship) => {
-				relationship.rendered = renderRelationship(relationship);
-			});
-
 			next();
 			return null;
 		})


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-409

Relationships were being rendered by the server into an HTML string and injected directly on the front-end with `dangerouslySetHTML`.
This causes issues if the title of an entity has scripting language in it, opening the door to XSS attacks.


### Solution
Instead, use the same components we use in the entity editor to render the relationships.

This PR also brings a few small improvements in how relationship are displayed:
• minor visual tweaks
• display disambiguation if it exists (currently it only does so in the entity search fields)
