### PR TITLE
BB-471: Save pagination parameters in url bar

### DIFF
--- a/src/client/components/pages/editor-revision.js
+++ b/src/client/components/pages/editor-revision.js
@@ -30,7 +30,7 @@ class EditorRevisionPage extends React.Component {
 		};
 
 		this.searchResultsCallback = this.searchResultsCallback.bind(this);
-		this.paginationUrl = './revisions/revisions?q=';
+		this.paginationUrl = './revisions/revisions?';
 	}
 
 	searchResultsCallback(newResults) {

--- a/src/client/components/pages/editor-revision.js
+++ b/src/client/components/pages/editor-revision.js
@@ -30,7 +30,7 @@ class EditorRevisionPage extends React.Component {
 		};
 
 		this.searchResultsCallback = this.searchResultsCallback.bind(this);
-		this.paginationUrl = './revisions/revisions?';
+		this.paginationUrl = './revisions/revisions';
 	}
 
 	searchResultsCallback(newResults) {

--- a/src/client/components/pages/entity-revisions.js
+++ b/src/client/components/pages/entity-revisions.js
@@ -43,7 +43,7 @@ class EntityRevisions extends React.Component {
 		// React does not autobind non-React class methods
 		this.renderHeader = this.renderHeader.bind(this);
 		this.searchResultsCallback = this.searchResultsCallback.bind(this);
-		this.paginationUrl = './revisions/revisions?';
+		this.paginationUrl = './revisions/revisions';
 	}
 
 	searchResultsCallback(newResults) {

--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -49,7 +49,7 @@ class PagerElement extends React.Component {
 		if (url.searchParams.get('size') !== this.state.size || url.searchParams.get('from') !== this.state.from) {
 			url.searchParams.set('size', this.state.size);
 			url.searchParams.set('from', this.state.from);
-			window.history.replaceState(null, '', `?${url.searchParams}`);
+			window.history.pushState(null, '', `?${url.searchParams}`);
 		}
 	}
 
@@ -58,6 +58,10 @@ class PagerElement extends React.Component {
 			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState({from: 0, query: this.props.query}, this.triggerSearch);
 		}
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener('popstate', this.handleURLChange);
 	}
 
 	handleURLChange = () => {
@@ -76,18 +80,20 @@ class PagerElement extends React.Component {
 			return;
 		}
 
-		this.triggerSearch(newFrom, newSize);
+		this.triggerSearch(newFrom, newSize, false);
 	};
 
-	triggerSearch(newFrom = this.state.from, newSize = this.state.size) {
+	triggerSearch(newFrom = this.state.from, newSize = this.state.size, setSearchParams = true) {
 		// get 1 more result than size to check nextEnabled
 		const pagination = `&size=${newSize + 1}&from=${newFrom}`;
 
-		const url = new URL(window.location.href);
-		if (url.searchParams.get('size') !== newSize || url.searchParams.get('from') !== newFrom) {
-			url.searchParams.set('size', newSize);
-			url.searchParams.set('from', newFrom);
-			window.history.pushState(null, '', `?${url.searchParams}`);
+		if (setSearchParams) {
+			const url = new URL(window.location.href);
+			if (url.searchParams.get('size') !== newSize || url.searchParams.get('from') !== newFrom) {
+				url.searchParams.set('size', newSize);
+				url.searchParams.set('from', newFrom);
+				window.history.pushState(null, '', `?${url.searchParams}`);
+			}
 		}
 
 		request.get(`${this.props.paginationUrl}${this.state.query}${pagination}`)

--- a/src/client/components/pages/parts/search-field.js
+++ b/src/client/components/pages/parts/search-field.js
@@ -41,43 +41,65 @@ const SearchButton = (
 	</Button>
 );
 
-const updateDelay = 300;
+const updateDelay = 400;
 
-class SearchField extends React.Component {
-	constructor(props) {
+type SearchFieldState = {
+	type: string,
+	query: string,
+};
+type SearchFieldProps = {
+	entityTypes: any[],
+	onSearch: Function,
+	query?: string,
+	type?: string
+};
+
+class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
+	constructor(props: SearchFieldProps) {
 		super(props);
 
 		this.state = {
-			type: ''
+			query: props.query || '',
+			type: props.type || ''
 		};
-		// React does not autobind non-React class methods
-		this.handleSubmit = this.handleSubmit.bind(this);
-		this.change = this.change.bind(this);
-		this.handleEntitySelect = this.handleEntitySelect.bind(this);
+		this.debouncedTriggerOnSearch = _.debounce(this.triggerOnSearch, updateDelay, {});
 	}
 
-	triggerOnSearch() {
-		const inputValue = this.queryInput.getValue();
-		const {type} = this.state;
-		this.props.onSearch(inputValue, _.snakeCase(type));
-	}
-
-	handleSubmit(event) {
-		event.preventDefault();
-		event.stopPropagation();
-		this.triggerOnSearch();
-	}
-
-	change() {
-		const inputValue = this.queryInput.getValue();
-		if (!inputValue.match(/^ *$/)) {
-			this.triggerOnSearch();
+	// If search term is changed outside this component (for example browser navigation),
+	// reflects those changes
+	componentDidUpdate(prevProps: SearchFieldProps) {
+		if (prevProps.query !== this.props.query) {
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState({query: this.props.query});
+		}
+		if (prevProps.type !== this.props.type) {
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState({type: this.props.type});
 		}
 	}
 
-	handleEntitySelect(eventKey: any) {
-		this.setState({type: eventKey}, this.triggerOnSearch);
+	debouncedTriggerOnSearch: Function;
+
+	triggerOnSearch() {
+		const {query, type} = this.state;
+		this.props.onSearch(query, _.snakeCase(type));
 	}
+
+	handleSubmit = event => {
+		event.preventDefault();
+		event.stopPropagation();
+		this.triggerOnSearch();
+	};
+
+	handleChange = event => {
+		if (!event.target.value.match(/^ *$/) && event.target.value !== this.state.query) {
+			this.setState({query: event.target.value}, this.debouncedTriggerOnSearch);
+		}
+	};
+
+	handleEntitySelect = (eventKey: any) => {
+		this.setState({type: eventKey}, this.debouncedTriggerOnSearch);
+	};
 
 	render() {
 		const entityTypeSelect = Array.isArray(this.props.entityTypes) ? (
@@ -125,11 +147,10 @@ class SearchField extends React.Component {
 					>
 						<CustomInput
 							buttonAfter={[entityTypeSelect, SearchButton]}
-							defaultValue={this.props.query}
 							name="q"
-							ref={(ref) => this.queryInput = ref}
 							type="text"
-							onChange={_.debounce(this.change, updateDelay)}
+							value={this.state.query}
+							onChange={this.handleChange}
 						/>
 					</form>
 				</div>
@@ -142,11 +163,13 @@ SearchField.displayName = 'SearchField';
 SearchField.propTypes = {
 	entityTypes: PropTypes.array.isRequired,
 	onSearch: PropTypes.func.isRequired,
-	query: PropTypes.string
+	query: PropTypes.string,
+	type: PropTypes.string
 };
 
 SearchField.defaultProps = {
-	query: ''
+	query: '',
+	type: ''
 };
 
 export default SearchField;

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -31,7 +31,7 @@ class RevisionsPage extends React.Component {
 
 		// React does not autobind non-React class methods
 		this.searchResultsCallback = this.searchResultsCallback.bind(this);
-		this.paginationUrl = './revisions/revisions?q=';
+		this.paginationUrl = './revisions/revisions?';
 	}
 
 	searchResultsCallback(newResults) {

--- a/src/client/components/pages/revisions.js
+++ b/src/client/components/pages/revisions.js
@@ -31,7 +31,7 @@ class RevisionsPage extends React.Component {
 
 		// React does not autobind non-React class methods
 		this.searchResultsCallback = this.searchResultsCallback.bind(this);
-		this.paginationUrl = './revisions/revisions?';
+		this.paginationUrl = './revisions/revisions';
 	}
 
 	searchResultsCallback(newResults) {

--- a/src/client/components/pages/search.js
+++ b/src/client/components/pages/search.js
@@ -42,47 +42,56 @@ class SearchPage extends React.Component {
 			type: props.type
 		};
 
-		// React does not autobind non-React class methods
-		this.handleSearch = this.handleSearch.bind(this);
-		this.searchResultsCallback = this.searchResultsCallback.bind(this);
 		this.paginationUrl = './search/search?q=';
 	}
 
 	componentDidMount() {
-		window.addEventListener('popstate', () => {
-			const url = new URL(window.location.href);
-			let query;
-			let type;
-			if (url.searchParams.has('q')) {
-				query = url.searchParams.get('q');
-			}
-			if (url.searchParams.has('type')) {
-				type = url.searchParams.get('type');
-			}
-			this.setState({query, type});
-		});
+		window.addEventListener('popstate', this.handleURLChange);
 	}
 
+	componentWillUnmount() {
+		window.removeEventListener('popstate', this.handleURLChange);
+	}
+
+	handleURLChange = () => {
+		const url = new URL(window.location.href);
+		let query;
+		let type;
+		if (url.searchParams.has('q')) {
+			query = url.searchParams.get('q');
+		}
+		if (url.searchParams.has('type')) {
+			type = url.searchParams.get('type');
+		}
+		if (query === this.state.query && type === this.state.type) {
+			return;
+		}
+		this.setState({query, type});
+	};
+
 	/**
-	 * Gets user text query from the SearchField component/ browser nav and
-	 * sets it in state to be passed down to
+	 * Gets user text query from the browser's URL search parameters and
+	 * sets it in the state to be passed down to SearchField and Pager components
 	 *
 	 * @param {string} query - Query string entered by user.
 	 * @param {string} type - Entity type selected from dropdown
 	 */
-	handleSearch(query, type) {
+	handleSearch = (query, type) => {
 		const url = new URL(window.location.href);
 		if (url.searchParams.get('q') !== query || url.searchParams.get('type') !== type) {
 			url.searchParams.set('q', query);
-			url.searchParams.set('type', type);
+			// Don't set the type if it's empty
+			if (type) {
+				url.searchParams.set('type', type);
+			}
 			window.history.pushState(null, '', `?${url.searchParams}`);
 		}
 		this.setState({query, type});
-	}
+	};
 
-	searchResultsCallback(newResults) {
+	searchResultsCallback = (newResults) => {
 		this.setState({results: newResults});
-	}
+	};
 
 	/**
 	 * Renders the component: Search bar with results table located vertically

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -65,7 +65,8 @@ router.get('/', (req, res, next) => {
 				hideSearch: true,
 				nextEnabled,
 				resultsPerPage: size,
-				...searchResults
+				...searchResults,
+				type: req.query.type
 			});
 			const markup = ReactDOMServer.renderToString(
 				<Layout {...propHelpers.extractLayoutProps(props)}>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
https://tickets.metabrainz.org/browse/BB-471
Pagination parameters (search query, size, page) aren't reflected in the browser's address bar or history.



### Solution
Previous/Next buttons in pagination component now save the parameters in the browser's history (thus updating the address bar and allowing for browser button navigation).

Upon browser navigation, we also needed a way to send back other query parameters back to the parent component (in the case of search page [i.e. `?q=myquerry&type=author`]).
This required a small refactor to handle a search parameters string instead of just the query string


### Areas of Impact
Pager component 
Search page component
Small touch (remove '?' from pagination url) on other pages that use pagination.