### PR TITLE
fix(css): Adjust button margins

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -73,6 +73,19 @@ body {
     }
 }
 
+// We use bootstrap badges in buttons, which makes them a smidge taller than buttons with just text
+.btn.btn-sm , .btn.btn-xs , .btn-group-xs > .btn, .btn-group-sm > .btn {
+	.badge{
+		padding: 2px 6px;
+	}
+}
+
+// Buttons in Lobes overlap for some reason, which if opacity is reduced (disabled) will look quite bad
+.btn {
+    margin-left: 0;
+    margin-right: 0;
+}
+
 
 /* Site-wide styling */
 /* ================= */


### PR DESCRIPTION
With the User Collections we're doing new things with buttons that we haven't done before, which is unearthing a couple of small CSS issues.
For some reason the Lobes theme has slightly overlapping buttons, which means an opacity change (disabled) looks really bad.
We're also using badges in buttons which requires a small padding adjustment.


### Problem
Buttons are overlapping, which looks terrible with opacity (disabled buttons).
Also buttons with badges are a tiny bit higher that without.
<img width="603" alt="Capture d’écran 2020-08-27 à 14 28 38" src="https://user-images.githubusercontent.com/6179856/91443062-16d28580-e873-11ea-8a7a-2f9ce3b23a47.png">


### Solution
Adjust button css here and there:
<img width="697" alt="Capture d’écran 2020-08-27 à 14 37 14" src="https://user-images.githubusercontent.com/6179856/91443107-23ef7480-e873-11ea-90ea-fba2aa248f94.png">



### Areas of Impact
Just the LESS file.
