### PR TITLE
changed background opacity of navbar in mobile view

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -43,7 +43,7 @@ The production configuration for webpack needs to be finalized before using this
 @disabled-color: lighten(@disabled-bg,15%);
 
 .navbar.BookBrainz {
-	background: rgba(255, 255, 255, 0.9);
+	background: rgba(255, 255, 255, 1);
 	margin-bottom: 0px;
 	.nav.navbar-nav > .disabled > a {
 		color: @disabled-color;


### PR DESCRIPTION

### Problem

https://tickets.metabrainz.org/browse/BB-411

### Solution
the opacity of  .navabar.BookBrainz has been changed from 0.9 to 1 . 

before>>>

![issuenavbar](https://user-images.githubusercontent.com/43696525/73837481-96492a80-4837-11ea-9a9f-58cb73c3e318.png)





after >>>
![solvednavbar](https://user-images.githubusercontent.com/43696525/73837344-45d1cd00-4837-11ea-86ba-bd676198aae8.png)


### Areas of Impact
only navbar's background opacity is changed 
