### PR TITLE
Multiple entities not visible in revision table

### DIFF
--- a/src/server/helpers/utils.js
+++ b/src/server/helpers/utils.js
@@ -81,6 +81,8 @@ export async function getAssociatedEntityRevisions(revisions, orm) {
 				qb.whereIn('id', revisionIDs);
 			})
 			.fetchAll({
+				merge: false,
+				remove: false,
 				require: false,
 				withRelated: [
 					'data.aliasSet.defaultAlias'


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Revisions page shows only one affected entity per type
<!-- What are you trying to solve? -->


### Solution
Because there were multiple rows with same 'id' in EntityRevision table (work_revision, author_revision, etc) , `merge: false` and `remove: false` had to be used to multiple rows.
<!-- What does this PR do to fix the problem? -->
![Screenshot_2020-03-11 BookBrainz – The Open Book Database](https://user-images.githubusercontent.com/45737735/76422339-0b75c580-63cb-11ea-81ea-f9d7fc602cc9.png)


### Areas of Impact
src/server/helpers/utils.js
<!-- What parts of the codebase and which behaviors are affected? -->
