### PR TITLE
BB-435 (test): Allow creation of multiple test entities

### DIFF
--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -252,8 +252,9 @@ export async function createEdition(optionalBBID) {
 
 	await new Entity({bbid, type: 'Edition'})
 		.save(null, {method: 'insert'});
-	await new Edition({...entityAttribs, bbid})
+	const edition = await new Edition({...entityAttribs, bbid})
 		.save(null, {method: 'insert'});
+	return edition;
 }
 
 export async function createWork(optionalBBID) {
@@ -270,8 +271,9 @@ export async function createWork(optionalBBID) {
 	};
 	await new WorkType({id: workAttribs.typeId, label: `Work Type ${workAttribs.typeId}`})
 		.save(null, {method: 'insert'});
-	await new Work({...entityAttribs, ...workAttribs})
+	const work = await new Work({...entityAttribs, ...workAttribs})
 		.save(null, {method: 'insert'});
+	return work;
 }
 
 export async function createEditionGroup(optionalBBID) {
@@ -285,8 +287,9 @@ export async function createEditionGroup(optionalBBID) {
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'EditionGroup'})
 		.save(null, {method: 'insert'});
-	await new EditionGroup({...entityAttribs, ...editionGroupAttribs})
+	const editionGroup = await new EditionGroup({...entityAttribs, ...editionGroupAttribs})
 		.save(null, {method: 'insert'});
+	return editionGroup;
 }
 
 export async function createAuthor(optionalBBID) {
@@ -313,8 +316,9 @@ export async function createAuthor(optionalBBID) {
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'Author'})
 		.save(null, {method: 'insert'});
-	await new Author({...entityAttribs, ...authorAttribs})
+	const author = await new Author({...entityAttribs, ...authorAttribs})
 		.save(null, {method: 'insert'});
+	return author;
 }
 
 export async function createPublisher(optionalBBID) {
@@ -338,8 +342,9 @@ export async function createPublisher(optionalBBID) {
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'Publisher'})
 		.save(null, {method: 'insert'});
-	await new Publisher({...entityAttribs, ...publisherAttribs})
+	const publisher = await new Publisher({...entityAttribs, ...publisherAttribs})
 		.save(null, {method: 'insert'});
+	return publisher;
 }
 
 export function truncateEntities() {

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -268,7 +268,7 @@ export async function createWork(optionalBBID) {
 		languageSetId,
 		typeId: random.number()
 	};
-	await new WorkType({id: workAttribs.typeId, label: 'Work Type 1'})
+	await new WorkType({id: workAttribs.typeId, label: `Work Type ${workAttribs.typeId}`})
 		.save(null, {method: 'insert'});
 	await new Work({...entityAttribs, ...workAttribs})
 		.save(null, {method: 'insert'});
@@ -281,7 +281,7 @@ export async function createEditionGroup(optionalBBID) {
 		bbid,
 		typeId: random.number()
 	};
-	await new EditionGroupType({id: editionGroupAttribs.typeId, label: 'Edition Group Type 1'})
+	await new EditionGroupType({id: editionGroupAttribs.typeId, label: `Edition Group Type ${editionGroupAttribs.typeId}`})
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'EditionGroup'})
 		.save(null, {method: 'insert'});
@@ -309,7 +309,7 @@ export async function createAuthor(optionalBBID) {
 	};
 	await new Area({gid: uuidv4(), id: areaId, name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
-	await new AuthorType({id: authorAttribs.typeId, label: 'Author Type 1'})
+	await new AuthorType({id: authorAttribs.typeId, label: `Author Type ${authorAttribs.typeId}`})
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'Author'})
 		.save(null, {method: 'insert'});
@@ -334,7 +334,7 @@ export async function createPublisher(optionalBBID) {
 	};
 	await new Area({gid: uuidv4(), id: publisherAttribs.areaId, name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
-	await new PublisherType({id: publisherAttribs.typeId, label: 'Publisher Type 1'})
+	await new PublisherType({id: publisherAttribs.typeId, label: `Publisher Type ${publisherAttribs.typeId}`})
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'Publisher'})
 		.save(null, {method: 'insert'});

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+/* eslint-disable no-empty */
 /*
  * Copyright (C) 2019  Nicolas Pelletier
  *
@@ -16,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import {internet, random} from 'faker';
 import orm from '../bookbrainz-data';
 // eslint-disable-next-line import/no-internal-modules
 import uuidv4 from 'uuid/v4';
@@ -107,33 +110,52 @@ const entityAttribs = {
 };
 
 export async function createEditor() {
+	editorTypeAttribs.id = random.number();
 	await new EditorType(editorTypeAttribs)
 		.save(null, {method: 'insert'});
-	await new Gender({...setData, name: 'test'})
+	const gender = await new Gender({...setData, id: random.number(), name: 'test'})
 		.save(null, {method: 'insert'});
+
+	editorAttribs.id = random.number();
+	editorAttribs.genderId = gender.get('id');
+	editorAttribs.typeId = editorTypeAttribs.id;
+	editorAttribs.name = internet.userName();
+	editorAttribs.metabrainzUserId = random.number();
+	editorAttribs.cachedMetabrainzName = editorAttribs.name;
+
 	await new Editor(editorAttribs)
 		.save(null, {method: 'insert'});
 }
 
 async function createAliasAndAliasSet() {
+	aliasData.languageId = random.number();
 	await new Language({...languageAttribs, id: aliasData.languageId})
+		.save(null, {method: 'insert'})
+		.catch(console.log);
+	const alias = await new Alias({...aliasData, id: random.number()})
 		.save(null, {method: 'insert'});
-	const alias = await new Alias(aliasData)
-		.save(null, {method: 'insert'});
+
+	entityAttribs.aliasSetId = random.number();
 	await new AliasSet({
-		...setData,
-		defaultAliasId: alias.get('id')
+		defaultAliasId: alias.get('id'),
+		id: entityAttribs.aliasSetId
 	})
 		.save(null, {method: 'insert'})
 		.then((model) => model.aliases().attach([alias]));
 }
 
 async function createIdentifierAndIdentifierSet() {
+	identifierTypeData.id = random.number();
 	await new IdentifierType(identifierTypeData)
+		.save(null, {method: 'insert'})
+		.catch(console.log);
+
+	identifierData.typeId = identifierTypeData.id;
+	const identifier = await new Identifier({...identifierData, id: random.number()})
 		.save(null, {method: 'insert'});
-	const identifier = await new Identifier(identifierData)
-		.save(null, {method: 'insert'});
-	await new IdentifierSet(setData)
+
+	entityAttribs.identifierSetId = random.number();
+	await new IdentifierSet({id: entityAttribs.identifierSetId})
 		.save(null, {method: 'insert'})
 		.then((model) => model.identifiers().attach([identifier]));
 }
@@ -154,14 +176,20 @@ async function createRelationshipSet(sourceBbid, targetBbid, entityType, targetE
 		await new Entity({bbid: safeSourceBbid, type: entityType || 'Author'})
 			.save(null, {method: 'insert'});
 	}
+	relationshipTypeData.id = random.number();
 	await new RelationshipType(relationshipTypeData)
-		.save(null, {method: 'insert'});
+		.save(null, {method: 'insert'})
+		.catch(console.log);
 	await new Entity({bbid: safeTargetBbid, type: targetEntityType || 'Author'})
 		.save(null, {method: 'insert'});
 
+	relationshipData.typeId = relationshipTypeData.id;
+	relationshipData.id = random.number();
 	const relationship = await new Relationship(relationshipData)
 		.save(null, {method: 'insert'});
-	await new RelationshipSet(setData)
+
+	entityAttribs.relationshipSetId = random.number();
+	await new RelationshipSet({id: entityAttribs.relationshipSetId})
 		.save(null, {method: 'insert'})
 		.then(
 			(model) =>
@@ -189,15 +217,17 @@ async function createRelationshipAndRelationshipSet(sourceBbid, targetBbid, targ
 
 async function createLanguageSet() {
 	// Create relationships here if you need them
-	await new Language(languageAttribs)
+	const language1Id = random.number();
+	const language2Id = random.number();
+	await new Language({...languageAttribs, id: language1Id})
 		.save(null, {method: 'insert'});
-	await new Language({...languageAttribs, id: 2})
+	await new Language({...languageAttribs, id: language2Id})
 		.save(null, {method: 'insert'});
 	const languageSet = await updateLanguageSet(
 		orm,
 		null,
 		null,
-		[{id: 1}, {id: 2}]
+		[{id: language1Id}, {id: language2Id}]
 	);
 	return languageSet.get('id');
 }
@@ -212,17 +242,24 @@ async function createEntityPrerequisites(entityBbid) {
 	await createIdentifierAndIdentifierSet();
 	await createRelationshipSet(entityBbid);
 
-	await new Disambiguation({
-		...setData,
-		comment: 'Test Disambiguation'
+	const disambiguation = await new Disambiguation({
+		comment: 'Test Disambiguation',
+		id: random.number()
 	})
 		.save(null, {method: 'insert'});
+	entityAttribs.disambiguationId = disambiguation.get('id');
+
+	revisionAttribs.id = random.number();
+	revisionAttribs.authorId = editorAttribs.id;
 	await new Revision(revisionAttribs)
 		.save(null, {method: 'insert'});
+	entityAttribs.revisionId = revisionAttribs.id;
+
+	entityAttribs.annotationId = random.number();
 	await new Annotation({
-		...setData,
 		content: 'Test Annotation',
-		lastRevisionId: 1
+		id: entityAttribs.annotationId,
+		lastRevisionId: revisionAttribs.id
 	})
 		.save(null, {method: 'insert'});
 }
@@ -248,9 +285,9 @@ export async function createWork(optionalBBID) {
 	const workAttribs = {
 		bbid,
 		languageSetId,
-		typeId: setData.id
+		typeId: random.number()
 	};
-	await new WorkType({...setData, label: 'Work Type 1'})
+	await new WorkType({id: workAttribs.typeId, label: 'Work Type 1'})
 		.save(null, {method: 'insert'});
 	await new Work({...entityAttribs, ...workAttribs})
 		.save(null, {method: 'insert'});
@@ -261,9 +298,9 @@ export async function createEditionGroup(optionalBBID) {
 	await createEntityPrerequisites();
 	const editionGroupAttribs = {
 		bbid,
-		typeId: setData.id
+		typeId: random.number()
 	};
-	await new EditionGroupType({...setData, label: 'Edition Group Type 1'})
+	await new EditionGroupType({id: editionGroupAttribs.typeId, label: 'Edition Group Type 1'})
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'EditionGroup'})
 		.save(null, {method: 'insert'});
@@ -274,23 +311,24 @@ export async function createEditionGroup(optionalBBID) {
 export async function createAuthor(optionalBBID) {
 	const bbid = optionalBBID || uuidv4();
 	await createEntityPrerequisites();
+	const areaId = random.number();
 	const authorAttribs = {
 		bbid,
-		beginAreaId: setData.id,
+		beginAreaId: areaId,
 		beginDay: 25,
 		beginMonth: 12,
 		beginYear: 2000,
-		endAreaId: setData.id,
+		endAreaId: areaId,
 		endDay: 10,
 		endMonth: 5,
 		endYear: 2012,
 		ended: true,
-		genderId: setData.id,
-		typeId: setData.id
+		genderId: editorAttribs.genderId,
+		typeId: random.number()
 	};
-	await new Area({...setData, gid: uuidv4(), name: 'Rlyeh'})
+	await new Area({gid: uuidv4(), id: areaId, name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
-	await new AuthorType({...setData, label: 'Author Type 1'})
+	await new AuthorType({id: authorAttribs.typeId, label: 'Author Type 1'})
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'Author'})
 		.save(null, {method: 'insert'});
@@ -302,7 +340,7 @@ export async function createPublisher(optionalBBID) {
 	const bbid = optionalBBID || uuidv4();
 	await createEntityPrerequisites();
 	const publisherAttribs = {
-		areaId: setData.id,
+		areaId: random.number(),
 		bbid,
 		beginDay: 25,
 		beginMonth: 12,
@@ -311,11 +349,11 @@ export async function createPublisher(optionalBBID) {
 		endMonth: 5,
 		endYear: 2012,
 		ended: true,
-		typeId: setData.id
+		typeId: random.number()
 	};
-	await new Area({...setData, gid: uuidv4(), name: 'Rlyeh'})
+	await new Area({gid: uuidv4(), id: publisherAttribs.areaId, name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
-	await new PublisherType({...setData, label: 'Publisher Type 1'})
+	await new PublisherType({id: publisherAttribs.typeId, label: 'Publisher Type 1'})
 		.save(null, {method: 'insert'});
 	await new Entity({bbid, type: 'Publisher'})
 		.save(null, {method: 'insert'});

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-/* eslint-disable no-empty */
 /*
  * Copyright (C) 2019  Nicolas Pelletier
  *
@@ -197,23 +196,6 @@ async function createRelationshipSet(sourceBbid, targetBbid, entityType, targetE
 		);
 }
 
-async function createRelationshipAndRelationshipSet(sourceBbid, targetBbid, targetEntityType) {
-	const relationshipData = {
-		id: 1,
-		sourceBbid,
-		targetBbid,
-		typeId: 1
-	};
-	await new Entity({bbid: targetBbid, type: targetEntityType})
-		.save(null, {method: 'insert'});
-	await new RelationshipType(relationshipTypeData)
-		.save(null, {method: 'insert'});
-	const relationship = await new Relationship(relationshipData)
-		.save(null, {method: 'insert'});
-	await new RelationshipSet({id: 42})
-		.save(null, {method: 'insert'})
-		.then((model) => model.relationships().attach([relationship]));
-}
 
 async function createLanguageSet() {
 	// Create relationships here if you need them
@@ -279,7 +261,6 @@ export async function createWork(optionalBBID) {
 	await new Entity({bbid, type: 'Work'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid);
-	// await createRelationshipAndRelationshipSet(bbid, uuidv4(), 'Author');
 	const languageSetId = await createLanguageSet();
 
 	const workAttribs = {


### PR DESCRIPTION
### Problem
Errors are thrown in various places in create-entities test helpers when trying to create multiple test entities because of duplicate IDs.


### Solution
Instead of a static id, create a random ID every time where needed.

Also cleaned up unused function;

### Areas of Impact
test/test-helpers/create-entities.js
