### PR TITLE
docs(api): Clean up API & swagger definitions

### DIFF
--- a/src/api/helpers/entityLoader.js
+++ b/src/api/helpers/entityLoader.js
@@ -18,8 +18,8 @@
 
 // @flow
 
-
 import * as commonUtils from '../../common/helpers/utils';
+import log from 'log';
 
 /**
  * This is a middleware function to load entity detail according to given relations
@@ -55,7 +55,8 @@ export function makeEntityLoader(modelName, relations, errMessage, isBrowse) {
 				return next();
 			}
 			catch (err) {
-				return res.status(404).send({message: errMessage});
+				log.error(err);
+				return res.status(404).send({context: err, message: errMessage});
 			}
 		}
 		return res.status(400).send({message: 'BBID is not valid uuid'});

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -129,7 +129,8 @@ import workRouter from './routes/work';
  *            example: 'Heinlein, Robert A.'
  *          language:
  *            type: string
- *            example: 'English'
+ *            example: 'eng'
+ *            description: Three letter ISO 639-3 language code
  *          primary:
  *            type: boolean
  *            example: true
@@ -170,7 +171,7 @@ function initSearchRouter(app) {
 }
 
 function initDocsRoute(app) {
-	app.use('/api-docs', swaggerRoute);
+	app.use(['/api-docs', '/docs'], swaggerRoute);
 }
 
 function initRoutes() {

--- a/src/api/routes/author.js
+++ b/src/api/routes/author.js
@@ -82,7 +82,7 @@ const authorError = 'Author not found';
  *       type: string
  *       format: uuid
  *       example: 'f94d74ce-c748-4130-8d59-38b290af8af3'
- *     relatedAuthors:
+ *     authors:
  *       type: array
  *       items:
  *         type: object
@@ -259,22 +259,26 @@ router.get('/:bbid/relationships',
  *         in: query
  *         description: BBID of the corresponding Author
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: edition
  *         in: query
  *         description: BBID of the corresponding Edition
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: edition-group
  *         in: query
  *         description: BBID of the corresponding Edition Group
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: publisher
  *         in: query
  *         description: BBID of the corresponding Publisher
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: type
  *         in: query
  *         description: filter by Author type

--- a/src/api/routes/edition-group.js
+++ b/src/api/routes/edition-group.js
@@ -61,6 +61,31 @@ const editionGroupError = 'Edition Group not found';
  *      type:
  *        type: string
  *        example: 'Book'
+*  BrowsedEditionGroups:
+ *   type: object
+ *   properties:
+ *     bbid:
+ *       type: string
+ *       format: uuid
+ *       example: '4fb5ed30-e222-4204-83a3-5f2409c47e41'
+ *     editionGroups:
+ *       type: array
+ *       items:
+ *         type: object
+ *         properties:
+ *           entity:
+ *             $ref: '#/definitions/EditionGroupDetail'
+ *           relationships:
+ *             type: array
+ *             items:
+ *               type: object
+ *               properties:
+ *                  relationshipTypeID:
+ *                    type: number
+ *                    example: 3
+ *                  relationshipType:
+ *                    type: string
+ *                    example: 'Edition'
  *
  */
 
@@ -221,7 +246,8 @@ router.get('/:bbid/relationships',
  *         in: query
  *         description: BBID of the Edition
  *         required: true
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: type
  *         in: query
  *         description: filter by Edition Group type

--- a/src/api/routes/edition.js
+++ b/src/api/routes/edition.js
@@ -102,7 +102,7 @@ const editionError = 'Edition not found';
  *       type: string
  *       format: uuid
  *       example: 'f94d74ce-c748-4130-8d59-38b290af8af3'
- *     relatedWorks:
+ *     editions:
  *       type: array
  *       items:
  *         type: object
@@ -282,27 +282,32 @@ router.get('/:bbid/relationships',
  *         in: query
  *         description: BBID of the corresponding Author
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: edition
  *         in: query
  *         description: BBID of the corresponding Edition
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: edition-group
  *         in: query
  *         description: BBID of the corresponding Edition Group
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: publisher
  *         in: query
  *         description: BBID of the corresponding Publisher
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: work
  *         in: query
  *         description: BBID of the corresponding Work
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: format
  *         in: query
  *         description: filter by Edition format

--- a/src/api/routes/publisher.js
+++ b/src/api/routes/publisher.js
@@ -83,7 +83,7 @@ const publisherError = 'Publisher not found';
  *       type: string
  *       format: uuid
  *       example: 'f94d74ce-c748-4130-8d59-38b290af8af3'
- *     relatedPublishers:
+ *     publishers:
  *       type: array
  *       items:
  *         type: object
@@ -260,22 +260,26 @@ router.get('/:bbid/relationships',
  *         in: query
  *         description: BBID of the corresponding Author
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: edition
  *         in: query
  *         description: BBID of the corresponding Edition
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: publisher
  *         in: query
  *         description: BBID of the corresponding Publisher
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: work
  *         in: query
  *         description: BBID of the corresponding Work
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: type
  *         in: query
  *         description: filter by Publisher type

--- a/src/api/routes/work.js
+++ b/src/api/routes/work.js
@@ -79,7 +79,7 @@ const workError = 'Work not found';
  *       type: string
  *       format: uuid
  *       example: 'f94d74ce-c748-4130-8d59-38b290af8af3'
- *     relatedWorks:
+ *     works:
  *       type: array
  *       items:
  *         type: object
@@ -259,22 +259,26 @@ router.get('/:bbid/relationships',
  *         in: query
  *         description: BBID of the corresponding Author
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: edition
  *         in: query
  *         description: BBID of the corresponding Edition
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: publisher
  *         in: query
  *         description: BBID of the corresponding Publisher
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: work
  *         in: query
  *         description: BBID of the corresponding Work
  *         required: false
- *         type: bbid
+ *         type: string
+ *         format: uuid
  *       - name: type
  *         in: query
  *         description: filter by Work type

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -69,7 +69,7 @@ function _fetchEntityModelsForESResults(orm, results) {
 		}
 		const model = commonUtils.getEntityModelByType(orm, entityStub.type);
 		return model.forge({bbid: entityStub.bbid})
-			.fetch({require: false, withRelated: ['defaultAlias', 'disambiguation', 'aliasSet.aliases']})
+			.fetch({require: false, withRelated: ['defaultAlias.language', 'disambiguation', 'aliasSet.aliases']})
 			.then((entity) => entity && entity.toJSON());
 	}));
 }


### PR DESCRIPTION
- Missing defaultAlias language in search results (for API endpoint iso code)
- Missing swagger definitions and misc. corrections
- Log errors in makeEntityLoader