### PR TITLE
Refactor pagination component

### DIFF
--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2019 Prabal Singh
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import * as bootstrap from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import React from 'react';
+import request from 'superagent-bluebird-promise';
+
+
+const {Pager, Button, ButtonGroup, DropdownButton, MenuItem} = bootstrap;
+
+class PagerElement extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			from: this.props.from,
+			nextEnabled: this.props.results.length === this.props.size,
+			results: this.props.results,
+			size: this.props.size
+		};
+		this.handleClickPrevious = this.handleClickPrevious.bind(this);
+		this.handleClickNext = this.handleClickNext.bind(this);
+		this.handleResultsPerPageChange = this.handleResultsPerPageChange.bind(this);
+		this.triggerSearch = this.triggerSearch.bind(this);
+	}
+
+	triggerSearch() {
+		const pagination = `&size=${this.state.size}&from=${this.state.from}`;
+		const collectionString = this.state.collection ? `&collection=${this.state.collection}` : '';
+
+		request.get(`${this.props.paginationUrl}${this.props.query}${collectionString}${pagination}`)
+			.then((res) => JSON.parse(res.text))
+			.then((data) => {
+				this.setState(prevState => ({
+					nextEnabled: data.length >= prevState.size,
+					results: data
+				}));
+				this.props.changeDataInTable(data);
+			});
+	}
+
+	handleClickPrevious() {
+		this.setState(prevState => ({from: Math.max(prevState.from - prevState.size, 0)}), this.triggerSearch);
+	}
+
+	handleClickNext() {
+		this.setState(prevState => ({from: prevState.from + prevState.size}), this.triggerSearch);
+	}
+
+	handleResultsPerPageChange(value) {
+		this.setState({size: parseInt(value, 10)}, this.triggerSearch);
+	}
+
+	render() {
+		return (
+			<div id="PagerElement">
+				{
+					this.state.results && this.state.results.length ?
+						<div>
+							<hr className="thin"/>
+							<Pager>
+								<Pager.Item
+									previous disabled={this.state.from <= 0}
+									href="#" onClick={this.handleClickPrevious}
+								>
+									&larr; Previous Page
+								</Pager.Item>
+								<ButtonGroup>
+									<Button disabled>Results {this.state.from + 1} —
+										{this.state.results.length < this.state.size ?
+											this.state.from + this.state.results.length :
+											this.state.from + this.state.size
+										}
+									</Button>
+									<DropdownButton
+										dropup bsStyle="info" id="bg-nested-dropdown"
+										title={`${this.state.size} per page`}
+										onSelect={this.handleResultsPerPageChange}
+									>
+										<MenuItem eventKey="10">10 per page</MenuItem>
+										<MenuItem eventKey="20">20 per page</MenuItem>
+										<MenuItem eventKey="35">35 per page</MenuItem>
+										<MenuItem eventKey="50">50 per page</MenuItem>
+										<MenuItem eventKey="100">100 per page</MenuItem>
+									</DropdownButton>
+								</ButtonGroup>
+								<Pager.Item
+									next disabled={!this.state.nextEnabled}
+									href="#" onClick={this.handleClickNext}
+								>
+									Next Page &rarr;
+								</Pager.Item>
+							</Pager>
+
+						</div> :
+						null
+				}
+			</div>
+		);
+	}
+}
+
+
+PagerElement.propTypes = {
+	changeDataInTable: PropTypes.func.isRequired,
+	from: PropTypes.number,
+	paginationUrl: PropTypes.string.isRequired,
+	query: PropTypes.string,
+	results: PropTypes.array,
+	size: PropTypes.number
+};
+PagerElement.defaultProps = {
+	from: 0,
+	query: '',
+	results: [],
+	size: 20
+};
+
+export default PagerElement;

--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -41,16 +41,15 @@ class PagerElement extends React.Component {
 
 	triggerSearch() {
 		const pagination = `&size=${this.state.size}&from=${this.state.from}`;
-		const collectionString = this.state.collection ? `&collection=${this.state.collection}` : '';
 
-		request.get(`${this.props.paginationUrl}${this.props.query}${collectionString}${pagination}`)
+		request.get(`${this.props.paginationUrl}${this.props.query}${pagination}`)
 			.then((res) => JSON.parse(res.text))
 			.then((data) => {
 				this.setState(prevState => ({
 					nextEnabled: data.length >= prevState.size,
 					results: data
 				}));
-				this.props.changeDataInTable(data);
+				this.props.searchResultsCallback(data);
 			});
 	}
 
@@ -117,11 +116,11 @@ class PagerElement extends React.Component {
 
 
 PagerElement.propTypes = {
-	changeDataInTable: PropTypes.func.isRequired,
 	from: PropTypes.number,
 	paginationUrl: PropTypes.string.isRequired,
 	query: PropTypes.string,
 	results: PropTypes.array,
+	searchResultsCallback: PropTypes.func.isRequired,
 	size: PropTypes.number
 };
 PagerElement.defaultProps = {

--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -43,7 +43,7 @@ class PagerElement extends React.Component {
 	componentDidUpdate(prevProps, prevState) {
 		if (prevProps.query !== this.props.query) {
 			// eslint-disable-next-line react/no-did-update-set-state
-			this.setState(this.props, this.triggerSearch);
+			this.setState({from: 0, query: this.props.query}, this.triggerSearch);
 		}
 	}
 

--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -47,29 +47,31 @@ class PagerElement extends React.Component {
 		}
 	}
 
-	triggerSearch() {
-		const pagination = `&size=${this.state.size}&from=${this.state.from}`;
+	triggerSearch(newFrom = this.state.from, newSize = this.state.size) {
+		const pagination = `&size=${newSize}&from=${newFrom}`;
 		request.get(`${this.props.paginationUrl}${this.state.query}${pagination}`)
 			.then((res) => JSON.parse(res.text))
 			.then((data) => {
-				this.setState(prevState => ({
-					nextEnabled: data.length >= prevState.size,
-					results: data
-				}));
+				this.setState({
+					from: newFrom,
+					nextEnabled: data.length >= newSize,
+					results: data,
+					size: newSize
+				});
 				this.props.searchResultsCallback(data);
 			});
 	}
 
 	handleClickPrevious() {
-		this.setState(prevState => ({from: Math.max(prevState.from - prevState.size, 0)}), this.triggerSearch);
+		this.triggerSearch(Math.max(this.state.from - this.state.size, 0));
 	}
 
 	handleClickNext() {
-		this.setState(prevState => ({from: prevState.from + prevState.size}), this.triggerSearch);
+		this.triggerSearch(this.state.from + this.state.size);
 	}
 
-	handleResultsPerPageChange(value) {
-		this.setState({size: parseInt(value, 10)}, this.triggerSearch);
+	handleResultsPerPageChange(newSize) {
+		this.triggerSearch(this.state.from, parseInt(newSize, 10));
 	}
 
 	render() {

--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -30,6 +30,7 @@ class PagerElement extends React.Component {
 		this.state = {
 			from: this.props.from,
 			nextEnabled: this.props.results.length === this.props.size,
+			query: this.props.query,
 			results: this.props.results,
 			size: this.props.size
 		};
@@ -39,10 +40,16 @@ class PagerElement extends React.Component {
 		this.triggerSearch = this.triggerSearch.bind(this);
 	}
 
+	componentDidUpdate(prevProps, prevState) {
+		if (prevProps.query !== this.props.query) {
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState(this.props, this.triggerSearch);
+		}
+	}
+
 	triggerSearch() {
 		const pagination = `&size=${this.state.size}&from=${this.state.from}`;
-
-		request.get(`${this.props.paginationUrl}${this.props.query}${pagination}`)
+		request.get(`${this.props.paginationUrl}${this.state.query}${pagination}`)
 			.then((res) => JSON.parse(res.text))
 			.then((data) => {
 				this.setState(prevState => ({

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -32,25 +32,25 @@ class RevisionsPage extends React.Component {
 		};
 
 		// React does not autobind non-React class methods
-		this.changeDataInTable = this.changeDataInTable.bind(this);
+		this.searchResultsCallback = this.searchResultsCallback.bind(this);
 		this.paginationUrl = './revisions/revisions?q=';
 	}
 
-	changeDataInTable(newResults) {
+	searchResultsCallback(newResults) {
 		this.setState({results: newResults});
 	}
 
 	render() {
 		return (
 			<div className="container">
-				<div id="RevisionsPage">
+				<div id="pageWithPagination">
 
 					<RevisionsTable results={this.state.results}/>
 					<PagerElement
-						changeDataInTable={this.changeDataInTable}
 						from={this.state.from}
 						paginationUrl={this.paginationUrl}
 						results={this.state.results}
+						searchResultsCallback={this.searchResultsCallback}
 						size={this.state.size}
 					/>
 				</div>

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -16,53 +16,28 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as bootstrap from 'react-bootstrap';
+import PagerElement from './parts/pager';
 import PropTypes from 'prop-types';
 import React from 'react';
 import RevisionsTable from './parts/revisions-table';
-import request from 'superagent-bluebird-promise';
 
-
-const {Pager, Button, ButtonGroup, DropdownButton, MenuItem} = bootstrap;
 
 class RevisionsPage extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
 			from: this.props.from,
-			nextEnabled: this.props.results.length === this.props.size,
 			results: this.props.results,
 			size: this.props.size
 		};
+
 		// React does not autobind non-React class methods
-		this.triggerSearch = this.triggerSearch.bind(this);
-		this.handleClickPrevious = this.handleClickPrevious.bind(this);
-		this.handleClickNext = this.handleClickNext.bind(this);
-		this.handleResultsPerPageChange = this.handleResultsPerPageChange.bind(this);
+		this.sendDataBack = this.sendDataBack.bind(this);
+		this.paginationUrl = './revisions/revisions?q=';
 	}
 
-	triggerSearch() {
-		const pagination = `size=${this.state.size}&from=${this.state.from}`;
-		request.get(`./revisions/revisions?${pagination}`)
-			.then((res) => JSON.parse(res.text))
-			.then((data) => {
-				this.setState(prevState => ({
-					nextEnabled: data.length >= prevState.size,
-					results: data
-				}));
-			});
-	}
-
-	handleClickPrevious() {
-		this.setState(prevState => ({from: Math.max(prevState.from - prevState.size, 0)}), this.triggerSearch);
-	}
-
-	handleClickNext() {
-		this.setState(prevState => ({from: prevState.from + prevState.size}), this.triggerSearch);
-	}
-
-	handleResultsPerPageChange(value) {
-		this.setState({size: parseInt(value, 10)}, this.triggerSearch);
+	changeDataInTable(newResults) {
+		this.setState({results: newResults});
 	}
 
 	render() {
@@ -71,47 +46,13 @@ class RevisionsPage extends React.Component {
 				<div id="RevisionsPage">
 
 					<RevisionsTable results={this.state.results}/>
-					{
-						this.state.results && this.state.results.length ?
-							<div>
-								<hr className="thin"/>
-								<Pager>
-									<Pager.Item
-										previous disabled={this.state.from <= 0}
-										href="#" onClick={this.handleClickPrevious}
-									>
-										&larr; Previous Page
-									</Pager.Item>
-									<ButtonGroup>
-										<Button disabled>Results {this.state.from + 1} —
-											{this.state.results.length < this.state.size ?
-												this.state.from + this.state.results.length :
-												this.state.from + this.state.size
-											}
-										</Button>
-										<DropdownButton
-											dropup bsStyle="info" id="bg-nested-dropdown"
-											title={`${this.state.size} per page`}
-											onSelect={this.handleResultsPerPageChange}
-										>
-											<MenuItem eventKey="10">10 per page</MenuItem>
-											<MenuItem eventKey="20">20 per page</MenuItem>
-											<MenuItem eventKey="35">35 per page</MenuItem>
-											<MenuItem eventKey="50">50 per page</MenuItem>
-											<MenuItem eventKey="100">100 per page</MenuItem>
-										</DropdownButton>
-									</ButtonGroup>
-									<Pager.Item
-										next disabled={!this.state.nextEnabled}
-										href="#" onClick={this.handleClickNext}
-									>
-										Next Page &rarr;
-									</Pager.Item>
-								</Pager>
-
-							</div> :
-							null
-					}
+					<PagerElement
+						changeDataInTable={this.changeDataInTable}
+						from={this.state.from}
+						paginationUrl={this.paginationUrl}
+						results={this.state.results}
+						size={this.state.size}
+					/>
 				</div>
 			</div>
 		);

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -26,9 +26,7 @@ class RevisionsPage extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			from: this.props.from,
-			results: this.props.results,
-			size: this.props.size
+			results: this.props.results
 		};
 
 		// React does not autobind non-React class methods
@@ -47,11 +45,11 @@ class RevisionsPage extends React.Component {
 
 					<RevisionsTable results={this.state.results}/>
 					<PagerElement
-						from={this.state.from}
+						from={this.props.from}
 						paginationUrl={this.paginationUrl}
 						results={this.state.results}
 						searchResultsCallback={this.searchResultsCallback}
-						size={this.state.size}
+						size={this.props.size}
 					/>
 				</div>
 			</div>

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -32,7 +32,7 @@ class RevisionsPage extends React.Component {
 		};
 
 		// React does not autobind non-React class methods
-		this.sendDataBack = this.sendDataBack.bind(this);
+		this.changeDataInTable = this.changeDataInTable.bind(this);
 		this.paginationUrl = './revisions/revisions?q=';
 	}
 

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -84,7 +84,7 @@ class SearchPage extends React.Component {
 	 */
 	render() {
 		return (
-			<div id="searchPage">
+			<div id="pageWithPagination">
 				<SearchField
 					entityTypes={this.props.entityTypes}
 					query={this.props.query}

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -59,17 +59,17 @@ class SearchPage extends React.Component {
 	 * @param {boolean} reset - Reset the search 'from' to 0 for a new search
 	 */
 	handleSearch(query, collection) {
-		if (query === this.state.query && collection === this.state.collection) {
-			return;
-		}
 		if (typeof query !== 'string' || typeof collection !== 'string') {
 			return;
 		}
+
 		const collectionString = collection ? `&collection=${collection}` : '';
 		const fullQuery = `${query}${collectionString}`;
 
-		this.pagerElement.setState({from: 0, query: fullQuery});
-		this.setState({collection, from: 0, query}, this.pagerElement.triggerSearch);
+		if (this.state.query === fullQuery) {
+			return;
+		}
+		this.setState({from: 0, query: fullQuery});
 	}
 
 	searchResultsCallback(newResults) {
@@ -95,7 +95,6 @@ class SearchPage extends React.Component {
 					from={this.state.from}
 					paginationUrl={this.paginationUrl}
 					query={this.state.query}
-					ref={ref => this.pagerElement = ref}
 					results={this.state.results}
 					searchResultsCallback={this.searchResultsCallback}
 					size={this.state.size}

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -18,17 +18,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import * as bootstrap from 'react-bootstrap';
 
+import PagerElement from './parts/pager';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SearchField from './parts/search-field';
 import SearchResults from './parts/search-results';
-import {isNil} from 'lodash';
-import request from 'superagent-bluebird-promise';
 
-
-const {Button, ButtonGroup, DropdownButton, MenuItem, Pager} = bootstrap;
 
 class SearchPage extends React.Component {
 	/**
@@ -43,7 +39,6 @@ class SearchPage extends React.Component {
 
 		this.state = {
 			from: 0,
-			nextEnabled: this.props.initialResults.length === this.props.resultsPerPage,
 			query: this.props.query,
 			results: this.props.initialResults,
 			size: this.props.resultsPerPage
@@ -51,10 +46,9 @@ class SearchPage extends React.Component {
 
 		// React does not autobind non-React class methods
 		this.handleSearch = this.handleSearch.bind(this);
-		this.triggerSearch = this.triggerSearch.bind(this);
-		this.handleClickPrevious = this.handleClickPrevious.bind(this);
-		this.handleClickNext = this.handleClickNext.bind(this);
-		this.handleResultsPerPageChange = this.handleResultsPerPageChange.bind(this);
+		this.redirectUrl = this.redirectUrl.bind(this);
+		this.changeDataInTable = this.changeDataInTable.bind(this);
+		this.paginationUrl = './search/search?q=';
 	}
 
 	/**
@@ -73,32 +67,19 @@ class SearchPage extends React.Component {
 			return;
 		}
 
-		this.setState({collection, from: 0, query}, this.triggerSearch);
+		this.setState({collection, from: 0, query}, this.redirectUrl);
 	}
 
-	triggerSearch() {
+	redirectUrl() {
 		const collectionString = this.state.collection ? `&collection=${this.state.collection}` : '';
 		const pagination = `&size=${this.state.size}&from=${this.state.from}`;
-		request.get(`./search/search?q=${this.state.query}${collectionString}${pagination}`)
-			.then((res) => JSON.parse(res.text))
-			.then((data) => {
-				this.setState(prevState => ({
-					nextEnabled: data.length >= prevState.size,
-					results: data.filter(result => !isNil(result))
-				}));
-			});
+
+		const url = `./search/search?q=${this.state.query}${collectionString}${pagination}`;
+		// TODO redirect to url;
 	}
 
-	handleClickPrevious(event) {
-		this.setState(prevState => ({from: Math.max(prevState.from - prevState.size, 0)}), this.triggerSearch);
-	}
-
-	handleClickNext(event) {
-		this.setState(prevState => ({from: prevState.from + prevState.size}), this.triggerSearch);
-	}
-
-	handleResultsPerPageChange(value) {
-		this.setState({size: parseInt(value, 10)}, this.triggerSearch);
+	changeDataInTable(newResults) {
+		this.setState({results: newResults});
 	}
 
 	/**
@@ -116,46 +97,14 @@ class SearchPage extends React.Component {
 					onSearch={this.handleSearch}
 				/>
 				<SearchResults results={this.state.results}/>
-				{
-					this.state.results && this.state.results.length ?
-						<div>
-							<hr className="thin"/>
-							<Pager>
-								<Pager.Item
-									previous disabled={this.state.from <= 0}
-									href="#" onClick={this.handleClickPrevious}
-								>
-									&larr; Previous Page
-								</Pager.Item>
-								<ButtonGroup>
-									<Button disabled>Results {this.state.from + 1} —
-										{this.state.results.length < this.state.size ?
-											this.state.from + this.state.results.length :
-											this.state.from + this.state.size
-										}
-									</Button>
-									<DropdownButton
-										dropup bsStyle="info" id="bg-nested-dropdown"
-										title={`${this.state.size} per page`}
-										onSelect={this.handleResultsPerPageChange}
-									>
-										<MenuItem eventKey="10">10 per page</MenuItem>
-										<MenuItem eventKey="20">20 per page</MenuItem>
-										<MenuItem eventKey="35">35 per page</MenuItem>
-										<MenuItem eventKey="50">50 per page</MenuItem>
-										<MenuItem eventKey="100">100 per page</MenuItem>
-									</DropdownButton>
-								</ButtonGroup>
-								<Pager.Item
-									next disabled={!this.state.nextEnabled}
-									href="#" onClick={this.handleClickNext}
-								>
-									Next Page &rarr;
-								</Pager.Item>
-							</Pager>
-						</div> :
-						null
-				}
+				<PagerElement
+					changeDataInTable={this.changeDataInTable}
+					from={this.state.from}
+					paginationUrl={this.paginationUrl}
+					query={this.state.query}
+					results={this.state.results}
+					size={this.state.size}
+				/>
 			</div>
 		);
 	}

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -46,8 +46,7 @@ class SearchPage extends React.Component {
 
 		// React does not autobind non-React class methods
 		this.handleSearch = this.handleSearch.bind(this);
-		this.redirectUrl = this.redirectUrl.bind(this);
-		this.changeDataInTable = this.changeDataInTable.bind(this);
+		this.searchResultsCallback = this.searchResultsCallback.bind(this);
 		this.paginationUrl = './search/search?q=';
 	}
 
@@ -66,19 +65,14 @@ class SearchPage extends React.Component {
 		if (typeof query !== 'string' || typeof collection !== 'string') {
 			return;
 		}
+		const collectionString = collection ? `&collection=${collection}` : '';
+		const fullQuery = `${query}${collectionString}`;
 
-		this.setState({collection, from: 0, query}, this.redirectUrl);
+		this.pagerElement.setState({from: 0, query: fullQuery});
+		this.setState({collection, from: 0, query}, this.pagerElement.triggerSearch);
 	}
 
-	redirectUrl() {
-		const collectionString = this.state.collection ? `&collection=${this.state.collection}` : '';
-		const pagination = `&size=${this.state.size}&from=${this.state.from}`;
-
-		const url = `./search/search?q=${this.state.query}${collectionString}${pagination}`;
-		// TODO redirect to url;
-	}
-
-	changeDataInTable(newResults) {
+	searchResultsCallback(newResults) {
 		this.setState({results: newResults});
 	}
 
@@ -98,11 +92,12 @@ class SearchPage extends React.Component {
 				/>
 				<SearchResults results={this.state.results}/>
 				<PagerElement
-					changeDataInTable={this.changeDataInTable}
 					from={this.state.from}
 					paginationUrl={this.paginationUrl}
 					query={this.state.query}
+					ref={ref => this.pagerElement = ref}
 					results={this.state.results}
+					searchResultsCallback={this.searchResultsCallback}
 					size={this.state.size}
 				/>
 			</div>

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -38,10 +38,8 @@ class SearchPage extends React.Component {
 		super(props);
 
 		this.state = {
-			from: 0,
 			query: this.props.query,
-			results: this.props.initialResults,
-			size: this.props.resultsPerPage
+			results: this.props.initialResults
 		};
 
 		// React does not autobind non-React class methods
@@ -92,12 +90,12 @@ class SearchPage extends React.Component {
 				/>
 				<SearchResults results={this.state.results}/>
 				<PagerElement
-					from={this.state.from}
+					from={this.props.from}
 					paginationUrl={this.paginationUrl}
 					query={this.state.query}
 					results={this.state.results}
 					searchResultsCallback={this.searchResultsCallback}
-					size={this.state.size}
+					size={this.props.resultsPerPage}
 				/>
 			</div>
 		);
@@ -107,11 +105,13 @@ class SearchPage extends React.Component {
 SearchPage.displayName = 'SearchPage';
 SearchPage.propTypes = {
 	entityTypes: PropTypes.array.isRequired,
+	from: PropTypes.number,
 	initialResults: PropTypes.array,
 	query: PropTypes.string,
 	resultsPerPage: PropTypes.number
 };
 SearchPage.defaultProps = {
+	from: 0,
 	initialResults: [],
 	query: '',
 	resultsPerPage: 20

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -344,7 +344,7 @@ hr.wide {
 	margin-top: 40px;
     margin-bottom: 40px;
 }
-#searchPage .pager .dropdown-menu {
+#pageWithPagination .pager .dropdown-menu {
 	li {
 	  display: initial;
 	  > a,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-406
Refactoring Pagination Component

The bootstrap Pager element is used across various pages (search, revisions page, editor's revisions page), each having a copy of the code.

This PR is about refactoring that pager code into a component that can be reused

<!-- What are you trying to solve? -->


### Solution
<!-- What does this PR do to fix the problem? -->

Added a new component - PagerElement and reused it for search-results and revision-table
