### PR TITLE
Pager next enabled 

### DIFF
--- a/src/client/components/pages/editor-revision.js
+++ b/src/client/components/pages/editor-revision.js
@@ -48,6 +48,7 @@ class EditorRevisionPage extends React.Component {
 				/>
 				<PagerElement
 					from={this.props.from}
+					nextEnabled={this.props.nextEnabled}
 					paginationUrl={this.paginationUrl}
 					results={this.state.results}
 					searchResultsCallback={this.searchResultsCallback}
@@ -62,6 +63,7 @@ class EditorRevisionPage extends React.Component {
 EditorRevisionPage.displayName = 'EditorRevisionPage';
 EditorRevisionPage.propTypes = {
 	from: PropTypes.number,
+	nextEnabled: PropTypes.bool.isRequired,
 	results: PropTypes.array,
 	showRevisionEditor: PropTypes.bool,
 	showRevisionNote: PropTypes.bool,

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -47,6 +47,7 @@ class RevisionsPage extends React.Component {
 				/>
 				<PagerElement
 					from={this.props.from}
+					nextEnabled={this.props.nextEnabled}
 					paginationUrl={this.paginationUrl}
 					results={this.state.results}
 					searchResultsCallback={this.searchResultsCallback}
@@ -61,6 +62,7 @@ class RevisionsPage extends React.Component {
 RevisionsPage.displayName = 'RevisionsPage';
 RevisionsPage.propTypes = {
 	from: PropTypes.number,
+	nextEnabled: PropTypes.bool.isRequired,
 	results: PropTypes.array,
 	showRevisionEditor: PropTypes.bool,
 	size: PropTypes.number

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -91,6 +91,7 @@ class SearchPage extends React.Component {
 				<SearchResults results={this.state.results}/>
 				<PagerElement
 					from={this.props.from}
+					nextEnabled={this.props.nextEnabled}
 					paginationUrl={this.paginationUrl}
 					query={this.state.query}
 					results={this.state.results}
@@ -107,6 +108,7 @@ SearchPage.propTypes = {
 	entityTypes: PropTypes.array.isRequired,
 	from: PropTypes.number,
 	initialResults: PropTypes.array,
+	nextEnabled: PropTypes.bool.isRequired,
 	query: PropTypes.string,
 	resultsPerPage: PropTypes.number
 };

--- a/src/client/controllers/search.js
+++ b/src/client/controllers/search.js
@@ -31,7 +31,6 @@ const markup = (
 	<AppContainer>
 		<Layout {...extractLayoutProps(props)}>
 			<SearchPage
-				query={props.query}
 				{...extractChildProps(props)}
 			/>
 		</Layout>

--- a/src/client/controllers/search.js
+++ b/src/client/controllers/search.js
@@ -16,12 +16,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import {extractChildProps, extractLayoutProps} from '../helpers/props';
 import {AppContainer} from 'react-hot-loader';
 import Layout from '../containers/layout';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import SearchPage from '../components/pages/search';
-import {extractLayoutProps} from '../helpers/props';
 
 
 const propsTarget = document.getElementById('props');
@@ -31,8 +31,8 @@ const markup = (
 	<AppContainer>
 		<Layout {...extractLayoutProps(props)}>
 			<SearchPage
-				entityTypes={props.entityTypes}
-				initialResults={props.initialResults} query={props.query}
+				query={props.query}
+				{...extractChildProps(props)}
 			/>
 		</Layout>
 	</AppContainer>

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -308,3 +308,17 @@ export function getAdditionalRelations(modelType) {
 	}
 	return [];
 }
+
+export function getNextEnabledAndResultsArray(array, size) {
+	if (array.length > size) {
+		array.pop();
+		return {
+			newResultsArray: array,
+			nextEnabled: true
+		};
+	}
+	return {
+		newResultsArray: array,
+		nextEnabled: false
+	};
+}

--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -311,7 +311,9 @@ export function getAdditionalRelations(modelType) {
 
 export function getNextEnabledAndResultsArray(array, size) {
 	if (array.length > size) {
-		array.pop();
+		while (array.length > size) {
+			array.pop();
+		}
 		return {
 			newResultsArray: array,
 			nextEnabled: true

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -288,15 +288,17 @@ router.get('/:id/revisions', async (req, res, next) => {
 	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
 
 	try {
-		const orderedRevisions = await getOrderedRevisionForEditorPage(from, size, req);
-
+		// get 1 more result to check nextEnabled
+		const orderedRevisions = await getOrderedRevisionForEditorPage(from, size + 1, req);
+		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
 		const editor = await new Editor({id: req.params.id}).fetch();
 		const editorJSON = await getEditorTitleJSON(editor.toJSON(), TitleUnlock);
 
 		const props = generateProps(req, res, {
 			editor: editorJSON,
 			from,
-			results: orderedRevisions,
+			nextEnabled,
+			results: newResultsArray,
 			showRevisionNote: true,
 			size,
 			tabActive: 1,

--- a/src/server/routes/revisions.js
+++ b/src/server/routes/revisions.js
@@ -38,9 +38,10 @@ router.get('/', async (req, res, next) => {
 	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
 	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
 
-	function render(results) {
+	function render(results, nextEnabled) {
 		const props = generateProps(req, res, {
 			from,
+			nextEnabled,
 			results,
 			showRevisionEditor: true,
 			size
@@ -67,8 +68,9 @@ router.get('/', async (req, res, next) => {
 	}
 
 	try {
-		const orderedRevisions = await utils.getOrderedRevisions(from, size, orm);
-		return render(orderedRevisions);
+		const orderedRevisions = await utils.getOrderedRevisions(from, size + 1, orm);
+		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
+		return render(newResultsArray, nextEnabled);
 	}
 	catch (err) {
 		return next(err);

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -68,7 +68,6 @@ router.get('/', (req, res, next) => {
 			const markup = ReactDOMServer.renderToString(
 				<Layout {...propHelpers.extractLayoutProps(props)}>
 					<SearchPage
-						query={query}
 						{...propHelpers.extractChildProps(props)}
 					/>
 				</Layout>

--- a/test/src/server/helpers/utils.js
+++ b/test/src/server/helpers/utils.js
@@ -1,0 +1,52 @@
+import chai from 'chai';
+import {getNextEnabledAndResultsArray} from '../../../../src/server/helpers/utils';
+
+
+const {expect} = chai;
+
+describe('Testing getNextEnabledAndResultsArray', () => {
+	it('newResultsArray size should be 9 and nextEnabled true when arrayLength=10 and size=9', () => {
+		const array = Array(10).fill(0);
+		const size = 9;
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
+
+		expect(newResultsArray.length).to.equal(9);
+		expect(nextEnabled).to.equal(true);
+	});
+
+	it('newResultsArray size should be 10 and nextEnabled false when arrayLength=10 and size=10', () => {
+		const array = Array(10).fill(0);
+		const size = 10;
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
+
+		expect(newResultsArray.length).to.equal(10);
+		expect(nextEnabled).to.equal(false);
+	});
+
+	it('newResultsArray size should be 9 and nextEnabled false when arrayLength=9 and size=10', () => {
+		const array = Array(9).fill(0);
+		const size = 10;
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
+
+		expect(newResultsArray.length).to.equal(9);
+		expect(nextEnabled).to.equal(false);
+	});
+
+	it('newResultsArray size should be 0 and nextEnabled false when arrayLength=0 and size=10', () => {
+		const array = Array(1).fill(0);
+		const size = 10;
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
+
+		expect(newResultsArray.length).to.equal(1);
+		expect(nextEnabled).to.equal(false);
+	});
+
+	it('newResultsArray size should be 10 and nextEnabled true when arrayLength=20 and size=10', () => {
+		const array = Array(20).fill(0);
+		const size = 10;
+		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
+
+		expect(newResultsArray.length).to.equal(10);
+		expect(nextEnabled).to.equal(true);
+	});
+});

--- a/test/src/server/helpers/utils.js
+++ b/test/src/server/helpers/utils.js
@@ -4,8 +4,8 @@ import {getNextEnabledAndResultsArray} from '../../../../src/server/helpers/util
 
 const {expect} = chai;
 
-describe('Testing getNextEnabledAndResultsArray', () => {
-	it('newResultsArray size should be 9 and nextEnabled true when arrayLength=10 and size=9', () => {
+describe('getNextEnabledAndResultsArray', () => {
+	it('should return an array of required length and nextEnabled:true when results.length > size', () => {
 		const array = Array(10).fill(0);
 		const size = 9;
 		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
@@ -14,7 +14,7 @@ describe('Testing getNextEnabledAndResultsArray', () => {
 		expect(nextEnabled).to.equal(true);
 	});
 
-	it('newResultsArray size should be 10 and nextEnabled false when arrayLength=10 and size=10', () => {
+	it('should return an array of required length and nextEnabled:false when results.length = size', () => {
 		const array = Array(10).fill(0);
 		const size = 10;
 		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
@@ -23,7 +23,7 @@ describe('Testing getNextEnabledAndResultsArray', () => {
 		expect(nextEnabled).to.equal(false);
 	});
 
-	it('newResultsArray size should be 9 and nextEnabled false when arrayLength=9 and size=10', () => {
+	it('should return an array of required length and nextEnabled:false when results.length < size', () => {
 		const array = Array(9).fill(0);
 		const size = 10;
 		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
@@ -32,7 +32,7 @@ describe('Testing getNextEnabledAndResultsArray', () => {
 		expect(nextEnabled).to.equal(false);
 	});
 
-	it('newResultsArray size should be 0 and nextEnabled false when arrayLength=0 and size=10', () => {
+	it('should return an array of required length and nextEnabled:false when results.length = 0', () => {
 		const array = Array(0).fill(0);
 		const size = 10;
 		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
@@ -41,7 +41,7 @@ describe('Testing getNextEnabledAndResultsArray', () => {
 		expect(nextEnabled).to.equal(false);
 	});
 
-	it('newResultsArray size should be 10 and nextEnabled true when arrayLength=20 and size=10', () => {
+	it('should return an array of required length and nextEnabled:true when results.length > size and results.length - size > 1', () => {
 		const array = Array(20).fill(0);
 		const size = 10;
 		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);

--- a/test/src/server/helpers/utils.js
+++ b/test/src/server/helpers/utils.js
@@ -33,11 +33,11 @@ describe('Testing getNextEnabledAndResultsArray', () => {
 	});
 
 	it('newResultsArray size should be 0 and nextEnabled false when arrayLength=0 and size=10', () => {
-		const array = Array(1).fill(0);
+		const array = Array(0).fill(0);
 		const size = 10;
 		const {newResultsArray, nextEnabled} = getNextEnabledAndResultsArray(array, size);
 
-		expect(newResultsArray.length).to.equal(1);
+		expect(newResultsArray.length).to.equal(0);
 		expect(nextEnabled).to.equal(false);
 	});
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-419

`Next` button in pager was wrongfully enabled in some special cases. 
https://beta.bookbrainz.org/editor/56/revisions?size=11

https://bookbrainz.org/search?q=harry+potter&size=1
Also when you visit this link, `nextEnabled` is disabled, it should be enabled. This PR solves this bug as well 

<!-- What are you trying to solve? -->


### Solution
This was because of `nextEnabled: data.length>=size`
For all the pages which use pagination - ./search, ./revisions, ./editor/id/revisions -  I checked `nextEnabled` by getting 1 more entity than `size`
Did the same for `triggerSearch` function as well. 
<!-- What does this PR do to fix the problem? -->


