### PR TITLE
Add icons in entity editor buttons

### DIFF
--- a/src/client/entity-editor/alias-editor/alias-editor.js
+++ b/src/client/entity-editor/alias-editor/alias-editor.js
@@ -92,7 +92,8 @@ const AliasEditor = ({
 				<Row>
 					<Col className="text-right" md={3} mdOffset={9}>
 						<Button bsStyle="success" onClick={onAddAlias}>
-							Add alias
+							<FontAwesomeIcon icon="plus"/>
+							<span>&nbsp;Add alias</span>
 						</Button>
 					</Col>
 				</Row>

--- a/src/client/entity-editor/alias-editor/alias-row.js
+++ b/src/client/entity-editor/alias-editor/alias-row.js
@@ -25,6 +25,7 @@ import {
 import {
 	validateAliasLanguage, validateAliasName, validateAliasSortName
 } from '../validators/common';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import LanguageField from '../common/language-field';
 import NameField from '../common/name-field';
 import PropTypes from 'prop-types';
@@ -126,7 +127,8 @@ const AliasRow = ({
 					className="margin-top-d5"
 					onClick={onRemoveButtonClick}
 				>
-					Remove
+					<FontAwesomeIcon icon="times"/>
+					<span>&nbsp;Remove</span>
 				</Button>
 			</Col>
 		</Row>

--- a/src/client/entity-editor/identifier-editor/identifier-editor.js
+++ b/src/client/entity-editor/identifier-editor/identifier-editor.js
@@ -89,7 +89,8 @@ const IdentifierEditor = ({
 				<Row>
 					<Col className="text-right" md={3} mdOffset={9}>
 						<Button bsStyle="success" onClick={onAddIdentifier}>
-							Add identifier
+							<FontAwesomeIcon icon="plus"/>
+							<span>&nbsp;Add identifier</span>
 						</Button>
 					</Col>
 				</Row>

--- a/src/client/entity-editor/identifier-editor/identifier-row.js
+++ b/src/client/entity-editor/identifier-editor/identifier-row.js
@@ -29,6 +29,7 @@ import {
 	validateIdentifierValue
 } from '../validators/common';
 import CustomInput from '../../input';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import React from 'react';
 import Select from 'react-select';
 import ValueField from './value-field';
@@ -118,7 +119,8 @@ function IdentifierRow({
 						className="margin-top-d15"
 						onClick={onRemoveButtonClick}
 					>
-						Remove
+						<FontAwesomeIcon icon="times"/>
+						<span>&nbsp;Remove</span>
 					</Button>
 				</Col>
 			</Row>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -37,6 +37,7 @@ import type {
 } from './types';
 
 import EntitySearchFieldOption from '../common/entity-search-field-option';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import React from 'react';
 import ReactSelect from 'react-select';
 import Relationship from './relationship';
@@ -371,13 +372,17 @@ class RelationshipModal
 							/>
 						</Col>
 					</Row>
-					<Button bsStyle="danger" onClick={onCancel}>Cancel</Button>
+					<Button bsStyle="danger" onClick={onCancel}>
+						<FontAwesomeIcon icon="times"/>
+						<span>&nbsp;Cancel</span>
+					</Button>
 					<Button
 						bsStyle="success"
 						disabled={submitDisabled}
 						onClick={this.handleAdd}
 					>
-						Add
+						<FontAwesomeIcon icon="plus"/>
+						<span>&nbsp;Add</span>
 					</Button>
 				</Modal.Footer>
 			</Modal>

--- a/src/client/entity-editor/relationship-editor/relationship-section.js
+++ b/src/client/entity-editor/relationship-editor/relationship-section.js
@@ -200,7 +200,8 @@ function RelationshipSection({
 						<Button
 							onClick={onUndo}
 						>
-							Undo last action
+							<FontAwesomeIcon icon="undo"/>
+							<span>&nbsp;Undo last action</span>
 						</Button>
 					</Col>
 				</Row>

--- a/src/client/entity-editor/relationship-editor/relationship-section.js
+++ b/src/client/entity-editor/relationship-editor/relationship-section.js
@@ -38,6 +38,7 @@ import type {
 	Relationship as _Relationship
 } from './types';
 import type {Dispatch} from 'redux'; // eslint-disable-line import/named
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Relationship from './relationship';
@@ -78,7 +79,8 @@ function RelationshipList(
 								bsStyle="warning"
 								onClick={onEdit.bind(this, rowID)}
 							>
-								Edit
+								<FontAwesomeIcon icon="pencil-alt"/>
+								<span>&nbsp;Edit</span>
 							</Button>
 						</ButtonGroup>
 						<ButtonGroup>
@@ -86,7 +88,8 @@ function RelationshipList(
 								bsStyle="danger"
 								onClick={onRemove.bind(this, rowID)}
 							>
-								Remove
+								<FontAwesomeIcon icon="times"/>
+								<span>&nbsp;Remove</span>
 							</Button>
 						</ButtonGroup>
 					</ButtonGroup>
@@ -182,7 +185,8 @@ function RelationshipSection({
 						bsStyle="success"
 						onClick={onAddRelationship}
 					>
-						Add relationship
+						<FontAwesomeIcon icon="plus"/>
+						<span>&nbsp;Add relationship</span>
 					</Button>
 				</Col>
 			</Row>

--- a/src/client/helpers/setupIconLibrary.js
+++ b/src/client/helpers/setupIconLibrary.js
@@ -22,7 +22,7 @@ import {
 	faComment, faEnvelope, faExclamationTriangle, faExternalLinkAlt,
 	faGlobe, faHistory, faInfo, faPenNib, faPencilAlt, faPencilRuler,
 	faPlus, faQuestionCircle, faRemoveFormat, faSearch, faSignInAlt,
-	faSignOutAlt, faSlash, faTimes, faTimesCircle, faTrashAlt,
+	faSignOutAlt, faSlash, faTimes, faTimesCircle, faTrashAlt, faUndo,
 	faUniversity, faUser, faUserCircle, faWindowRestore
 } from '@fortawesome/free-solid-svg-icons';
 import {fab} from '@fortawesome/free-brands-svg-icons';
@@ -37,6 +37,6 @@ library.add(
 	faComment, faEnvelope, faExclamationTriangle, faExternalLinkAlt,
 	faGlobe, faHistory, faInfo, faPenNib, faPencilAlt, faPencilRuler,
 	faPlus, faQuestionCircle, faRemoveFormat, faSearch, faSignInAlt,
-	faSignOutAlt, faSlash, faTimes, faTimesCircle, faTrashAlt,
+	faSignOutAlt, faSlash, faTimes, faTimesCircle, faTrashAlt, faUndo,
 	faUniversity, faUser, faUserCircle, faWindowRestore
 );


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Relationship Section was like this before
![Screenshot_2020-02-13 Edit The Lord of the Rings (Work) – BookBrainz(2)](https://user-images.githubusercontent.com/45737735/74389838-8d52ed00-4e25-11ea-86be-bd314b37896b.png)

Icons for `edit`, `remove` and `add relationship` were missing
<!-- What are you trying to solve? -->


### Solution

Added corresponding icons
![Screenshot_2020-02-13 Edit The Lord of the Rings (Work) – BookBrainz(1)](https://user-images.githubusercontent.com/45737735/74389891-af4c6f80-4e25-11ea-80f4-b5decb07eddd.png)

<!-- What does this PR do to fix the problem? -->


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

 src/client/entity-editor/relationship-editor/relationship-section.js
