### PR TITLE
BB-417 fix(revision-table) : remove unneccesary div tag and use 'pull-right'

### DIFF
--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -212,20 +212,17 @@ class IndexPage extends React.Component {
 						Register!
 					</Button>
 				</div>
-				<RevisionsTable
-					results={this.props.recent}
-				/>
 				<div>
-					<Row>
-						<Col mdOffset={10}>
-							<Button
-								bsStyle="primary"
-								href="/revisions"
-							>
-								See all revisions
-							</Button>
-						</Col>
-					</Row>
+					<RevisionsTable
+						results={this.props.recent}
+					/>
+					<Button
+						bsStyle="primary"
+						className="pull-right"
+						href="/revisions"
+					>
+						See all revisions
+					</Button>
 				</div>
 			</Grid>
 		);

--- a/src/client/components/pages/index.js
+++ b/src/client/components/pages/index.js
@@ -216,13 +216,14 @@ class IndexPage extends React.Component {
 					<RevisionsTable
 						results={this.props.recent}
 					/>
-					<Button
-						bsStyle="primary"
-						className="pull-right"
-						href="/revisions"
-					>
-						See all revisions
-					</Button>
+					<div className="text-center">
+						<Button
+							bsStyle="primary"
+							href="/revisions"
+						>
+							See all revisions
+						</Button>
+					</div>
 				</div>
 			</Grid>
 		);

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -67,52 +67,49 @@ class RevisionsPage extends React.Component {
 
 	render() {
 		return (
-			<div className="container">
-				<div id="RevisionsPage">
-
-					<RevisionsTable results={this.state.results}/>
-					{
-						this.state.results && this.state.results.length ?
-							<div>
-								<hr className="thin"/>
-								<Pager>
-									<Pager.Item
-										previous disabled={this.state.from <= 0}
-										href="#" onClick={this.handleClickPrevious}
+			<div id="RevisionsPage">
+				<RevisionsTable results={this.state.results}/>
+				{
+					this.state.results && this.state.results.length ?
+						<div>
+							<hr className="thin"/>
+							<Pager>
+								<Pager.Item
+									previous disabled={this.state.from <= 0}
+									href="#" onClick={this.handleClickPrevious}
+								>
+									&larr; Previous Page
+								</Pager.Item>
+								<ButtonGroup>
+									<Button disabled>Results {this.state.from + 1} —
+										{this.state.results.length < this.state.size ?
+											this.state.from + this.state.results.length :
+											this.state.from + this.state.size
+										}
+									</Button>
+									<DropdownButton
+										dropup bsStyle="info" id="bg-nested-dropdown"
+										title={`${this.state.size} per page`}
+										onSelect={this.handleResultsPerPageChange}
 									>
-										&larr; Previous Page
-									</Pager.Item>
-									<ButtonGroup>
-										<Button disabled>Results {this.state.from + 1} —
-											{this.state.results.length < this.state.size ?
-												this.state.from + this.state.results.length :
-												this.state.from + this.state.size
-											}
-										</Button>
-										<DropdownButton
-											dropup bsStyle="info" id="bg-nested-dropdown"
-											title={`${this.state.size} per page`}
-											onSelect={this.handleResultsPerPageChange}
-										>
-											<MenuItem eventKey="10">10 per page</MenuItem>
-											<MenuItem eventKey="20">20 per page</MenuItem>
-											<MenuItem eventKey="35">35 per page</MenuItem>
-											<MenuItem eventKey="50">50 per page</MenuItem>
-											<MenuItem eventKey="100">100 per page</MenuItem>
-										</DropdownButton>
-									</ButtonGroup>
-									<Pager.Item
-										next disabled={!this.state.nextEnabled}
-										href="#" onClick={this.handleClickNext}
-									>
-										Next Page &rarr;
-									</Pager.Item>
-								</Pager>
+										<MenuItem eventKey="10">10 per page</MenuItem>
+										<MenuItem eventKey="20">20 per page</MenuItem>
+										<MenuItem eventKey="35">35 per page</MenuItem>
+										<MenuItem eventKey="50">50 per page</MenuItem>
+										<MenuItem eventKey="100">100 per page</MenuItem>
+									</DropdownButton>
+								</ButtonGroup>
+								<Pager.Item
+									next disabled={!this.state.nextEnabled}
+									href="#" onClick={this.handleClickNext}
+								>
+									Next Page &rarr;
+								</Pager.Item>
+							</Pager>
 
-							</div> :
-							null
-					}
-				</div>
+						</div> :
+						null
+				}
 			</div>
 		);
 	}


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/projects/BB/issues/BB-417
For the revisions table, right margin was lesser than left. It was looking unsymmetrical 
In the main page, `see all revisions` button was showing on the left side for smaller screens( mobile)
<!-- What are you trying to solve? -->


### Solution
Removed an unnecessary `<div id=container>` (made it same as search result table)
For the main page, used `pull-right` for `see all revisions` button 
<!-- What does this PR do to fix the problem? -->

![Screenshot from 2020-02-09 18-07-31](https://user-images.githubusercontent.com/45737735/74109684-7acd7f00-4bab-11ea-8157-23ae337ee7df.png)

![Screenshot from 2020-02-09 18-07-39](https://user-images.githubusercontent.com/45737735/74109685-7ef99c80-4bab-11ea-8e2a-147de188fc8c.png)


### Areas of Impact
 src/client/components/pages/index.js
 src/client/components/pages/revisions.js
<!-- What parts of the codebase and which behaviors are affected? -->
