### PR TITLE
Don’t open search results in new tab

### DIFF
--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -85,7 +85,7 @@ function SearchResults(props) {
 					</td>
 				}
 				<td>
-					<a href={link} rel="noopener noreferrer" target="_blank">
+					<a href={link}>
 						{name} {disambiguation}
 					</a>
 				</td>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/projects/BB/issues/BB-431


On the search page, links to results are currently opening in a new tab which is a bit frustrating, breaking tab history when you only go to a single search result.

In most (all?) browsers, there’s no way to reasonably circumvent this, while Ctrl+click is a common(/universal?) way to make links open in new tabs when you do want that behaviour.

<!-- What are you trying to solve? -->




### Areas of Impact
src/client/components/pages/parts/search-results.js 
<!-- What parts of the codebase and which behaviors are affected? -->
