### PR TITLE
Fix BB-453: Prevent multiple form submissions

### DIFF
--- a/src/client/entity-editor/submission-section/actions.js
+++ b/src/client/entity-editor/submission-section/actions.js
@@ -25,6 +25,7 @@ import request from 'superagent';
 
 export const SET_SUBMIT_ERROR = 'SET_SUBMIT_ERROR';
 export const UPDATE_REVISION_NOTE = 'UPDATE_REVISION_NOTE';
+export const SET_SUBMITTED = 'SET_SUBMITTED';
 
 export type Action = {
 	type: string,
@@ -46,6 +47,20 @@ export function setSubmitError(error: string): Action {
 	return {
 		error,
 		type: SET_SUBMIT_ERROR
+	};
+}
+
+/**
+ * Produces an action indicating whether the form  has been submitted or not.
+ * This consequently enables or disables the submit button to prevent double submissions
+ *
+ * @param {boolean} submitted - Boolean indicating if the form has been submitted
+ * @returns {Action} The resulting SET_SUBMITTED action.
+ */
+export function setSubmitted(submitted: boolean): Action {
+	return {
+		submitted,
+		type: SET_SUBMITTED
 	};
 }
 
@@ -102,6 +117,7 @@ export function submit(
 ): ((Action) => mixed, () => Map<string, mixed>) => mixed {
 	return (dispatch, getState) => {
 		const rootState = getState();
+		dispatch(setSubmitted(true));
 		return postSubmission(submissionUrl, rootState)
 			.catch(
 				(error: {message: string}) => {
@@ -112,6 +128,8 @@ export function submit(
 					const message =
 						_.get(error, ['res', 'body', 'error'], null) ||
 						error.message;
+					// If there was an error submitting the form, make the submit button clickable again
+					dispatch(setSubmitted(false));
 					return dispatch(setSubmitError(message));
 				}
 			);

--- a/src/client/entity-editor/submission-section/actions.js
+++ b/src/client/entity-editor/submission-section/actions.js
@@ -87,7 +87,7 @@ type Response = {
 	}
 };
 
-function postSubmission(url: string, data: Map<string, mixed>): Promise {
+function postSubmission(url: string, data: Map<string, mixed>): Promise<void> {
 	/*
 	 * TODO: Not the best way to do this, but once we unify the
 	 * /<entity>/create/handler and /<entity>/edit/handler URLs, we can simply
@@ -126,7 +126,7 @@ export function submit(
 					 * superagent message
 					 */
 					const message =
-						_.get(error, ['res', 'body', 'error'], null) ||
+						_.get(error, ['response', 'body', 'error'], null) ||
 						error.message;
 					// If there was an error submitting the form, make the submit button clickable again
 					dispatch(setSubmitted(false));

--- a/src/client/entity-editor/submission-section/reducer.js
+++ b/src/client/entity-editor/submission-section/reducer.js
@@ -17,7 +17,7 @@
  */
 
 import {
-	SET_SUBMIT_ERROR, UPDATE_REVISION_NOTE
+	SET_SUBMITTED, SET_SUBMIT_ERROR, UPDATE_REVISION_NOTE
 } from './actions';
 import Immutable from 'immutable';
 
@@ -25,7 +25,8 @@ import Immutable from 'immutable';
 function reducer(
 	state = Immutable.Map({
 		note: '',
-		submitError: ''
+		submitError: '',
+		submitted: false
 	}),
 	action
 ) {
@@ -34,6 +35,8 @@ function reducer(
 			return state.set('note', action.value);
 		case SET_SUBMIT_ERROR:
 			return state.set('submitError', action.error);
+		case SET_SUBMITTED:
+			return state.set('submitted', action.submitted);
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/submission-section/submission-section.js
+++ b/src/client/entity-editor/submission-section/submission-section.js
@@ -34,10 +34,14 @@ import {connect} from 'react-redux';
  * @param {Object} props - The properties passed to the component.
  * @param {string} props.errorText - A message to be displayed within the
  *        component in the case of an error.
+ * @param {boolean} props.formValid - Boolean indicating if the form has been
+ *        validated successfully or if it contains errors
  * @param {Function} props.onNoteChange - A function to be called when the
  *        revision note is changed.
- * @param {Function} props.onSubmitClick - A function to be called when the
+ * @param {Function} props.onSubmit - A function to be called when the
  *        submit button is clicked.
+ * @param {boolean} props.submitted - Boolean indicating if the form has been submitted
+ *        (i.e. submit button clicked) to prevent submitting again
  * @returns {ReactElement} React element containing the rendered
  *          SubmissionSection.
  */
@@ -45,7 +49,8 @@ function SubmissionSection({
 	errorText,
 	formValid,
 	onNoteChange,
-	onSubmit
+	onSubmit,
+	submitted
 }) {
 	const errorAlertClass =
 		classNames('text-center', 'margin-top-1', {hidden: !errorText});
@@ -84,7 +89,7 @@ function SubmissionSection({
 			<div className="text-center margin-top-1">
 				<Button
 					bsStyle="success"
-					disabled={!formValid}
+					disabled={!formValid || submitted}
 					onClick={onSubmit}
 				>
 					Submit
@@ -101,14 +106,16 @@ SubmissionSection.propTypes = {
 	errorText: PropTypes.node.isRequired,
 	formValid: PropTypes.bool.isRequired,
 	onNoteChange: PropTypes.func.isRequired,
-	onSubmit: PropTypes.func.isRequired
+	onSubmit: PropTypes.func.isRequired,
+	submitted: PropTypes.bool.isRequired
 };
 
 function mapStateToProps(rootState, {validate, identifierTypes}) {
 	const state = rootState.get('submissionSection');
 	return {
 		errorText: state.get('submitError'),
-		formValid: validate(rootState, identifierTypes)
+		formValid: validate(rootState, identifierTypes),
+		submitted: state.get('submitted')
 	};
 }
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
A user can mash the submit button and the form will be submitted as many times as they clicked it before being redirected.
That's obviously an issue and resulted in a bunch of duplicates in the database.


### Solution
Disable the submit button once submitted.
re-enable it if there was an error with the submission.

While I was in there, I also fixed a small issue introduced in #438 where a submission error message was not extracted properly from the response body following the replacement of superagent-bluebird-promise  library with superagent itself.