### PR TITLE
Fix entity /create route

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -192,6 +192,8 @@ function cleanupFunction() {
 /* eslint-enable no-console */
 
 // Run cleanup function
-appCleanup(cleanupFunction);
+if (process.env.NODE_ENV !== 'test') {
+	appCleanup(cleanupFunction);
+}
 
 export default server;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -92,20 +92,25 @@ else {
 }
 app.use(express.static(path.join(rootDir, 'static')));
 
-const RedisStore = redis(session);
-app.use(session({
+/* Set up sessions, using Redis in production and default in-memory for testing environment*/
+const sessionOptions = {
 	cookie: {
 		maxAge: _get(config, 'session.maxAge', 2592000000),
 		secure: _get(config, 'session.secure', false)
 	},
 	resave: false,
 	saveUninitialized: false,
-	secret: config.session.secret,
-	store: new RedisStore({
+	secret: config.session.secret
+};
+if (process.env.NODE_ENV !== 'test') {
+	const RedisStore = redis(session);
+	sessionOptions.store = new RedisStore({
 		host: _get(config, 'session.redis.host', 'localhost'),
 		port: _get(config, 'session.redis.port', 6379)
-	})
-}));
+	});
+}
+app.use(session(sessionOptions));
+
 
 if (config.influx) {
 	initInflux(app, config);

--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -139,7 +139,10 @@ export function makeEntityLoader(modelName, additionalRels, errMessage) {
 
 	return async (req, res, next, bbid) => {
 		const {orm} = req.app.locals;
-		if (commonUtils.isValidBBID(bbid)) {
+		if (req.path === '/create') {
+			return next('route');
+		}
+		else if (commonUtils.isValidBBID(bbid)) {
 			try {
 				const entity = await orm.func.entity.getEntity(orm, modelName, bbid, relations);
 				if (!entity.dataId) {

--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -139,7 +139,7 @@ export function makeEntityLoader(modelName, additionalRels, errMessage) {
 
 	return async (req, res, next, bbid) => {
 		const {orm} = req.app.locals;
-		if (req.path === '/create') {
+		if (req.path.toLowerCase() === '/create') {
 			return next('route');
 		}
 		else if (commonUtils.isValidBBID(bbid)) {

--- a/test/src/server/routes/entity/author.js
+++ b/test/src/server/routes/entity/author.js
@@ -1,0 +1,47 @@
+import {createAuthor, getRandomUUID, truncateEntities} from '../../../../test-helpers/create-entities';
+
+import app from '../../../../../src/server/app';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+
+chai.use(chaiHttp);
+const {expect} = chai;
+
+describe('Author routes', () => {
+	const aBBID = getRandomUUID();
+	const inValidBBID = 'have-you-seen-the-fnords';
+
+	before(async () => {
+		await createAuthor(aBBID);
+	});
+	after(truncateEntities);
+
+	it('should throw an error if requested BBID is invalid', (done) => {
+		chai.request(app)
+			.get(`/author/${inValidBBID}`)
+			.end((err, res) => {
+				expect(err).to.be.null;
+				expect(res).to.have.status(400);
+				done();
+			});
+	});
+	it('should not throw an error if creating new author', async () => {
+		const res = await chai.request(app)
+			.get('/author/create');
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error if requested author BBID exists', async () => {
+		const res = await chai.request(app)
+			.get(`/author/${aBBID}`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error trying to edit an existing author', async () => {
+		const res = await chai.request(app)
+			.get(`/author/${aBBID}/edit`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+});

--- a/test/src/server/routes/entity/edition-group.js
+++ b/test/src/server/routes/entity/edition-group.js
@@ -1,0 +1,47 @@
+import {createEditionGroup, getRandomUUID, truncateEntities} from '../../../../test-helpers/create-entities';
+
+import app from '../../../../../src/server/app';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+
+chai.use(chaiHttp);
+const {expect} = chai;
+
+describe('Edition Group routes', () => {
+	const aBBID = getRandomUUID();
+	const inValidBBID = 'have-you-seen-the-fnords';
+
+	before(async () => {
+		await createEditionGroup(aBBID);
+	});
+	after(truncateEntities);
+
+	it('should throw an error if requested BBID is invalid', (done) => {
+		chai.request(app)
+			.get(`/edition-group/${inValidBBID}`)
+			.end((err, res) => {
+				expect(err).to.be.null;
+				expect(res).to.have.status(400);
+				done();
+			});
+	});
+	it('should not throw an error if creating new edition-group', async () => {
+		const res = await chai.request(app)
+			.get('/edition-group/create');
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error if requested edition group BBID exists', async () => {
+		const res = await chai.request(app)
+			.get(`/edition-group/${aBBID}`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error trying to edit an existing edition group', async () => {
+		const res = await chai.request(app)
+			.get(`/edition-group/${aBBID}/edit`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+});

--- a/test/src/server/routes/entity/edition.js
+++ b/test/src/server/routes/entity/edition.js
@@ -1,0 +1,47 @@
+import {createEdition, getRandomUUID, truncateEntities} from '../../../../test-helpers/create-entities';
+
+import app from '../../../../../src/server/app';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+
+chai.use(chaiHttp);
+const {expect} = chai;
+
+describe('Edition routes', () => {
+	const aBBID = getRandomUUID();
+	const inValidBBID = 'have-you-seen-the-fnords';
+
+	before(async () => {
+		await createEdition(aBBID);
+	});
+	after(truncateEntities);
+
+	it('should throw an error if requested BBID is invalid', (done) => {
+		chai.request(app)
+			.get(`/edition/${inValidBBID}`)
+			.end((err, res) => {
+				expect(err).to.be.null;
+				expect(res).to.have.status(400);
+				done();
+			});
+	});
+	it('should not throw an error if creating new edition', async () => {
+		const res = await chai.request(app)
+			.get('/edition/create');
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error if requested edition BBID exists', async () => {
+		const res = await chai.request(app)
+			.get(`/edition/${aBBID}`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error trying to edit an existing edition', async () => {
+		const res = await chai.request(app)
+			.get(`/edition/${aBBID}/edit`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+});

--- a/test/src/server/routes/entity/publisher.js
+++ b/test/src/server/routes/entity/publisher.js
@@ -1,0 +1,47 @@
+import {createPublisher, getRandomUUID, truncateEntities} from '../../../../test-helpers/create-entities';
+
+import app from '../../../../../src/server/app';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+
+chai.use(chaiHttp);
+const {expect} = chai;
+
+describe('Publisher routes', () => {
+	const aBBID = getRandomUUID();
+	const inValidBBID = 'have-you-seen-the-fnords';
+
+	before(async () => {
+		await createPublisher(aBBID);
+	});
+	after(truncateEntities);
+
+	it('should throw an error if requested BBID is invalid', (done) => {
+		chai.request(app)
+			.get(`/publisher/${inValidBBID}`)
+			.end((err, res) => {
+				expect(err).to.be.null;
+				expect(res).to.have.status(400);
+				done();
+			});
+	});
+	it('should not throw an error if creating new publisher', async () => {
+		const res = await chai.request(app)
+			.get('/publisher/create');
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error if requested publisher BBID exists', async () => {
+		const res = await chai.request(app)
+			.get(`/publisher/${aBBID}`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error trying to edit an existing publisher', async () => {
+		const res = await chai.request(app)
+			.get(`/publisher/${aBBID}/edit`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+});

--- a/test/src/server/routes/entity/work.js
+++ b/test/src/server/routes/entity/work.js
@@ -1,0 +1,47 @@
+import {createWork, getRandomUUID, truncateEntities} from '../../../../test-helpers/create-entities';
+
+import app from '../../../../../src/server/app';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+
+chai.use(chaiHttp);
+const {expect} = chai;
+
+describe('Work routes', () => {
+	const aBBID = getRandomUUID();
+	const inValidBBID = 'have-you-seen-the-fnords';
+
+	before(async () => {
+		await createWork(aBBID);
+	});
+	after(truncateEntities);
+
+	it('should throw an error if requested BBID is invalid', (done) => {
+		chai.request(app)
+			.get(`/work/${inValidBBID}`)
+			.end((err, res) => {
+				expect(err).to.be.null;
+				expect(res).to.have.status(400);
+				done();
+			});
+	});
+	it('should not throw an error if creating new work', async () => {
+		const res = await chai.request(app)
+			.get('/work/create');
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error if requested work BBID exists', async () => {
+		const res = await chai.request(app)
+			.get(`/work/${aBBID}`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+	it('should not throw an error trying to edit an existing work', async () => {
+		const res = await chai.request(app)
+			.get(`/work/${aBBID}/edit`);
+		expect(res.ok).to.be.true;
+		expect(res).to.have.status(200);
+	});
+});


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Following PR #402 , the create route for entities (i.e: `/work/create`) throws an "Invalid BBID" error


### Solution
Modify the entity loading middleware to accept the `/create` route path, since we have no good way to differentiate a mistyped BBID and a valid route. 

Also added basic tests for the entity routes to make sure we don't break them as easily in the future.