### PR TITLE
Default alias selection

### DIFF
--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -112,7 +112,7 @@ function authorToFormState(author) {
 			language: languageId
 		})) : [];
 
-	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(author.aliasSet);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -108,12 +108,6 @@ router.get(
 	}
 );
 
-
-function getDefaultAliasIndex(aliases) {
-	const index = aliases.findIndex((alias) => alias.default);
-	return index > 0 ? index : 0;
-}
-
 function editionGroupToFormState(editionGroup) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = editionGroup.aliasSet ?
@@ -122,7 +116,7 @@ function editionGroupToFormState(editionGroup) {
 			language: languageId
 		})) : [];
 
-	const defaultAliasIndex = getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(editionGroup.aliasSet);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -200,11 +200,6 @@ router.get(
 );
 
 
-function getDefaultAliasIndex(aliases) {
-	const index = aliases.findIndex((alias) => alias.default);
-	return index > 0 ? index : 0;
-}
-
 function editionToFormState(edition) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = edition.aliasSet ?
@@ -213,7 +208,7 @@ function editionToFormState(edition) {
 			language: languageId
 		})) : [];
 
-	const defaultAliasIndex = getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(edition.aliasSet);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -847,8 +847,34 @@ export function constructRelationships(relationshipSection) {
 	);
 }
 
-export function getDefaultAliasIndex(aliases) {
-	const index = aliases.findIndex((alias) => alias.default);
+/**
+ * Returns the index of the default alias if defined in the aliasSet.
+ * If there is no defaultAliasId, return the first alias where default = true.
+ * Returns null if there are no aliases in the set.
+ * @param {Object} aliasSet - The entity's aliasSet returned by the ORM
+ * @param {Object[]} aliasSet.aliases - The array of aliases contained in the set
+ * @param {string} aliasSet.defaultAliasId - The id of the set's default alias
+ * @returns {?number} The index of the default alias, or 0; returns null if 0 aliases in set
+ */
+export function getDefaultAliasIndex(aliasSet) {
+	if (_.isNil(aliasSet)) {
+		return null;
+	}
+	const {aliases, defaultAliasId} = aliasSet;
+	if (!aliases || !aliases.length) {
+		return null;
+	}
+	let index;
+	if (!_.isNil(defaultAliasId) && isFinite(defaultAliasId)) {
+		let defaultAliasIdNumber = defaultAliasId;
+		if (_.isString(defaultAliasId)) {
+			defaultAliasIdNumber = Number(defaultAliasId);
+		}
+		index = aliases.findIndex((alias) => alias.id === defaultAliasIdNumber);
+	}
+	else {
+		index = aliases.findIndex((alias) => alias.default);
+	}
 	return index > 0 ? index : 0;
 }
 

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -129,7 +129,7 @@ function publisherToFormState(publisher) {
 			language: languageId
 		})) : [];
 
-	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(publisher.aliasSet);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -153,11 +153,6 @@ router.get(
 	}
 );
 
-function getDefaultAliasIndex(aliases) {
-	const index = aliases.findIndex((alias) => alias.default);
-	return index > 0 ? index : 0;
-}
-
 function workToFormState(work) {
 	/** The front-end expects a language id rather than the language object. */
 	const aliases = work.aliasSet ?
@@ -166,7 +161,7 @@ function workToFormState(work) {
 			language: languageId
 		})) : [];
 
-	const defaultAliasIndex = getDefaultAliasIndex(aliases);
+	const defaultAliasIndex = entityRoutes.getDefaultAliasIndex(work.aliasSet);
 	const defaultAliasList = aliases.splice(defaultAliasIndex, 1);
 
 	const aliasEditor = {};

--- a/test/src/server/routes/entity/entity.js
+++ b/test/src/server/routes/entity/entity.js
@@ -1,0 +1,82 @@
+import chai from 'chai';
+import {getDefaultAliasIndex} from '../../../../../src/server/routes/entity/entity';
+
+
+const {expect} = chai;
+
+describe('getDefaultAliasIndex', () => {
+	const defaultAlias = {
+		default: true,
+		id: 33,
+		name: 'Bob'
+	};
+	const randomAliases = [
+		{
+			default: false,
+			id: 1,
+			name: 'Bob'
+		},
+		{
+			default: false,
+			id: 2,
+			name: 'John'
+		},
+		{
+			default: false,
+			id: 100,
+			name: 'Fnord'
+		}
+	];
+
+	it('should return null if there is not aliasSet', () => {
+		expect(getDefaultAliasIndex()).to.be.null;
+		expect(getDefaultAliasIndex(null)).to.be.null;
+		// eslint-disable-next-line no-undefined
+		expect(getDefaultAliasIndex(undefined)).to.be.null;
+	});
+
+	it('should return null if there are no aliases in the aliasSet', () => {
+		const aliasSet = {
+			aliases: null
+		};
+		expect(getDefaultAliasIndex(aliasSet)).to.be.null;
+		aliasSet.aliases = [];
+		expect(getDefaultAliasIndex(aliasSet)).to.be.null;
+	});
+
+	it('should return 0 if there is no defaultAliasId and no alias marked as default', () => {
+		const aliasSet = {
+			aliases: randomAliases,
+			defaultAliasId: null
+		};
+		expect(getDefaultAliasIndex(aliasSet)).to.equal(0);
+	});
+
+	it('should return the index of the first alias marked as default if there is no defaultAliasId', () => {
+		const aliasSet = {
+			aliases: [
+				randomAliases[0],
+				randomAliases[1],
+				defaultAlias,
+				randomAliases[2],
+				defaultAlias
+			],
+			defaultAliasId: null
+		};
+		expect(getDefaultAliasIndex(aliasSet)).to.equal(2);
+	});
+	it("should return the index of the alias matching the set's defaultAliasId", () => {
+		const aliasSet = {
+			aliases: [...randomAliases, defaultAlias],
+			defaultAliasId: 100
+		};
+		expect(getDefaultAliasIndex(aliasSet)).to.equal(2);
+	});
+	it("should return the index of the alias matching the set's defaultAliasId if it is a string", () => {
+		const aliasSet = {
+			aliases: [...randomAliases, defaultAlias],
+			defaultAliasId: '100'
+		};
+		expect(getDefaultAliasIndex(aliasSet)).to.equal(2);
+	});
+});


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
The defaultAlias was not necessarily the one appearing in the main nameSection on the entity editor page, while showing correctly both on the display page and API requests


### Solution
The problem hence must come from how we transform a DB entry (or its ORM representation) into the entity-editor page state.
Sure enough, it was just trying to get the first alias in the aliasSet that has 'default' set to true, which turned out to be a problem when merging: I ended up with multiple aliases with default set to true (one for each entity merged) but only one corresponding to the aliasSet's defaultAliasId.

I reworked the utility to be more resilient and also wrote a few tests for it while I was there.

It also turned out most entities used an identical copy of the utility each in its page, instead of all using the same one. Fixed that.

### Areas of Impact

`getDefaultAliasIndex` utility