### PR TITLE
Fix: Pagination is showing wrong range in some cases

### DIFF
--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -61,6 +61,7 @@ router.get('/', (req, res, next) => {
 
 			const props = generateProps(req, res, {
 				entityTypes,
+				from,
 				hideSearch: true,
 				nextEnabled,
 				resultsPerPage: size,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://test.bookbrainz.org/search?q=harry+potter&from=20
In the pagination, this should be showing `21-40` but is showing `1-20`
<!-- What are you trying to solve? -->


### Solution
`from` was not passed in the props
<!-- What does this PR do to fix the problem? -->


