### PR TITLE
fix(achievement): UI improvement in achievement tab

### DIFF
--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -125,7 +125,9 @@ class EditorAchievementTab extends React.Component {
 						<DragAndDrop name="rank3"/>
 					</div>
 					<div className="form-group">
-						<span>
+						<span style={{
+							marginLeft: '30px'
+						}}>
 							<button
 								className="btn btn-default"
 								type="submit"
@@ -158,6 +160,7 @@ class EditorAchievementTab extends React.Component {
 										const updatedStyle = {
 											...style,
 											background: 'white',
+											borderBottom: '1px solid',
 											flex: '1',
 											marginTop: STICKY_TOP_MARGIN,
 											zIndex: 10
@@ -170,7 +173,7 @@ class EditorAchievementTab extends React.Component {
 									}
 								}
 							</Sticky>
-							<div style={{zIndex: 1}}>
+							<div style={{zIndex: 1, marginLeft: '21px', marginRight: '21px'}}>
 								<div className="h1">Unlocked Achievements</div>
 								{achievements}
 								<div className="h1">Locked Achievements</div>
@@ -197,3 +200,4 @@ EditorAchievementTab.propTypes = {
 };
 
 export default EditorAchievementTab;
+

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -125,21 +125,11 @@ class EditorAchievementTab extends React.Component {
 						<DragAndDrop name="rank3"/>
 					</div>
 					<div className="form-group">
-						<span style={{
-							marginLeft: '30px'
-						}}>
-							<button
-								className="btn btn-default"
-								type="submit"
-							>
+						<span style={{ marginLeft: '30px'}}>
+							<button className="btn btn-default" type="submit" >
 								Update
 							</button>
-							<p
-								style={{
-									display: 'inline-block',
-									marginLeft: '10px'
-								}}
-							>
+							<p style={{ display: 'inline-block', marginLeft: '10px'}} >
 								click badge to unset
 							</p>
 						</span>

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -173,7 +173,7 @@ class EditorAchievementTab extends React.Component {
 									}
 								}
 							</Sticky>
-							<div style={{zIndex: 1, marginLeft: '21px', marginRight: '21px'}}>
+							<div style={{marginLeft: '21px', marginRight: '21px', zIndex: 1}}>
 								<div className="h1">Unlocked Achievements</div>
 								{achievements}
 								<div className="h1">Locked Achievements</div>

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -125,11 +125,11 @@ class EditorAchievementTab extends React.Component {
 						<DragAndDrop name="rank3"/>
 					</div>
 					<div className="form-group">
-						<span style={{ marginLeft: '30px'}}>
-							<button className="btn btn-default" type="submit" >
+						<span style={{marginLeft: '30px'}}>
+							<button className="btn btn-default" type="submit">
 								Update
 							</button>
-							<p style={{ display: 'inline-block', marginLeft: '10px'}} >
+							<p style={{display: 'inline-block', marginLeft: '10px'}}>
 								click badge to unset
 							</p>
 						</span>

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -115,28 +115,23 @@ class EditorAchievementTab extends React.Component {
 		if (this.props.isOwner) {
 			rankUpdate = (
 				<form
-					className="form-horizontal"
+					className="form-horizontal padding-bottom-1"
 					id="rankSelectForm"
 					method="post"
-					className="padding-bottom-1"
 				>
 					<div className="dnd-container">
 						<DragAndDrop name="rank1"/>
 						<DragAndDrop name="rank2"/>
 						<DragAndDrop name="rank3"/>
 					</div>
-					
+					<span className="margin-left-1">
+						<button className="btn btn-success" type="submit">
+							Update
+						</button>
 						<span className="margin-left-1">
-							<button className="btn btn-success" type="submit">
-								Update
-							</button>
-							<span className="margin-left-1">
-								click badge to unset
-							</span>
-
-
+							click badge to unset
 						</span>
-					
+					</span>
 				</form>
 			);
 		}
@@ -166,7 +161,7 @@ class EditorAchievementTab extends React.Component {
 									}
 								}
 							</Sticky>
-							<div className="margin-left-2 margin-right-2"  style={{zIndex: 1}}>
+							<div className="margin-left-2 margin-right-2" style={{zIndex: 1}}>
 								<div className="h1">Unlocked Achievements</div>
 								{achievements}
 								<div className="h1">Locked Achievements</div>

--- a/src/client/components/pages/parts/editor-achievements.js
+++ b/src/client/components/pages/parts/editor-achievements.js
@@ -118,22 +118,25 @@ class EditorAchievementTab extends React.Component {
 					className="form-horizontal"
 					id="rankSelectForm"
 					method="post"
+					className="padding-bottom-1"
 				>
-					<div className="row dnd-container form-group">
+					<div className="dnd-container">
 						<DragAndDrop name="rank1"/>
 						<DragAndDrop name="rank2"/>
 						<DragAndDrop name="rank3"/>
 					</div>
-					<div className="form-group">
-						<span style={{marginLeft: '30px'}}>
-							<button className="btn btn-default" type="submit">
+					
+						<span className="margin-left-1">
+							<button className="btn btn-success" type="submit">
 								Update
 							</button>
-							<p style={{display: 'inline-block', marginLeft: '10px'}}>
+							<span className="margin-left-1">
 								click badge to unset
-							</p>
+							</span>
+
+
 						</span>
-					</div>
+					
 				</form>
 			);
 		}
@@ -150,7 +153,7 @@ class EditorAchievementTab extends React.Component {
 										const updatedStyle = {
 											...style,
 											background: 'white',
-											borderBottom: '1px solid',
+											borderBottom: '1px solid #ebe2df',
 											flex: '1',
 											marginTop: STICKY_TOP_MARGIN,
 											zIndex: 10
@@ -163,7 +166,7 @@ class EditorAchievementTab extends React.Component {
 									}
 								}
 							</Sticky>
-							<div style={{marginLeft: '21px', marginRight: '21px', zIndex: 1}}>
+							<div className="margin-left-2 margin-right-2"  style={{zIndex: 1}}>
 								<div className="h1">Unlocked Achievements</div>
 								{achievements}
 								<div className="h1">Locked Achievements</div>
@@ -190,4 +193,3 @@ EditorAchievementTab.propTypes = {
 };
 
 export default EditorAchievementTab;
-


### PR DESCRIPTION
noticed a little discontinuity under the achievement tab in the profile page. The background behind the update button is little discontinuous which causes a trouble for eyes while scrolling. Just changed some margins to make the content a little more clear.

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
fixing ticket: BB-447


### Solution
<!-- What does this PR do to fix the problem? -->


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
