### PR TITLE
feature(navbar): Added menu item pointing to revisions page

### DIFF
--- a/src/client/containers/layout.js
+++ b/src/client/containers/layout.js
@@ -193,6 +193,12 @@ class Layout extends React.Component {
 						{' Statistics '}
 					</NavItem>
 				</Nav>
+				<Nav pullRight>
+					<NavItem href="/revisions">
+						<FontAwesomeIcon icon="list-ul"/>
+						{' Revisions '}
+					</NavItem>
+				</Nav>
 				{!(homepage || hideSearch) && (
 					<form
 						action="/search"

--- a/src/client/helpers/setupIconLibrary.js
+++ b/src/client/helpers/setupIconLibrary.js
@@ -20,7 +20,7 @@ import {config, library} from '@fortawesome/fontawesome-svg-core';
 import {
 	faBook, faCalendarAlt, faChartLine, faCheck, faCircle, faCircleNotch,
 	faComment, faEnvelope, faExclamationTriangle, faExternalLinkAlt,
-	faGlobe, faHistory, faInfo, faPenNib, faPencilAlt, faPencilRuler,
+	faGlobe, faHistory, faInfo, faListUl, faPenNib, faPencilAlt, faPencilRuler,
 	faPlus, faQuestionCircle, faRemoveFormat, faSearch, faSignInAlt,
 	faSignOutAlt, faSlash, faTimes, faTimesCircle, faTrashAlt, faUndo,
 	faUniversity, faUser, faUserCircle, faWindowRestore
@@ -38,7 +38,7 @@ config.autoAddCss = true;
 library.add(
 	fab, faBook, faCalendarAlt, faChartLine, faCheck, faCircle, faCircleNotch,
 	faComment, faEnvelope, faExclamationTriangle, faExternalLinkAlt,
-	faGlobe, faHistory, faInfo, faPenNib, faPencilAlt, faPencilRuler,
+	faGlobe, faHistory, faInfo, faListUl, faPenNib, faPencilAlt, faPencilRuler,
 	faPlus, faQuestionCircle, faRemoveFormat, faSearch, faSignInAlt,
 	faSignOutAlt, faSlash, faTimes, faTimesCircle, faTrashAlt, faUndo,
 	faUniversity, faUser, faUserCircle, faWindowRestore


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
The revisions page is quite an important new page, and it should be accessible on every page.


### Solution
Add new menu item to navbar

<img width="1221" alt="Capture d’écran 2020-04-08 à 14 37 34" src="https://user-images.githubusercontent.com/6179856/78784947-89b39080-79a6-11ea-9165-e840a1849359.png">

