### PR TITLE
Fix(aliases): add legal and pseudonym label in aliases

### DIFF
--- a/src/client/entity-editor/alias-editor/alias-row.js
+++ b/src/client/entity-editor/alias-editor/alias-row.js
@@ -25,6 +25,7 @@ import {
 import {
 	validateAliasLanguage, validateAliasName, validateAliasSortName
 } from '../validators/common';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import LanguageField from '../common/language-field';
 import NameField from '../common/name-field';
 import PropTypes from 'prop-types';
@@ -47,7 +48,7 @@ import {isAliasEmpty} from '../helpers';
  * @param {string} props.nameValue - The name currently set for this alias.
  * @param {string} props.sortNameValue - The sort name currently set for this
  *        alias.
- * @param {string} props.primaryChecked - Whether or not the primary checkbox
+ * @param {boolean} props.primaryChecked - Whether or not the primary checkbox
  *        is checked.
  * @param {Function} props.onLanguageChange - A function to be called when a
  *        new alias language is selected.
@@ -58,7 +59,7 @@ import {isAliasEmpty} from '../helpers';
  * @param {Function} props.onRemoveButtonClick - A function to be called when
  *        the button to remove the alias is clicked.
  * @param {Function} props.onPrimaryClick - A function to be called when
- *        the primary checkbox is clicked.
+ *        the Primary checkbox is clicked.
  * @returns {ReactElement} React element containing the rendered AliasRow.
  */
 const AliasRow = ({
@@ -111,22 +112,23 @@ const AliasRow = ({
 			</Col>
 		</Row>
 		<Row>
-			<Col md={2} mdOffset={5}>
+			<Col md={2} mdOffset={2}>
 				<Checkbox
 					defaultChecked={primaryChecked}
 					onChange={onPrimaryClick}
 				>
-					Primary
+					Legal
 				</Checkbox>
 			</Col>
-			<Col className="text-right" md={3} mdOffset={2}>
+			<Col className="text-right" md={2} mdOffset={6}>
 				<Button
 					block
 					bsStyle="danger"
 					className="margin-top-d5"
 					onClick={onRemoveButtonClick}
 				>
-					Remove
+					<FontAwesomeIcon icon="times"/>
+					<span>&nbsp;Remove</span>
 				</Button>
 			</Col>
 		</Row>

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -18,6 +18,7 @@
  */
 /* eslint-disable react/display-name */
 
+
 import * as bootstrap from 'react-bootstrap';
 
 import {get as _get, kebabCase as _kebabCase} from 'lodash';
@@ -45,6 +46,7 @@ export function getLanguageAttribute(entity) {
 		).join(', ') : '?';
 	return {data: languages, title: 'Languages'};
 }
+
 
 export function getTypeAttribute(entityType) {
 	return {data: extractAttribute(entityType, 'label'), title: 'Type'};
@@ -212,7 +214,7 @@ export function getEntitySecondaryAliases(entity) {
 	if (entity.aliasSet && Array.isArray(entity.aliasSet.aliases) && entity.aliasSet.aliases.length > 1) {
 		const aliases = entity.aliasSet.aliases
 			.filter(item => item.id !== entity.defaultAlias.id)
-			.map(item => item.name)
+			.map(item => item.primary ? item.name + "(Legal)":item.name + "(Pseudonym)")
 			.join(', ');
 		return <h4>{aliases}</h4>;
 	}

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -215,14 +215,15 @@ export function getEntitySecondaryAliases(entity) {
 		const legal = '(Legal)';
 		const pseudo = '(Pseudonym)';
 		const aliases = entity.aliasSet.aliases
-			.filter(item => (item.id !== entity.defaultAlias.id))
-			.map(item => item.primary ? item.name + `${legal}`:item.name + `${pseudo}`)
+			.filter(item => item.id !== entity.defaultAlias.id)
+			.map(item => {return item.primary ? item.name `${legal}`:item.name `${pseudo}`})
 			.join(', ');
 		return <h4>{aliases}</h4>;
 	}
 
 	return null;
 }
+
 
 export function getEntityUrl(entity) {
 	const entityType = _kebabCase(entity.type);

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -216,13 +216,14 @@ export function getEntitySecondaryAliases(entity) {
 		const pseudo = '(Pseudonym)';
 		const aliases = entity.aliasSet.aliases
 			.filter(item => item.id !== entity.defaultAlias.id)
-			.map(item => {return item.primary ? item.name `${legal}`:item.name `${pseudo}`})
+			.map(item =>{ return item.primary ? item.name + `${legal}`: item.name + `${pseudo}`; })
 			.join(', ');
 		return <h4>{aliases}</h4>;
 	}
 
 	return null;
 }
+
 
 
 export function getEntityUrl(entity) {

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -216,14 +216,13 @@ export function getEntitySecondaryAliases(entity) {
 		const pseudo = '(Pseudonym)';
 		const aliases = entity.aliasSet.aliases
 			.filter(item => item.id !== entity.defaultAlias.id)
-			.map(item =>{ return item.primary ? item.name + `${legal}`: item.name + `${pseudo}`; })
+			.map(item => (item.primary ? `${item.name}${legal}` : `${item.name}${pseudo}`))
 			.join(', ');
 		return <h4>{aliases}</h4>;
 	}
 
 	return null;
 }
-
 
 
 export function getEntityUrl(entity) {

--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -212,9 +212,11 @@ export function getEntityDisambiguation(entity) {
 
 export function getEntitySecondaryAliases(entity) {
 	if (entity.aliasSet && Array.isArray(entity.aliasSet.aliases) && entity.aliasSet.aliases.length > 1) {
+		const legal = '(Legal)';
+		const pseudo = '(Pseudonym)';
 		const aliases = entity.aliasSet.aliases
-			.filter(item => item.id !== entity.defaultAlias.id)
-			.map(item => item.primary ? item.name + "(Legal)":item.name + "(Pseudonym)")
+			.filter(item => (item.id !== entity.defaultAlias.id))
+			.map(item => item.primary ? item.name + `${legal}`:item.name + `${pseudo}`)
 			.join(', ');
 		return <h4>{aliases}</h4>;
 	}


### PR DESCRIPTION
BB-284 
<!-- What are you trying to solve? -->
Earlier there was no way that a user can know about the legal or pseudonym of an alias

### Solution
<!-- What does this PR do to fix the problem? -->
I changed the primary label to legal . If the checkbox is checked then append "(legal)" with the name, otherwise "(pseudonym)".

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
