### PR TITLE
Docker postgres no password error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - postgres
     volumes:
       - "./config/config.json:/home/bookbrainz/bookbrainz-site/config/config.json:ro"
-  
+
   postgres:
     container_name: postgres
     restart: unless-stopped
@@ -28,6 +28,7 @@ services:
       - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - postgres-data:/var/lib/postgresql/data
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://github.com/docker-library/postgres/issues/681
Due to a recent change in postgres, an empty password was throwing an error.

<!-- What are you trying to solve? -->


### Solution
Modified the environment to allow empty password
<!-- What does this PR do to fix the problem? -->


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
 docker-compose.yml
