### PR TITLE
removed disambiguation button and added disambiguation input as a def…

### DIFF
--- a/src/client/entity-editor/button-bar/actions.js
+++ b/src/client/entity-editor/button-bar/actions.js
@@ -19,7 +19,6 @@
 // @flow
 
 export const SHOW_ALIAS_EDITOR = 'SHOW_ALIAS_EDITOR';
-export const SHOW_DISAMBIGUATION = 'SHOW_DISAMBIGUATION';
 export const SHOW_IDENTIFIER_EDITOR = 'SHOW_IDENTIFIER_EDITOR';
 
 export type Action = {
@@ -40,18 +39,6 @@ export type Action = {
 export function showAliasEditor(): Action {
 	return {
 		type: SHOW_ALIAS_EDITOR
-	};
-}
-
-/**
- * Produces an action indicating that the disambiguation field should be
- * made visible.
- *
- * @returns {Action} The resulting SHOW_DISAMBIGUATION action.
- */
-export function showDisambiguation(): Action {
-	return {
-		type: SHOW_DISAMBIGUATION
 	};
 }
 

--- a/src/client/entity-editor/button-bar/button-bar.js
+++ b/src/client/entity-editor/button-bar/button-bar.js
@@ -38,17 +38,12 @@ import {connect} from 'react-redux';
  * (IdentifierButton).
  *
  * @param {Object} props - The properties passed to the component.
- * @param {boolean} props.disambiguationVisible - Whether or not the
- *        disambiguation is currently shown in the editor - used to disable the
- *       "Add disambiguation" button.
  * @param {number} props.numAliases - The number of aliases present in
  *        the AliasEditor - passed to the AliasButton component.
  * @param {number} props.numIdentifiers - The number of identifiers present in
  *        the IdentifierEditor - passed to the IdentiferButton component.
  * @param {Function} props.onAliasButtonClick - A function to be called when the
  *        AliasButton is clicked.
- * @param {Function} props.onDisambiguationButtonClick - A function to be
- *        called when the disambiguation button is clicked.
  * @param {Function} props.onIdentifierButtonClick - A function to be called
  *        when the IdentifierButton is clicked.
  * @returns {ReactElement} React element containing the rendered ButtonBar.

--- a/src/client/entity-editor/button-bar/button-bar.js
+++ b/src/client/entity-editor/button-bar/button-bar.js
@@ -16,10 +16,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {Button, Col, Row} from 'react-bootstrap';
+import {Col, Row} from 'react-bootstrap';
 import {
 	showAliasEditor,
-	showDisambiguation,
 	showIdentifierEditor
 } from './actions';
 import {validateAliases, validateIdentifiers} from '../validators/common';
@@ -56,43 +55,30 @@ import {connect} from 'react-redux';
  */
 function ButtonBar({
 	aliasesInvalid,
-	disambiguationVisible,
 	identifiersInvalid,
 	numAliases,
 	numIdentifiers,
 	onAliasButtonClick,
-	onDisambiguationButtonClick,
 	onIdentifierButtonClick
 }) {
 	return (
 		<div>
 			<form>
 				<Row className="margin-top-1">
-					<Col className="text-center" md={4}>
+					<Col className="text-center" md={6}>
 						<AliasButton
 							aliasesInvalid={aliasesInvalid}
 							numAliases={numAliases}
 							onClick={onAliasButtonClick}
 						/>
 					</Col>
-					<Col className="text-center" md={4}>
+					<Col className="text-center" md={6}>
 						<IdentifierButton
 							identifiersInvalid={identifiersInvalid}
 							numIdentifiers={numIdentifiers}
 							onClick={onIdentifierButtonClick}
 						/>
 					</Col>
-					{
-						!disambiguationVisible &&
-						<Col className="text-center" md={4}>
-							<Button
-								bsStyle="link"
-								onClick={onDisambiguationButtonClick}
-							>
-								Add disambiguation…
-							</Button>
-						</Col>
-					}
 				</Row>
 			</form>
 		</div>
@@ -101,20 +87,16 @@ function ButtonBar({
 ButtonBar.displayName = 'ButtonBar';
 ButtonBar.propTypes = {
 	aliasesInvalid: PropTypes.bool.isRequired,
-	disambiguationVisible: PropTypes.bool.isRequired,
 	identifiersInvalid: PropTypes.bool.isRequired,
 	numAliases: PropTypes.number.isRequired,
 	numIdentifiers: PropTypes.number.isRequired,
 	onAliasButtonClick: PropTypes.func.isRequired,
-	onDisambiguationButtonClick: PropTypes.func.isRequired,
 	onIdentifierButtonClick: PropTypes.func.isRequired
 };
 
 function mapStateToProps(rootState, {identifierTypes}) {
-	const state = rootState.get('buttonBar');
 	return {
 		aliasesInvalid: !validateAliases(rootState.get('aliasEditor')),
-		disambiguationVisible: state.get('disambiguationVisible'),
 		identifiersInvalid: !validateIdentifiers(
 			rootState.get('identifierEditor'), identifierTypes
 		),
@@ -129,7 +111,6 @@ function mapDispatchToProps(dispatch) {
 			dispatch(showAliasEditor());
 			dispatch(addAliasRow());
 		},
-		onDisambiguationButtonClick: () => dispatch(showDisambiguation()),
 		onIdentifierButtonClick: () => {
 			dispatch(showIdentifierEditor());
 			dispatch(addIdentifierRow());

--- a/src/client/entity-editor/button-bar/reducer.js
+++ b/src/client/entity-editor/button-bar/reducer.js
@@ -17,7 +17,7 @@
  */
 
 import {
-	SHOW_ALIAS_EDITOR, SHOW_DISAMBIGUATION, SHOW_IDENTIFIER_EDITOR
+	SHOW_ALIAS_EDITOR, SHOW_IDENTIFIER_EDITOR
 } from './actions';
 import {HIDE_ALIAS_EDITOR} from '../alias-editor/actions';
 import {HIDE_IDENTIFIER_EDITOR} from '../identifier-editor/actions';
@@ -27,14 +27,11 @@ import Immutable from 'immutable';
 function reducer(
 	state = Immutable.Map({
 		aliasEditorVisible: false,
-		disambiguationVisible: false,
 		identifierEditorVisible: false
 	}),
 	action
 ) {
 	switch (action.type) {
-		case SHOW_DISAMBIGUATION:
-			return state.set('disambiguationVisible', true);
 		case SHOW_ALIAS_EDITOR:
 			return state.set('aliasEditorVisible', true);
 		case HIDE_ALIAS_EDITOR:

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -55,8 +55,6 @@ import {getEntityDisambiguation} from '../../helpers/entity';
  * @param {Object} props - The properties passed to the component.
  * @param {string} props.disambiguationDefaultValue - The default value for the
  *        disambiguation field.
- * @param {boolean} props.disambiguationVisible - Whether or not the
- *        disambiguation field should be visible.
  * @param {Array} props.languageOptions - The list of possible languages for the
  *        entity name.
  * @param {string} props.languageValue - The ID of the language currently
@@ -222,24 +220,22 @@ class NameSection extends React.Component {
 							/>
 						</Col>
 					</Row>
-					{
-						<Row>
-							<Col md={6} mdOffset={3}>
-								<DisambiguationField
-									defaultValue={disambiguationDefaultValue}
-									error={isRequiredDisambiguationEmpty(
-										warnIfExists,
-										disambiguationDefaultValue
-									) ||
-									!validateNameSectionDisambiguation(
-										disambiguationDefaultValue
-									)}
-									required={warnIfExists}
-									onChange={onDisambiguationChange}
-								/>
-							</Col>
-						</Row>
-					}
+					<Row>
+						<Col md={6} mdOffset={3}>
+							<DisambiguationField
+								defaultValue={disambiguationDefaultValue}
+								error={isRequiredDisambiguationEmpty(
+									warnIfExists,
+									disambiguationDefaultValue
+								) ||
+								!validateNameSectionDisambiguation(
+									disambiguationDefaultValue
+								)}
+								required={warnIfExists}
+								onChange={onDisambiguationChange}
+							/>
+						</Col>
+					</Row>
 				</form>
 			</div>
 		);

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -113,7 +113,6 @@ class NameSection extends React.Component {
 	render() {
 		const {
 			disambiguationDefaultValue,
-			disambiguationVisible,
 			entityType,
 			exactMatches,
 			languageOptions,
@@ -224,7 +223,6 @@ class NameSection extends React.Component {
 						</Col>
 					</Row>
 					{
-						(warnIfExists || disambiguationVisible) &&
 						<Row>
 							<Col md={6} mdOffset={3}>
 								<DisambiguationField
@@ -251,7 +249,6 @@ NameSection.displayName = 'NameSection';
 NameSection.propTypes = {
 	action: PropTypes.string,
 	disambiguationDefaultValue: PropTypes.string,
-	disambiguationVisible: PropTypes.bool.isRequired,
 	entityType: entityTypeProperty.isRequired, // eslint-disable-line react/no-typos, max-len
 	exactMatches: PropTypes.array,
 	languageOptions: PropTypes.array.isRequired,
@@ -288,8 +285,6 @@ function mapStateToProps(rootState) {
 	);
 	return {
 		disambiguationDefaultValue: state.get('disambiguation'),
-		disambiguationVisible:
-			rootState.getIn(['buttonBar', 'disambiguationVisible']),
 		exactMatches: state.get('exactMatches'),
 		languageValue: state.get('language'),
 		nameValue: state.get('name'),

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -120,7 +120,6 @@ function authorToFormState(author) {
 
 	const buttonBar = {
 		aliasEditorVisible: false,
-		disambiguationVisible: Boolean(author.disambiguation),
 		identifierEditorVisible: false
 	};
 

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -130,7 +130,6 @@ function editionGroupToFormState(editionGroup) {
 
 	const buttonBar = {
 		aliasEditorVisible: false,
-		disambiguationVisible: Boolean(editionGroup.disambiguation),
 		identifierEditorVisible: false
 	};
 

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -221,7 +221,6 @@ function editionToFormState(edition) {
 
 	const buttonBar = {
 		aliasEditorVisible: false,
-		disambiguationVisible: Boolean(edition.disambiguation),
 		identifierEditorVisible: false
 	};
 

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -137,7 +137,6 @@ function publisherToFormState(publisher) {
 
 	const buttonBar = {
 		aliasEditorVisible: false,
-		disambiguationVisible: Boolean(publisher.disambiguation),
 		identifierEditorVisible: false
 	};
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -174,7 +174,6 @@ function workToFormState(work) {
 
 	const buttonBar = {
 		aliasEditorVisible: false,
-		disambiguationVisible: Boolean(work.disambiguation),
 		identifierEditorVisible: false
 	};
 


### PR DESCRIPTION
### Problem
as discussed in https://github.com/bookbrainz/bookbrainz-site/pull/376 ,
disambiguation buton is obsolete and disambiguation field must pe present all the time on editor page .


### Solution
removed the disambiguation button from button bar , and added disambiguation input as default in editor section.


### Areas of Impact
src/client/components/entity-link.js
src/client/entity-editor/button-bar/button-bar.js
src/client/entity-editor/button-bar/reducer.js
src/client/entity-editor/name-section/name-section.js
src/server/routes/entity/author.js
src/server/routes/entity/work.js