### PR TITLE
feat(merge-tool): Show full revision history of merged entities

### DIFF
--- a/src/server/helpers/revisions.js
+++ b/src/server/helpers/revisions.js
@@ -168,19 +168,18 @@ export async function getOrderedRevisionForEditorPage(from, size, req) {
 	return orderedRevisions;
 }
 
-export async function getOrderedRevisionsForEntityPage(from, size, RevisionModel, req) {
-	const {orm} = req.app.locals;
+export async function getOrderedRevisionsForEntityPage(orm, from, size, RevisionModel, bbid) {
 	let otherMergedBBIDs = await orm.bookshelf.knex
 		.select('source_bbid')
 		.from('bookbrainz.entity_redirect')
-		.where('target_bbid', req.params.bbid);
+		.where('target_bbid', bbid);
 
 	// Flatten the returned array of objects
 	otherMergedBBIDs = flatMap(otherMergedBBIDs, 'source_bbid');
 
 	const revisions = await new RevisionModel()
 		.query((qb) => {
-			qb.whereIn('bbid', [req.params.bbid, ...otherMergedBBIDs]);
+			qb.whereIn('bbid', [bbid, ...otherMergedBBIDs]);
 			qb.join('bookbrainz.revision', `${RevisionModel.prototype.tableName}.id`, '=', 'bookbrainz.revision.id');
 			qb.orderBy('revision.created_at', 'DESC');
 		}).fetchPage({

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -194,10 +194,11 @@ export async function displayRevisions(
 ) {
 	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
 	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
-
+	const {orm}: any = req.app.locals;
+	const {bbid} = req.params;
 	try {
 		// get 1 more revision than required to check nextEnabled
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(from, size + 1, RevisionModel, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, from, size + 1, RevisionModel, bbid);
 		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
 		const props = generateProps(req, res, {
 			from,
@@ -234,9 +235,10 @@ export async function updateDisplayedRevisions(
 ) {
 	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
 	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
-
+	const {orm}: any = req.app.locals;
+	const {bbid} = req.params;
 	try {
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(from, size, RevisionModel, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, from, size, RevisionModel, bbid);
 		res.send(orderedRevisions);
 	}
 	catch (err) {

--- a/test/src/server/helpers/revisions.js
+++ b/test/src/server/helpers/revisions.js
@@ -415,13 +415,10 @@ describe('getOrderedRevisionForEditorPage', () => {
 /* eslint-disable no-await-in-loop */
 describe('getOrderedRevisionsForEntityPage', () => {
 	// eslint-disable-next-line one-var
-	let editorJSON, req;
+	let editorJSON;
 	before(async () => {
 		const editor = await createEditor();
 		editorJSON = editor.toJSON();
-		req = {
-			params: {}
-		};
 	});
 	after(truncateEntities);
 
@@ -429,7 +426,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		const numberOfRevisions = 10;
 		const author = await createAuthor();
 		const authorJSON = author.toJSON();
-		req.params.bbid = authorJSON.bbid;
 
 		// starting from 2 because one revision is created while creating the author
 		for (let i = 2; i <= numberOfRevisions; i++) {
@@ -439,7 +435,7 @@ describe('getOrderedRevisionsForEntityPage', () => {
 			await new AuthorData({aliasSetId: authorJSON.aliasSetId, id: dataId}).save(null, {method: 'insert'});
 			await new AuthorRevision({bbid: authorJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
 		}
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(0, numberOfRevisions, AuthorRevision, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, AuthorRevision, authorJSON.bbid);
 
 		expect(orderedRevisions.length).to.equal(numberOfRevisions);
 		expect(orderedRevisions).to.be.descendingBy('createdAt');
@@ -458,7 +454,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		const numberOfRevisions = 10;
 		const work = await createWork();
 		const workJSON = work.toJSON();
-		req.params.bbid = workJSON.bbid;
 
 		// starting from 2 because one revision is created while creating the work
 		for (let i = 2; i <= numberOfRevisions; i++) {
@@ -469,7 +464,7 @@ describe('getOrderedRevisionsForEntityPage', () => {
 			await new WorkRevision({bbid: workJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
 		}
 
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(0, numberOfRevisions, WorkRevision, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, WorkRevision, workJSON.bbid);
 
 		expect(orderedRevisions.length).to.equal(numberOfRevisions);
 		expect(orderedRevisions).to.be.descendingBy('createdAt');
@@ -488,7 +483,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		const numberOfRevisions = 10;
 		const edition = await createEdition();
 		const editionJSON = edition.toJSON();
-		req.params.bbid = editionJSON.bbid;
 
 		// starting from 2 because one revision is created while creating the work
 		for (let i = 2; i <= numberOfRevisions; i++) {
@@ -499,7 +493,7 @@ describe('getOrderedRevisionsForEntityPage', () => {
 			await new EditionRevision({bbid: editionJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
 		}
 
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(0, numberOfRevisions, EditionRevision, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, EditionRevision, editionJSON.bbid);
 
 		expect(orderedRevisions.length).to.equal(numberOfRevisions);
 		expect(orderedRevisions).to.be.descendingBy('createdAt');
@@ -518,7 +512,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		const numberOfRevisions = 10;
 		const publisher = await createPublisher();
 		const publisherJSON = publisher.toJSON();
-		req.params.bbid = publisherJSON.bbid;
 
 		// starting from 2 because one revision is created while creating the publisher
 		for (let i = 2; i <= numberOfRevisions; i++) {
@@ -529,7 +522,7 @@ describe('getOrderedRevisionsForEntityPage', () => {
 			await new PublisherRevision({bbid: publisherJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
 		}
 
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(0, numberOfRevisions, PublisherRevision, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, PublisherRevision, publisherJSON.bbid);
 
 		expect(orderedRevisions.length).to.equal(numberOfRevisions);
 		expect(orderedRevisions).to.be.descendingBy('createdAt');
@@ -548,7 +541,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		const numberOfRevisions = 10;
 		const editionGroup = await createEditionGroup();
 		const editionGroupJSON = editionGroup.toJSON();
-		req.params.bbid = editionGroupJSON.bbid;
 
 		// starting from 2 because one revision is created while creating the editionGroup
 		for (let i = 2; i <= numberOfRevisions; i++) {
@@ -559,7 +551,7 @@ describe('getOrderedRevisionsForEntityPage', () => {
 			await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
 		}
 
-		const orderedRevisions = await getOrderedRevisionsForEntityPage(0, numberOfRevisions, EditionGroupRevision, req);
+		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, EditionGroupRevision, editionGroupJSON.bbid);
 
 		expect(orderedRevisions.length).to.equal(numberOfRevisions);
 		expect(orderedRevisions).to.be.descendingBy('createdAt');
@@ -577,7 +569,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 	it('should return revisions with notes sorted according to "postedAt" and with expected keys', async () => {
 		const author = await createAuthor();
 		const authorJSON = await author.toJSON();
-		req.params.bbid = authorJSON.bbid;
 		// revision created while create author
 		const revisionID = authorJSON.revisionId;
 
@@ -598,7 +589,7 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		}
 		await Promise.all(promiseArray);
 
-		const orderedRevision = await getOrderedRevisionsForEntityPage(0, 10, AuthorRevision, req);
+		const orderedRevision = await getOrderedRevisionsForEntityPage(orm, 0, 10, AuthorRevision, authorJSON.bbid);
 
 		expect(orderedRevision.length).to.be.equal(1);
 		expect(orderedRevision[0].notes.length).to.be.equal(10);
@@ -606,5 +597,26 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		orderedRevision[0].notes.forEach((note) => {
 			expect(note.author).to.deep.equal(editorJSON);
 		});
+	});
+
+	it('should return revisions of merged entities', async () => {
+		const author1 = await createAuthor();
+		const author2 = await createAuthor();
+		const author1JSON = await author1.toJSON();
+		const author2JSON = await author2.toJSON();
+		// revision created while create author
+		const revisionID1 = author1JSON.revisionId;
+		const revisionID2 = author2JSON.revisionId;
+
+		// Let's pretend author2 was merged into author1 it was merged
+		await orm.bookshelf.knex('bookbrainz.entity_redirect')
+			// eslint-disable-next-line camelcase
+			.insert({source_bbid: author2JSON.bbid, target_bbid: author1JSON.bbid});
+
+		const orderedRevision = await getOrderedRevisionsForEntityPage(orm, 0, 10, AuthorRevision, author1JSON.bbid);
+
+		expect(orderedRevision.length).to.be.equal(2);
+		expect(orderedRevision[0].revisionId).to.be.equal(revisionID2);
+		expect(orderedRevision[1].revisionId).to.be.equal(revisionID1);
 	});
 });


### PR DESCRIPTION
### Problem
Once entities are merged, their revision history is hidden and unaccessible


### Solution
This PR loads the revisions for entities that  have been merged, thus presenting the full revision history tree.
