### PR TITLE
BB-481: Fix merged entities path redirect

### DIFF
--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -17,16 +17,20 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+// @flow
+
 import * as commonUtils from '../../common/helpers/utils';
 import * as error from '../../common/helpers/error';
 import * as utils from '../helpers/utils';
+import type {$Request, $Response, NextFunction} from 'express';
 
 import Promise from 'bluebird';
 
 
 function makeLoader(modelName, propName, sortFunc) {
-	return function loaderFunc(req, res, next) {
-		const model = req.app.locals.orm[modelName];
+	return function loaderFunc(req: $Request, res: $Response, next: NextFunction) {
+		const {orm}: any = req.app.locals;
+		const model = orm[modelName];
 		return model.fetchAll()
 			.then((results) => {
 				const resultsSerial = results.toJSON();
@@ -65,8 +69,8 @@ export const loadLanguages = makeLoader('Language', 'languages', (a, b) => {
 	return a.name.localeCompare(b.name);
 });
 
-export function loadEntityRelationships(req, res, next) {
-	const {orm} = req.app.locals;
+export function loadEntityRelationships(req: $Request, res: $Response, next: NextFunction) {
+	const {orm}: any = req.app.locals;
 	const {RelationshipSet} = orm;
 	const {entity} = res.locals;
 
@@ -124,20 +128,17 @@ export function loadEntityRelationships(req, res, next) {
 		})
 		.catch(next);
 }
-export async function redirectedBbid(req, res, next, bbid) {
-	if (req.path.toLowerCase() === '/create') {
-		return next('route');
-	}
+export async function redirectedBbid(req: $Request, res: $Response, next: NextFunction, bbid: string) {
 	if (!commonUtils.isValidBBID(bbid)) {
 		return next(new error.BadRequestError(`Invalid bbid: ${req.params.bbid}`, req));
 	}
-	const {orm} = req.app.locals;
+	const {orm}: any = req.app.locals;
 
 	try {
 		const redirectBbid = await orm.func.entity.recursivelyGetRedirectBBID(orm, bbid);
 		if (redirectBbid !== bbid) {
 			// res.location(`${req.baseUrl}/${redirectBbid}`);
-			return res.redirect(301, `${req.baseUrl}/${redirectBbid}`);
+			return res.redirect(301, `${req.baseUrl}${req.path.replace(bbid, redirectBbid)}`);
 		}
 	}
 	catch (err) {
@@ -146,7 +147,7 @@ export async function redirectedBbid(req, res, next, bbid) {
 	return next();
 }
 
-export function makeEntityLoader(modelName, additionalRels, errMessage) {
+export function makeEntityLoader(modelName: string, additionalRels: Array<string>, errMessage: string) {
 	const relations = [
 		'aliasSet.aliases.language',
 		'annotation.lastRevision',
@@ -157,12 +158,9 @@ export function makeEntityLoader(modelName, additionalRels, errMessage) {
 		'revision.revision'
 	].concat(additionalRels);
 
-	return async (req, res, next, bbid) => {
-		const {orm} = req.app.locals;
-		if (req.path.toLowerCase() === '/create') {
-			return next('route');
-		}
-		else if (commonUtils.isValidBBID(bbid)) {
+	return async (req: $Request, res: $Response, next: NextFunction, bbid: string) => {
+		const {orm}: any = req.app.locals;
+		if (commonUtils.isValidBBID(bbid)) {
 			try {
 				const entity = await orm.func.entity.getEntity(orm, modelName, bbid, relations);
 				if (!entity.dataId) {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Links to merged bbids subpaths (for example `/$BBID/revisions`) would redirect to the merged entity without the subpath  (i.e: `/$newBBID`).


### Solution
Replace the bbid in the full path and redirect to that.

This PR also puts entity routes without BBIDs (/create, /create/handler) before the route parameters are defined for routes with bbids.
This allows us to remove an ugly solution to detect routes without bbid introduced in this commit:
https://github.com/bookbrainz/bookbrainz-site/commit/0e1a8349f6cdc9bc6d97f6416eb5c0a0049f2c08#diff-04b1046083d3d54b6df49ebe87477558

Also adds a bit of flow types

### Areas of Impact
Entity router files and middleware helpers.
