### PR TITLE
Fix BB-415: Reimplement annotations

### DIFF
--- a/src/client/components/pages/entities/annotation.js
+++ b/src/client/components/pages/entities/annotation.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020  Nicolas Pelletier
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {Col, Row} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {formatDate} from '../../../helpers/utils';
+
+
+function EntityAnnotation({entity}) {
+	const {annotation} = entity;
+	if (!annotation || !annotation.content) {
+		return null;
+	}
+	const lastModifiedDate = new Date(annotation.lastRevision.createdAt);
+	return (
+		<Row>
+			<Col md={12}>
+				<h2>Annotation</h2>
+				<p>{annotation.content}</p>
+				<p className="text-muted">Last modified: <span title={formatDate(lastModifiedDate, true)}>{formatDate(lastModifiedDate)}</span>
+					<span className="small"> (revision <a href={`/revision/${annotation.lastRevisionId}`}>#{annotation.lastRevisionId}</a>)</span>
+				</p>
+			</Col>
+		</Row>
+	);
+}
+EntityAnnotation.displayName = 'EntityAnnotation';
+EntityAnnotation.propTypes = {
+	entity: PropTypes.object.isRequired
+};
+
+export default EntityAnnotation;

--- a/src/client/components/pages/entities/author.js
+++ b/src/client/components/pages/entities/author.js
@@ -19,6 +19,7 @@
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
+import EntityAnnotation from './annotation';
 import EntityFooter from './footer';
 import EntityImage from './image';
 import EntityLinks from './links';
@@ -121,6 +122,7 @@ function AuthorDisplayPage({entity, identifierTypes}) {
 					<AuthorAttributes author={entity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
 				<EntityLinks

--- a/src/client/components/pages/entities/edition-group.js
+++ b/src/client/components/pages/entities/edition-group.js
@@ -18,8 +18,8 @@
 
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
-
 import EditionTable from './edition-table';
+import EntityAnnotation from './annotation';
 import EntityFooter from './footer';
 import EntityImage from './image';
 import EntityLinks from './links';
@@ -79,6 +79,7 @@ function EditionGroupDisplayPage({entity, identifierTypes}) {
 					<EditionGroupAttributes editionGroup={entity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
 				<EditionTable editions={entity.editions} entity={entity}/>

--- a/src/client/components/pages/entities/edition.js
+++ b/src/client/components/pages/entities/edition.js
@@ -18,7 +18,7 @@
 
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
-
+import EntityAnnotation from './annotation';
 import EntityFooter from './footer';
 import EntityImage from './image';
 import EntityLinks from './links';
@@ -139,6 +139,7 @@ function EditionDisplayPage({entity, identifierTypes}) {
 					{editionGroupSection}
 				</Col>
 			</Row>
+			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
 				<WorksTable

--- a/src/client/components/pages/entities/publisher.js
+++ b/src/client/components/pages/entities/publisher.js
@@ -18,8 +18,8 @@
 
 import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
-
 import EditionTable from './edition-table';
+import EntityAnnotation from './annotation';
 import EntityFooter from './footer';
 import EntityImage from './image';
 import EntityLinks from './links';
@@ -97,6 +97,7 @@ function PublisherDisplayPage({entity, identifierTypes}) {
 					<PublisherAttributes publisher={entity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
 				<EditionTable editions={entity.editions} entity={entity}/>

--- a/src/client/components/pages/entities/work.js
+++ b/src/client/components/pages/entities/work.js
@@ -20,6 +20,7 @@ import * as bootstrap from 'react-bootstrap';
 import * as entityHelper from '../../../helpers/entity';
 
 import EditionTable from './edition-table';
+import EntityAnnotation from './annotation';
 import EntityFooter from './footer';
 import EntityImage from './image';
 import EntityLinks from './links';
@@ -91,6 +92,7 @@ function WorkDisplayPage({entity, identifierTypes}) {
 					<WorkAttributes work={entity}/>
 				</Col>
 			</Row>
+			<EntityAnnotation entity={entity}/>
 			{!entity.deleted &&
 			<React.Fragment>
 				<EditionTable

--- a/src/client/entity-editor/submission-section/actions.js
+++ b/src/client/entity-editor/submission-section/actions.js
@@ -25,6 +25,7 @@ import request from 'superagent';
 
 export const SET_SUBMIT_ERROR = 'SET_SUBMIT_ERROR';
 export const UPDATE_REVISION_NOTE = 'UPDATE_REVISION_NOTE';
+export const UPDATE_ANNOTATION = 'UPDATE_ANNOTATION';
 export const SET_SUBMITTED = 'SET_SUBMITTED';
 
 export type Action = {
@@ -76,6 +77,22 @@ export function debounceUpdateRevisionNote(value: string): Action {
 	return {
 		meta: {debounce: 'keystroke'},
 		type: UPDATE_REVISION_NOTE,
+		value
+	};
+}
+
+/**
+ * Produces an action indicating that the annotation for the editing form
+ * should be updated with the provided value. The action is marked to be
+ * debounced by the keystroke debouncer defined for redux-debounce.
+ *
+ * @param {string} value - The new value to be used for the revision note.
+ * @returns {Action} The resulting UPDATE_ANNOTATION action.
+ */
+export function debounceUpdateAnnotation(value: string): Action {
+	return {
+		meta: {debounce: 'keystroke'},
+		type: UPDATE_ANNOTATION,
 		value
 	};
 }

--- a/src/client/entity-editor/submission-section/reducer.js
+++ b/src/client/entity-editor/submission-section/reducer.js
@@ -17,13 +17,14 @@
  */
 
 import {
-	SET_SUBMITTED, SET_SUBMIT_ERROR, UPDATE_REVISION_NOTE
+	SET_SUBMITTED, SET_SUBMIT_ERROR, UPDATE_ANNOTATION, UPDATE_REVISION_NOTE
 } from './actions';
 import Immutable from 'immutable';
 
 
 function reducer(
 	state = Immutable.Map({
+		annotation: Immutable.Map({content: ''}),
 		note: '',
 		submitError: '',
 		submitted: false
@@ -33,6 +34,8 @@ function reducer(
 	switch (action.type) {
 		case UPDATE_REVISION_NOTE:
 			return state.set('note', action.value);
+		case UPDATE_ANNOTATION:
+			return state.setIn(['annotation', 'content'], action.value);
 		case SET_SUBMIT_ERROR:
 			return state.set('submitError', action.error);
 		case SET_SUBMITTED:

--- a/src/client/entity-editor/submission-section/submission-section.js
+++ b/src/client/entity-editor/submission-section/submission-section.js
@@ -74,49 +74,44 @@ function SubmissionSection({
 
 	return (
 		<div>
-			<p className="text-muted">
-				Annotations allow you to enter freeform data that does not otherwise fit in the above form.
-			</p>
-			<form>
-				<Row>
-					<Col md={6} mdOffset={3}>
-						<CustomInput
-							label={annotationLabel}
-							rows="4"
-							tooltipText="Other data that does not fit in the form"
-							type="textarea"
-							value={annotation.content}
-							onChange={onAnnotationChange}
-						/>
-						{
-							annotation && annotation.lastRevision &&
-							<p className="text-muted">Last modified: {formatDate(new Date(annotation.lastRevision.createdAt))}</p>
-						}
-					</Col>
-				</Row>
-			</form>
 			<h2>
 				Submit Your Edit
 			</h2>
-			<p className="text-muted">
-				{`An edit note will make your entries more credible. Reply to one or more of these questions in the textarea below:
-				- Where did you get your info from? A link is worth a thousand words.
-				- What kind of information did you provide? If you made any changes, what are they and why?
- 				- Do you have any questions concerning the editing process you want to ask?`}
-			</p>
-			<form>
-				<Row>
-					<Col md={6} mdOffset={3}>
-						<CustomInput
-							label={editNoteLabel}
-							rows="6"
-							tooltipText="Cite your sources or an explanation of your edit"
-							type="textarea"
-							onChange={onNoteChange}
-						/>
-					</Col>
-				</Row>
-			</form>
+			<Row>
+				<Col md={6}>
+					<CustomInput
+						label={annotationLabel}
+						rows="6"
+						tooltipText="Additional freeform data that does not fit in the above form"
+						type="textarea"
+						value={annotation.content}
+						onChange={onAnnotationChange}
+					/>
+					{
+						annotation && annotation.lastRevision &&
+						<p className="small text-muted">Last modified: {formatDate(new Date(annotation.lastRevision.createdAt))}</p>
+					}
+					<p className="help-block">
+						Annotations allow you to enter freeform data that does not otherwise fit in the above form.
+						<b> Do not submit any copyrighted text here.</b> The contents will be made available to the public under <a href="https://musicbrainz.org/doc/About/Data_License">open licenses</a>.
+					</p>
+				</Col>
+				<Col md={6}>
+					<CustomInput
+						label={editNoteLabel}
+						rows="6"
+						tooltipText="Cite your sources or an explanation of your edit"
+						type="textarea"
+						onChange={onNoteChange}
+					/>
+					<p className="text-muted">
+						{`An edit note will make your entries more credible. Reply to one or more of these questions in the textarea below:
+						- Where did you get your info from? A link is worth a thousand words.
+						- What kind of information did you provide? If you made any changes, what are they and why?
+						- Do you have any questions concerning the editing process you want to ask?`}
+					</p>
+				</Col>
+			</Row>
 			<div className="text-center margin-top-1">
 				<Button
 					bsStyle="success"

--- a/src/client/entity-editor/validators/common.js
+++ b/src/client/entity-editor/validators/common.js
@@ -165,10 +165,15 @@ export function validateSubmissionSectionNote(value: any): boolean {
 	return validateOptionalString(value);
 }
 
+export function validateSubmissionSectionAnnotation(value: any): boolean {
+	return validateOptionalString(value);
+}
+
 export function validateSubmissionSection(
 	data: any
 ): boolean {
 	return (
-		validateSubmissionSectionNote(get(data, 'note', null))
+		validateSubmissionSectionNote(get(data, 'note', null)) &&
+		validateSubmissionSectionAnnotation(get(data, 'annotation.content', null))
 	);
 }

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -59,6 +59,7 @@ function transformNewForm(data) {
 
 	return {
 		aliases,
+		annotation: data.submissionSection.annotation.content,
 		beginAreaId: data.authorSection.beginArea &&
 			data.authorSection.beginArea.id,
 		beginDate: data.authorSection.beginDate,
@@ -234,13 +235,24 @@ function authorToFormState(author) {
 		}
 	));
 
+	const optionalSections = {};
+	if (author.annotation) {
+		optionalSections.submissionSection = {
+			annotation: author.annotation,
+			note: '',
+			submitError: '',
+			submitted: false
+		};
+	}
+
 	return {
 		aliasEditor,
 		authorSection,
 		buttonBar,
 		identifierEditor,
 		nameSection,
-		relationshipSection
+		relationshipSection,
+		...optionalSections
 	};
 }
 

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -52,6 +52,7 @@ function transformNewForm(data) {
 
 	return {
 		aliases,
+		annotation: data.submissionSection.annotation.content,
 		disambiguation: data.nameSection.disambiguation,
 		identifiers,
 		note: data.submissionSection.note,
@@ -220,13 +221,24 @@ function editionGroupToFormState(editionGroup) {
 		}
 	));
 
+	const optionalSections = {};
+	if (editionGroup.annotation) {
+		optionalSections.submissionSection = {
+			annotation: editionGroup.annotation,
+			note: '',
+			submitError: '',
+			submitted: false
+		};
+	}
+
 	return {
 		aliasEditor,
 		buttonBar,
 		editionGroupSection,
 		identifierEditor,
 		nameSection,
-		relationshipSection
+		relationshipSection,
+		...optionalSections
 	};
 }
 

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -69,6 +69,7 @@ function transformNewForm(data) {
 
 	return {
 		aliases,
+		annotation: data.submissionSection.annotation.content,
 		depth: data.editionSection.depth &&
 			parseInt(data.editionSection.depth, 10),
 		disambiguation: data.nameSection.disambiguation,
@@ -360,13 +361,24 @@ function editionToFormState(edition) {
 		}
 	));
 
+	const optionalSections = {};
+	if (edition.annotation) {
+		optionalSections.submissionSection = {
+			annotation: edition.annotation,
+			note: '',
+			submitError: '',
+			submitted: false
+		};
+	}
+
 	return {
 		aliasEditor,
 		buttonBar,
 		editionSection,
 		identifierEditor,
 		nameSection,
-		relationshipSection
+		relationshipSection,
+		...optionalSections
 	};
 }
 

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -55,6 +55,7 @@ function transformNewForm(data) {
 	);
 	return {
 		aliases,
+		annotation: data.submissionSection.annotation.content,
 		areaId: data.publisherSection.area && data.publisherSection.area.id,
 		beginDate: data.publisherSection.beginDate,
 		disambiguation: data.nameSection.disambiguation,
@@ -244,13 +245,24 @@ function publisherToFormState(publisher) {
 		}
 	));
 
+	const optionalSections = {};
+	if (publisher.annotation) {
+		optionalSections.submissionSection = {
+			annotation: publisher.annotation,
+			note: '',
+			submitError: '',
+			submitted: false
+		};
+	}
+
 	return {
 		aliasEditor,
 		buttonBar,
 		identifierEditor,
 		nameSection,
 		publisherSection,
-		relationshipSection
+		relationshipSection,
+		...optionalSections
 	};
 }
 

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -58,6 +58,7 @@ function transformNewForm(data) {
 
 	return {
 		aliases,
+		annotation: data.submissionSection.annotation.content,
 		disambiguation: data.nameSection.disambiguation,
 		identifiers,
 		languages,
@@ -261,13 +262,24 @@ function workToFormState(work) {
 		}
 	));
 
+	const optionalSections = {};
+	if (work.annotation) {
+		optionalSections.submissionSection = {
+			annotation: work.annotation,
+			note: '',
+			submitError: '',
+			submitted: false
+		};
+	}
+
 	return {
 		aliasEditor,
 		buttonBar,
 		identifierEditor,
 		nameSection,
 		relationshipSection,
-		workSection
+		workSection,
+		...optionalSections
 	};
 }
 


### PR DESCRIPTION
### Problem
https://tickets.metabrainz.org/browse/BB-415
Annotations were being deleted automatically on editing an entity, and there was no way to display or edit the annotations.


### Solution
Reimplement annotations on the server and allow to edit and display them on the client.
![annotation_submit](https://user-images.githubusercontent.com/6179856/84179795-c83cf880-aa86-11ea-9fc8-1ed17c453345.png)
![annotation_display](https://user-images.githubusercontent.com/6179856/84179803-ca9f5280-aa86-11ea-9012-8e476a56468e.png)


### Follow up
Un-delete the annotations https://tickets.metabrainz.org/browse/BB-493
