### PR TITLE
fix: fix mentions of "open in a new tab"

### DIFF
--- a/src/client/entity-editor/edition-section/edition-section.js
+++ b/src/client/entity-editor/edition-section/edition-section.js
@@ -224,8 +224,8 @@ function EditionSection({
 								'An existing Edition Group with the same name as this Edition already exists'
 							}:
 							<br/>
-							<small>The first match has been selected automatically.<br/>
-							Please review the choice: click on an item to open it in a new tab:
+							<small>The first match has been selected automatically. Please review the choice:
+								<br/>Click on an item to open it (Ctrl/Cmd + click to open in a new tab)
 							</small>
 							<SearchResults condensed results={matchingNameEditionGroups}/>
 						</Alert>

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -161,7 +161,7 @@ class NameSection extends React.Component {
 									We found the following&nbsp;
 									{_.startCase(entityType)}{exactMatches.length > 1 ? 's' : ''} with
 									exactly the same name or alias:
-									<br/><small className="help-block">Click on a name to open in a new tab</small>
+									<br/><small className="help-block">Click on a name to open it (Ctrl/Cmd + click to open in a new tab)</small>
 									<ListGroup className="margin-top-1 margin-bottom-1">
 										{exactMatches.map((match) =>
 											(
@@ -187,7 +187,8 @@ class NameSection extends React.Component {
 						<Row>
 							<Col md={6} mdOffset={3}>
 								If the {_.startCase(entityType)} you want to add appears in the results
-								below, click on it to inspect it in a new tab before adding a possible duplicate.
+								below, click on it to inspect it before adding a possible duplicate.<br/>
+								<small>Ctrl/Cmd + click to open in a new tab</small>
 								<SearchResults condensed results={searchResults}/>
 							</Col>
 						</Row>


### PR DESCRIPTION
After PR #383 , mentions of "click to open in a new tab" are wrong and misleading and will lead to users losing their progress and patience.

Replaced it with text suggesting shortcut to open in a new tab.