### PR TITLE
Elasticsearch APIversion fix to 5.6

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -30,7 +30,7 @@
 	"search": {
 		"host": "elasticsearch:9200",
 		"httpAuth": "elastic:changeme",
-		"apiVersion": "5.5",
+		"apiVersion": "5.6",
 		"maxRetries": -1,
 		"deadTimeout": 2000
 	}

--- a/config/config.local.json.example
+++ b/config/config.local.json.example
@@ -30,7 +30,7 @@
 	"search": {
 		"host": "localhost:9200",
 		"httpAuth": "elastic:changeme",
-		"apiVersion": "5.5",
+		"apiVersion": "5.6",
 		"maxRetries": -1,
 		"deadTimeout": 2000
 	}


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Elasticsearch does not work as the older version is getiing installed 

### Solution
<!-- What does this PR do to fix the problem? -->
Changes the elasticsearch api version to .56

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Changes 2 config files
