### PR TITLE
fix: disable edit EntityType field for non empty collection

### DIFF
--- a/src/client/components/forms/userCollection.js
+++ b/src/client/components/forms/userCollection.js
@@ -18,6 +18,7 @@
 
 
 import * as bootstrap from 'react-bootstrap';
+import {trim, uniqBy} from 'lodash';
 import CustomInput from '../../input';
 import DeleteCollectionModal from '../pages/parts/delete-collection-modal';
 import EntitySearchFieldOption from '../../entity-editor/common/entity-search-field-option';
@@ -28,7 +29,6 @@ import ReactSelect from 'react-select';
 import SelectWrapper from '../input/select-wrapper';
 import classNames from 'classnames';
 import request from 'superagent';
-import {uniqBy} from 'lodash';
 
 
 const {Alert, Button, ButtonGroup, Col} = bootstrap;
@@ -68,7 +68,7 @@ class UserCollectionForm extends React.Component {
 
 		const collaborators = this.getCleanedCollaborators();
 		const description = this.description.getValue();
-		const name = this.name.getValue();
+		const name = trim(this.name.getValue());
 		const privacy = this.privacy.getValue();
 		const entityType = this.entityType.getValue();
 
@@ -99,7 +99,7 @@ class UserCollectionForm extends React.Component {
 	}
 
 	isValid() {
-		return this.name.getValue() && this.entityType.getValue();
+		return trim(this.name.getValue()).length && this.entityType.getValue();
 	}
 
 	getCleanedCollaborators() {

--- a/src/client/components/forms/userCollection.js
+++ b/src/client/components/forms/userCollection.js
@@ -164,9 +164,9 @@ class UserCollectionForm extends React.Component {
 		const initialPrivacy = this.state.collection.public ? 'Public' : 'Private';
 		const initialType = this.state.collection.entityType;
 		const {errorText} = this.state;
-		const errorAlertClass =
-			classNames('text-center', 'margin-top-1', {hidden: !errorText});
+		const errorAlertClass = classNames('text-center', 'margin-top-1', {hidden: !errorText});
 		const submitLabel = this.props.collection.name ? 'Update collection' : 'Create collection';
+		const canEditType = this.props.collection.items.length === 0;
 
 		/* eslint-disable react/jsx-no-bind */
 		return (
@@ -202,7 +202,7 @@ class UserCollectionForm extends React.Component {
 							<SelectWrapper
 								base={ReactSelect}
 								defaultValue={initialType}
-								disabled={!this.props.canEditType}
+								disabled={!canEditType}
 								idAttribute="name"
 								label="Entity Type"
 								labelAttribute="name"
@@ -292,25 +292,23 @@ class UserCollectionForm extends React.Component {
 
 UserCollectionForm.displayName = 'UserCollectionForm';
 UserCollectionForm.propTypes = {
-	canEditType: PropTypes.bool,
 	collection: PropTypes.shape({
 		collaborators: PropTypes.array,
 		description: PropTypes.string,
 		entityType: PropTypes.string,
 		id: PropTypes.string,
-		isEdit: PropTypes.bool,
+		items: PropTypes.array,
 		name: PropTypes.string,
 		public: PropTypes.bool
 	})
 };
 UserCollectionForm.defaultProps = {
-	canEditType: true,
 	collection: {
 		collaborators: [],
 		description: '',
 		entityType: null,
 		id: null,
-		isEdit: false,
+		items: [],
 		name: null,
 		public: false
 	}

--- a/src/server/helpers/collectionRouteUtils.js
+++ b/src/server/helpers/collectionRouteUtils.js
@@ -21,7 +21,7 @@ import * as search from './search';
 import {camelCase, differenceWith, isEqual, toLower, upperFirst} from 'lodash';
 
 
-export async function collectionCreateOrEditHandler(req, res) {
+export async function collectionCreateOrEditHandler(req, res, next) {
 	try {
 		const {UserCollection, UserCollectionCollaborator} = req.app.locals.orm;
 		const isNew = !res.locals.collection;
@@ -34,6 +34,9 @@ export async function collectionCreateOrEditHandler(req, res) {
 			method = 'insert';
 		}
 		else {
+			if (upperFirst(camelCase(req.body.entityType)) !== res.locals.collection.entityType) {
+				throw new Error('Trying to change entityType of a non empty collection');
+			}
 			newCollection = await new UserCollection({id: req.params.collectionId}).fetch({
 				require: true
 			});
@@ -93,6 +96,6 @@ export async function collectionCreateOrEditHandler(req, res) {
 		return res.send(newCollection.toJSON());
 	}
 	catch (err) {
-		return res.status(500).send();
+		return next(err);
 	}
 }

--- a/src/server/routes/collection.js
+++ b/src/server/routes/collection.js
@@ -182,11 +182,9 @@ router.get('/:collectionId/edit', auth.isAuthenticated, auth.isCollectionOwner, 
 		collection
 	});
 	const script = '/js/collection/create.js';
-	const canEditType = collection.items.length === 0;
 	const markup = ReactDOMServer.renderToString(
 		<Layout {...propHelpers.extractLayoutProps(props)}>
 			<UserCollectionForm
-				canEditType={canEditType}
 				collection={props.collection}
 			/>
 		</Layout>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Collection Type field was editable for non empty collections
<!-- What are you trying to solve? -->


