### PR TITLE
fix: throw error when trying to add collection, area, editor to a collection

### DIFF
--- a/src/client/components/pages/parts/search-results.js
+++ b/src/client/components/pages/parts/search-results.js
@@ -109,8 +109,19 @@ class SearchResults extends React.Component {
 		const selectedEntities = this.state.selected;
 		if (selectedEntities.length) {
 			const areAllEntitiesOfSameType = selectedEntities.every(entity => entity.type === selectedEntities[0].type);
+			const entityTypes = ['Author', 'Edition', 'EditionGroup', 'Publisher', 'Work'];
 			if (areAllEntitiesOfSameType) {
-				this.setState({message: {}, showModal: true});
+				if (entityTypes.includes(selectedEntities[0].type)) {
+					this.setState({message: {}, showModal: true});
+				}
+				else {
+					this.setState({
+						message: {
+							text: `${selectedEntities[0].type} cannot be added to a collection`,
+							type: 'danger'
+						}
+					});
+				}
 			}
 			else {
 				this.setState({


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
If you select `Editor` or `Area` or `Collection` in the search results, you can press `Add to collection` button and it doesn't throw any error.
<!-- What are you trying to solve? -->


### Solution

<!-- What does this PR do to fix the problem? -->

![Screenshot_2020-08-11 Search Results – BookBrainz](https://user-images.githubusercontent.com/45737735/89883343-a62a3880-dbe5-11ea-8ab2-50e006dd7421.png)
