### PR TITLE
BB-367 fix(search): Fix entity search indexing

### DIFF
--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -775,9 +775,11 @@ export function handleCreateOrEditEntity(
 			editorJSON.id, body.note
 		);
 
-		/** savedMainEntity is already updated, but without relations (we need the aliases for search reindexing) */
-		const savedEntityWithRelationships = await savedMainEntity.load(['aliasSet.aliases'],
-			{transacting});
+		/** savedMainEntity should already be updated, but we need to refresh the aliases for search reindexing */
+		const savedEntityWithRelationships = await savedMainEntity.refresh({
+			transacting,
+			withRelated: ['aliasSet.aliases']
+		});
 
 		return savedEntityWithRelationships.toJSON();
 	});


### PR DESCRIPTION
### Problem
An elusive search indexing issue was introduced in PR #313.
Tried to solve it a couple of times already with PRs #330 and  #362 which both failed to address the issue.
It also shone a light on a problem with my local debugging setup swallowing console errors.


### Solution
Refresh entities after save; contrarily to what I thought, the ORM does not return a completely refreshed entity after a `.save` operation as described [in the BookshelfJS docs](https://bookshelfjs.org/api.html#Model-instance-save):

> After a model is saved it will be populated with all the attributes that are present in the database, so you don't need to manually call refresh to update it. This will use two queries unless the database supports the RETURNING statement, in which case the model will be saved and its data fetched with a single query.

I haven't figured out exactly what was missing with using `.load` to load aliases instead of `.refresh`ing with related aliases, but reverting the change and using `.refresh` works fine.