### PR TITLE
BB-443: Revision Notes Ordering

### DIFF
--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -267,7 +267,14 @@ async function getOrderedRevisionForEditorPage(from, size, req) {
 		.fetchPage({
 			limit: size,
 			offset: from,
-			withRelated: ['notes', 'notes.author']
+			withRelated: [
+				{
+					'notes'(q) {
+						q.orderBy('note.posted_at');
+					}
+				},
+				'notes.author'
+			]
 		});
 	const revisionsJSON = revisions.toJSON();
 	const formattedRevisions = revisionsJSON.map(rev => {

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -194,7 +194,14 @@ router.get('/:id', (req, res, next) => {
 	const revisionPromise = new Revision({id: req.params.id})
 		.fetch({
 			withRelated: [
-				'author', 'author.titleUnlock.title', 'notes', 'notes.author',
+				'author',
+				'author.titleUnlock.title',
+				{
+					'notes'(q) {
+						q.orderBy('note.posted_at');
+					}
+				},
+				'notes.author',
 				'notes.author.titleUnlock.title'
 			]
 		})


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/projects/BB/issues/BB-443
Revision Notes were not sorted.
![Screenshot_2020-03-16 BookBrainz – The Open Book Database(3)](https://user-images.githubusercontent.com/45737735/76746600-cae8c400-679d-11ea-9ba7-bc445f7cb27a.png)
![Screenshot_2020-03-16 BookBrainz – The Open Book Database(2)](https://user-images.githubusercontent.com/45737735/76746607-ce7c4b00-679d-11ea-8229-e7210a18959d.png)

<!-- What are you trying to solve? -->


### Solution

Sorted the notes while fetching them. </br>
![Screenshot_2020-03-16 BookBrainz – The Open Book Database(1)](https://user-images.githubusercontent.com/45737735/76746680-e522a200-679d-11ea-9ee1-c51f73e8307d.png)
![Screenshot_2020-03-16 BookBrainz – The Open Book Database](https://user-images.githubusercontent.com/45737735/76746692-e94ebf80-679d-11ea-89b6-17086c9a9b38.png)

<!-- What does this PR do to fix the problem? -->


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/server/routes/editor.js
src/server/routes/revision.js