### PR TITLE
BB-418: FontAwesomeIcon Alignment  

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -206,6 +206,7 @@ body {
  */
 .svg-inline--fa{
 	height: 1em;
+	vertical-align: -.125em;
 }
 
 /* Sticky footer styling */


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
FontAwesome icons were not aligned properly
<!-- What are you trying to solve? -->


### Solution
Added `vertical-align: -.125em` for icons
<!-- What does this PR do to fix the problem? -->


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/client/stylesheets/style.less
