### PR TITLE
test: Prevent conflict in test fixtures ids

### DIFF
--- a/test/src/api/routes/test-author.js
+++ b/test/src/api/routes/test-author.js
@@ -27,7 +27,6 @@ import {browseAuthorBasicTests} from '../helpers';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import orm from '../../../bookbrainz-data';
-import {random} from 'faker';
 
 
 const {Relationship, RelationshipSet, RelationshipType, Revision} = orm;
@@ -187,7 +186,7 @@ describe('Browse Author', () => {
 
 		// Now create a revision which forms the relationship b/w work and authors
 		const editor = await createEditor();
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.id})
 			.save(null, {method: 'insert'});
 
 		const relationshipTypeData = {
@@ -205,7 +204,6 @@ describe('Browse Author', () => {
 		const relationshipsPromise = [];
 		for (const authorBBID of authorBBIDs) {
 			const relationshipData = {
-				id: random.number(),
 				sourceBbid: authorBBID,
 				targetBbid: work.get('bbid'),
 				typeId: relationshipTypeData.id
@@ -217,12 +215,12 @@ describe('Browse Author', () => {
 		}
 		const relationships = await Promise.all(relationshipsPromise);
 
-		const workRelationshipSet = await new RelationshipSet({id: random.number()})
+		const workRelationshipSet = await new RelationshipSet()
 			.save(null, {method: 'insert'})
 			.then((model) => model.relationships().attach(relationships).then(() => model));
 
-		work.set('relationshipSetId', workRelationshipSet.get('id'));
-		work.set('revisionId', revision.get('id'));
+		work.set('relationshipSetId', workRelationshipSet.id);
+		work.set('revisionId', revision.id);
 		await work.save(null, {method: 'update'});
 	});
 	after(truncateEntities);

--- a/test/src/api/routes/test-edition-group.js
+++ b/test/src/api/routes/test-edition-group.js
@@ -31,7 +31,6 @@ import {browseEditionGroupBasicTests} from '../helpers';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import orm from '../../../bookbrainz-data';
-import {random} from 'faker';
 
 
 const {Revision} = orm;
@@ -179,10 +178,10 @@ describe('Browse EditionGroup', () => {
 		await createEditionGroup(editionGroupBbid, editionGroupAttribs);
 		// create a revision which adds these two edition in the editionGroup
 		const editor = await createEditor();
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.id})
 			.save(null, {method: 'insert'});
 
-		edition.set('revisionId', revision.get('id'));
+		edition.set('revisionId', revision.id);
 		edition.set('editionGroupBbid', editionGroupBbid);
 		await edition.save(null, {method: 'update'});
 	});

--- a/test/src/api/routes/test-edition.js
+++ b/test/src/api/routes/test-edition.js
@@ -31,7 +31,6 @@ import {browseEditionBasicTests} from '../helpers';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import orm from '../../../bookbrainz-data';
-import {random} from 'faker';
 
 
 const {EditionFormat, Language, PublisherSet, Relationship, RelationshipSet, RelationshipType, Revision} = orm;
@@ -186,14 +185,13 @@ describe('Browse Edition', () => {
 			isoCode3: 'eng',
 			name: 'English'
 		};
-		const englishId = random.number();
-		await new Language({...englishAttrib, id: englishId})
+		const englishLanguage = await new Language(englishAttrib)
 			.save(null, {method: 'insert'});
 		const englishLanguageSet = await orm.func.language.updateLanguageSet(
 			orm,
 			null,
 			null,
-			[{id: englishId}]
+			[{id: englishLanguage.id}]
 		);
 		const frenchAttrib = {
 			frequency: 2,
@@ -203,14 +201,13 @@ describe('Browse Edition', () => {
 			isoCode3: 'fra',
 			name: 'French'
 		};
-		const frenchId = random.number();
-		await new Language({...frenchAttrib, id: frenchId})
+		const frenchLanguage = await new Language(frenchAttrib)
 			.save(null, {method: 'insert'});
 		const frenchLanguageSet = await orm.func.language.updateLanguageSet(
 			orm,
 			null,
 			null,
-			[{id: frenchId}]
+			[{id: frenchLanguage.id}]
 		);
 
 		// create 4 editions. 2 of French Language and 2 of English Language
@@ -225,12 +222,12 @@ describe('Browse Edition', () => {
 			const editionBBID = getRandomUUID();
 			editionAttrib.bbid = editionBBID;
 			editionAttrib.formatId = formatId;
-			editionAttrib.languageSetId = englishLanguageSet.get('id');
+			editionAttrib.languageSetId = englishLanguageSet.id;
 			await createEdition(editionBBID, editionAttrib);
 
 			const workBBID2 = getRandomUUID();
 			editionAttrib.bbid = workBBID2;
-			editionAttrib.languageSetId = frenchLanguageSet.get('id');
+			editionAttrib.languageSetId = frenchLanguageSet.id;
 			await createEdition(workBBID2, editionAttrib);
 
 			editionBBIDs.push(editionBBID, workBBID2);
@@ -240,7 +237,7 @@ describe('Browse Edition', () => {
 
 		// Now create a revision which forms the relationship b/w author and editions
 		const editor = await createEditor();
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.id})
 			.save(null, {method: 'insert'});
 
 		const relationshipTypeData = {
@@ -258,7 +255,6 @@ describe('Browse Edition', () => {
 		const relationshipsPromise = [];
 		for (const editionBBID of editionBBIDs) {
 			const relationshipData = {
-				id: random.number(),
 				sourceBbid: author.get('bbid'),
 				targetBbid: editionBBID,
 				typeId: relationshipTypeData.id
@@ -270,12 +266,12 @@ describe('Browse Edition', () => {
 		}
 		const relationships = await Promise.all(relationshipsPromise);
 
-		const authorRelationshipSet = await new RelationshipSet({id: random.number()})
+		const authorRelationshipSet = await new RelationshipSet()
 			.save(null, {method: 'insert'})
 			.then((model) => model.relationships().attach(relationships).then(() => model));
 
-		author.set('relationshipSetId', authorRelationshipSet.get('id'));
-		author.set('revisionId', revision.get('id'));
+		author.set('relationshipSetId', authorRelationshipSet.id);
+		author.set('revisionId', revision.id);
 		await author.save(null, {method: 'update'});
 	});
 	after(truncateEntities);
@@ -340,12 +336,12 @@ describe('Browse Edition', () => {
 
 		// create a revision which adds these two edition in the editionGroup
 		const editor = await createEditor();
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.id})
 			.save(null, {method: 'insert'});
 
-		editionA.set('revisionId', revision.get('id'));
+		editionA.set('revisionId', revision.id);
 		editionA.set('editionGroupBbid', editionGroup.get('bbid'));
-		editionB.set('revisionId', revision.get('id'));
+		editionB.set('revisionId', revision.id);
 		editionB.set('editionGroupBbid', editionGroup.get('bbid'));
 		await editionA.save(null, {method: 'update'});
 		await editionB.save(null, {method: 'update'});
@@ -363,22 +359,22 @@ describe('Browse Edition', () => {
 		// Now create a revision which forms the relationship b/w publisher and editions
 		const editor = await createEditor();
 
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.id})
 			.save(null, {method: 'insert'});
-		const publisherSet = await new PublisherSet({id: random.number()})
+		const publisherSet = await new PublisherSet()
 			.save(null, {method: 'insert'})
 			.then((model) => model.publishers().attach([publisher]).then(() => model));
 
-		const revision2 = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision2 = await new Revision({authorId: editor.id})
 			.save(null, {method: 'insert'});
-		const publisherSet2 = await new PublisherSet({id: random.number()})
+		const publisherSet2 = await new PublisherSet()
 			.save(null, {method: 'insert'})
 			.then((model) => model.publishers().attach([publisher]).then(() => model));
 
-		edition.set('publisherSetId', publisherSet.get('id'));
-		edition.set('revisionId', revision.get('id'));
-		edition2.set('publisherSetId', publisherSet2.get('id'));
-		edition2.set('revisionId', revision2.get('id'));
+		edition.set('publisherSetId', publisherSet.id);
+		edition.set('revisionId', revision.id);
+		edition2.set('publisherSetId', publisherSet2.id);
+		edition2.set('revisionId', revision2.id);
 
 		await edition.save(null, {method: 'update'});
 		await edition2.save(null, {method: 'update'});

--- a/test/src/api/routes/test-publisher.js
+++ b/test/src/api/routes/test-publisher.js
@@ -32,7 +32,6 @@ import {browsePublisherBasicTests} from '../helpers';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import orm from '../../../bookbrainz-data';
-import {random} from 'faker';
 
 
 const {PublisherSet, Relationship, RelationshipSet, RelationshipType, Revision} = orm;
@@ -194,7 +193,7 @@ describe('Browse Publishers', () => {
 
 		// Now create a revision which forms the relationship b/w work and publishers
 		const editor = await createEditor();
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.get('id')})
 			.save(null, {method: 'insert'});
 
 		const relationshipTypeData = {
@@ -211,7 +210,6 @@ describe('Browse Publishers', () => {
 		const relationshipsPromise = [];
 		for (const publisherBBID of publisherBBIDs) {
 			const relationshipData = {
-				id: random.number(),
 				sourceBbid: work.get('bbid'),
 				targetBbid: publisherBBID,
 				typeId: relationshipTypeData.id
@@ -223,12 +221,12 @@ describe('Browse Publishers', () => {
 		}
 		const relationships = await Promise.all(relationshipsPromise);
 
-		const workRelationshipSet = await new RelationshipSet({id: random.number()})
+		const workRelationshipSet = await new RelationshipSet()
 			.save(null, {method: 'insert'})
 			.then((model) => model.relationships().attach(relationships).then(() => model));
 
 		work.set('relationshipSetId', workRelationshipSet.get('id'));
-		work.set('revisionId', revision.get('id'));
+		work.set('revisionId', revision.id);
 		await work.save(null, {method: 'update'});
 	});
 	after(truncateEntities);
@@ -287,14 +285,14 @@ describe('Browse Publishers', () => {
 
 		// Now create a revision which forms the relationship b/w publisher and editions
 		const editor = await createEditor();
-		const revision = await new Revision({authorId: editor.get('id'), id: random.number()})
+		const revision = await new Revision({authorId: editor.get('id')})
 			.save(null, {method: 'insert'});
-		const publisherSet = await new PublisherSet({id: random.number()})
+		const publisherSet = await new PublisherSet()
 			.save(null, {method: 'insert'})
 			.then((model) => model.publishers().attach(publishers).then(() => model));
 
 		edition.set('publisherSetId', publisherSet.get('id'));
-		edition.set('revisionId', revision.get('id'));
+		edition.set('revisionId', revision.id);
 		await edition.save(null, {method: 'update'});
 
 		const res = await chai.request(app).get(`/publisher?edition=${edition.get('bbid')}`);

--- a/test/src/server/helpers/revisions.js
+++ b/test/src/server/helpers/revisions.js
@@ -1,18 +1,23 @@
 import * as error from '../../../../src/common/helpers/error';
+
 import {
-	createAuthor, createEdition,
+	createAuthor,
+	createEdition,
 	createEditionGroup,
-	createEditor, createPublisher, createWork,
+	createEditor,
+	createPublisher,
+	createWork,
 	truncateEntities
 } from '../../../test-helpers/create-entities';
-import {date, random} from 'faker';
 import {
 	getAssociatedEntityRevisions,
 	getOrderedRevisionForEditorPage,
 	getOrderedRevisions,
 	getOrderedRevisionsForEntityPage
 } from '../../../../src/server/helpers/revisions';
+
 import chai from 'chai';
+import {date} from 'faker';
 import orm from '../../../bookbrainz-data';
 
 
@@ -36,7 +41,6 @@ describe('getOrderedRevisions', () => {
 		};
 		const promiseArray = [];
 		for (let id = 1; id <= 50; id++) {
-			revisionAttribs.id = random.number();
 			revisionAttribs.createdAt = date.recent();
 			promiseArray.push(
 				new Revision(revisionAttribs).save(null, {method: 'insert'})
@@ -110,19 +114,17 @@ describe('getAssociatedEntityRevisions', () => {
 
 	it('should return formatted revisions array after adding entity (1 revision with 1 entity revised)', async () => {
 		// here author is revised
-		const revisionId = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId})
+		const revision = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
-		const dataId = random.number();
 		// we can ignore other fields expect aliasSetId. We are interested in fetching alias only
-		await new AuthorData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new AuthorRevision({bbid: authorJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const authorData = await new AuthorData({aliasSetId}).save(null, {method: 'insert'});
+		await new AuthorRevision({bbid: authorJSON.bbid, dataId: authorData.id, id: revision.id}).save(null, {method: 'insert'});
 
 		const formattedRevision = [
 			{
 				authorId: editorJSON.id,
 				entities: [],
-				revisionId
+				revisionId: revision.id
 			}
 		];
 		const revisionsWithEntities = await getAssociatedEntityRevisions(formattedRevision, orm);
@@ -134,31 +136,26 @@ describe('getAssociatedEntityRevisions', () => {
 
 	it('should return formatted revisions array after adding entities (1 revision with multiple (different type) entities revised)', async () => {
 		// here author, work, edition, editionGroup, publisher is revised
-		const revisionId = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId})
+		const revision = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
+		const revisionId = revision.id;
 
 		// We are interested in fetching alias only, we can ignore other fields.
 		// setting each entity's alias to author's alias
-		let dataId = random.number();
-		await new AuthorData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new AuthorRevision({bbid: authorJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const authorData = await new AuthorData({aliasSetId}).save(null, {method: 'insert'});
+		await new AuthorRevision({bbid: authorJSON.bbid, dataId: authorData.id, id: revisionId}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		await new EditionData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new EditionRevision({bbid: editionJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const editionData = await new EditionData({aliasSetId}).save(null, {method: 'insert'});
+		await new EditionRevision({bbid: editionJSON.bbid, dataId: editionData.id, id: revisionId}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		await new EditionGroupData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const editionGroupData = await new EditionGroupData({aliasSetId}).save(null, {method: 'insert'});
+		await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId: editionGroupData.id, id: revisionId}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		await new PublisherData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new PublisherRevision({bbid: publisherJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const publisherData = await new PublisherData({aliasSetId}).save(null, {method: 'insert'});
+		await new PublisherRevision({bbid: publisherJSON.bbid, dataId: publisherData.id, id: revisionId}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		await new WorkData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new WorkRevision({bbid: workJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const workData = await new WorkData({aliasSetId}).save(null, {method: 'insert'});
+		await new WorkRevision({bbid: workJSON.bbid, dataId: workData.id, id: revisionId}).save(null, {method: 'insert'});
 
 		const formattedRevision = [
 			{
@@ -182,19 +179,17 @@ describe('getAssociatedEntityRevisions', () => {
 		const work2 = await createWork();
 		const workJSON2 = work2.toJSON();
 
-		const revisionId = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId})
+		const revision = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
+		const revisionId = revision.id;
 
 		// We are interested in fetching alias only, we can ignore other fields.
 		// setting each entity's alias to author's alias
-		let dataId = random.number();
-		await new WorkData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new WorkRevision({bbid: workJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const workData = await new WorkData({aliasSetId}).save(null, {method: 'insert'});
+		await new WorkRevision({bbid: workJSON.bbid, dataId: workData.id, id: revisionId}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		await new WorkData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new WorkRevision({bbid: workJSON2.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		const workData2 = await new WorkData({aliasSetId}).save(null, {method: 'insert'});
+		await new WorkRevision({bbid: workJSON2.bbid, dataId: workData2.id, id: revisionId}).save(null, {method: 'insert'});
 
 		const formattedRevision = [
 			{
@@ -217,66 +212,57 @@ describe('getAssociatedEntityRevisions', () => {
 
 		// We are interested in fetching alias only, we can ignore other fields.
 		// setting each entity's alias to author's alias
-		let dataId = random.number();
-		const revisionId = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId})
+		const revision1 = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
-		await new AuthorData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new AuthorRevision({bbid: authorJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+		let data = await new AuthorData({aliasSetId}).save(null, {method: 'insert'});
+		await new AuthorRevision({bbid: authorJSON.bbid, dataId: data.id, id: revision1.id}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		const revisionId2 = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId2})
+		const revision2 = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
-		await new EditionData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new EditionRevision({bbid: editionJSON.bbid, dataId, id: revisionId2}).save(null, {method: 'insert'});
+		data = await new EditionData({aliasSetId}).save(null, {method: 'insert'});
+		await new EditionRevision({bbid: editionJSON.bbid, dataId: data.id, id: revision2.id}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		const revisionId3 = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId3})
-			.save(null, {method: 'insert'});
-		await new EditionGroupData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId, id: revisionId3}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		const revisionId4 = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId4})
+		const revision3 = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
-		await new PublisherData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new PublisherRevision({bbid: publisherJSON.bbid, dataId, id: revisionId4}).save(null, {method: 'insert'});
+		data = await new EditionGroupData({aliasSetId}).save(null, {method: 'insert'});
+		await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId: data.id, id: revision3.id}).save(null, {method: 'insert'});
 
-		dataId = random.number();
-		const revisionId5 = random.number();
-		await new Revision({authorId: editorJSON.id, id: revisionId5})
+		const revision4 = await new Revision({authorId: editorJSON.id})
 			.save(null, {method: 'insert'});
-		await new WorkData({aliasSetId, id: dataId}).save(null, {method: 'insert'});
-		await new WorkRevision({bbid: workJSON.bbid, dataId, id: revisionId5}).save(null, {method: 'insert'});
+		data = await new PublisherData({aliasSetId}).save(null, {method: 'insert'});
+		await new PublisherRevision({bbid: publisherJSON.bbid, dataId: data.id, id: revision4.id}).save(null, {method: 'insert'});
+
+		const revision5 = await new Revision({authorId: editorJSON.id})
+			.save(null, {method: 'insert'});
+		data = await new WorkData({aliasSetId}).save(null, {method: 'insert'});
+		await new WorkRevision({bbid: workJSON.bbid, dataId: data.id, id: revision5.id}).save(null, {method: 'insert'});
 
 		const formattedRevision = [
 			{
 				authorId: editorJSON.id,
 				entities: [],
-				revisionId
+				revisionId: revision1.id
 			},
 			{
 				authorId: editorJSON.id,
 				entities: [],
-				revisionId: revisionId2
+				revisionId: revision2.id
 			},
 			{
 				authorId: editorJSON.id,
 				entities: [],
-				revisionId: revisionId3
+				revisionId: revision3.id
 			},
 			{
 				authorId: editorJSON.id,
 				entities: [],
-				revisionId: revisionId4
+				revisionId: revision4.id
 			},
 			{
 				authorId: editorJSON.id,
 				entities: [],
-				revisionId: revisionId5
+				revisionId: revision5.id
 			}
 		];
 		const revisionsWithEntities = await getAssociatedEntityRevisions(formattedRevision, orm);
@@ -302,7 +288,6 @@ describe('getOrderedRevisionForEditorPage', () => {
 		};
 		const promiseArray = [];
 		for (let i = 1; i <= 50; i++) {
-			revisionAttribs.id = random.number();
 			revisionAttribs.createdAt = date.recent();
 			promiseArray.push(
 				new Revision(revisionAttribs).save(null, {method: 'insert'})
@@ -358,7 +343,7 @@ describe('getOrderedRevisionForEditorPage', () => {
 	});
 
 	it('should throw an error for an invalid editor', async () => {
-		req.params.id = random.number();
+		req.params.id = '98765';
 		try {
 			await getOrderedRevisionForEditorPage(0, 10, req);
 		}
@@ -369,25 +354,22 @@ describe('getOrderedRevisionForEditorPage', () => {
 	});
 
 	it('should return sorted revisions with notes sorted according to "postedAt"', async () => {
-		const revisionID = random.number();
 		const editor = await createEditor();
 		const editorJSON2 = editor.toJSON();
-		await new Revision({
+		const revision = await new Revision({
 			authorId: editorJSON2.id,
-			createdAt: date.recent(),
-			id: revisionID
+			createdAt: date.recent()
 		}).save(null, {method: 'insert'});
 
 		const noteAttrib = {
 			authorId: editorJSON2.id,
 			content: 'note content',
-			revisionID
+			revisionId: revision.id
 		};
 
 		// Creating 10 notes for this new revision
 		const promiseArray = [];
 		for (let i = 1; i <= 10; i++) {
-			noteAttrib.id = random.number();
 			noteAttrib.postedAt = date.recent();
 			promiseArray.push(
 				new Note(noteAttrib).save(null, {method: 'insert'})
@@ -429,11 +411,9 @@ describe('getOrderedRevisionsForEntityPage', () => {
 
 		// starting from 2 because one revision is created while creating the author
 		for (let i = 2; i <= numberOfRevisions; i++) {
-			const revisionId = random.number();
-			const dataId = random.number();
-			await new Revision({authorId: editorJSON.id, createdAt: date.recent(), id: revisionId}).save(null, {method: 'insert'});
-			await new AuthorData({aliasSetId: authorJSON.aliasSetId, id: dataId}).save(null, {method: 'insert'});
-			await new AuthorRevision({bbid: authorJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+			const revision = await new Revision({authorId: editorJSON.id, createdAt: date.recent()}).save(null, {method: 'insert'});
+			const authorData = await new AuthorData({aliasSetId: authorJSON.aliasSetId}).save(null, {method: 'insert'});
+			await new AuthorRevision({bbid: authorJSON.bbid, dataId: authorData.id, id: revision.id}).save(null, {method: 'insert'});
 		}
 		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, AuthorRevision, authorJSON.bbid);
 
@@ -457,11 +437,9 @@ describe('getOrderedRevisionsForEntityPage', () => {
 
 		// starting from 2 because one revision is created while creating the work
 		for (let i = 2; i <= numberOfRevisions; i++) {
-			const revisionId = random.number();
-			const dataId = random.number();
-			await new Revision({authorId: editorJSON.id, createdAt: date.recent(), id: revisionId}).save(null, {method: 'insert'});
-			await new WorkData({aliasSetId: workJSON.aliasSetId, id: dataId}).save(null, {method: 'insert'});
-			await new WorkRevision({bbid: workJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+			const revision = await new Revision({authorId: editorJSON.id, createdAt: date.recent()}).save(null, {method: 'insert'});
+			const data = await new WorkData({aliasSetId: workJSON.aliasSetId}).save(null, {method: 'insert'});
+			await new WorkRevision({bbid: workJSON.bbid, dataId: data.id, id: revision.id}).save(null, {method: 'insert'});
 		}
 
 		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, WorkRevision, workJSON.bbid);
@@ -486,11 +464,9 @@ describe('getOrderedRevisionsForEntityPage', () => {
 
 		// starting from 2 because one revision is created while creating the work
 		for (let i = 2; i <= numberOfRevisions; i++) {
-			const revisionId = random.number();
-			const dataId = random.number();
-			await new Revision({authorId: editorJSON.id, createdAt: date.recent(), id: revisionId}).save(null, {method: 'insert'});
-			await new EditionData({aliasSetId: editionJSON.aliasSetId, id: dataId}).save(null, {method: 'insert'});
-			await new EditionRevision({bbid: editionJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+			const revision = await new Revision({authorId: editorJSON.id, createdAt: date.recent()}).save(null, {method: 'insert'});
+			const data = await new EditionData({aliasSetId: editionJSON.aliasSetId}).save(null, {method: 'insert'});
+			await new EditionRevision({bbid: editionJSON.bbid, dataId: data.id, id: revision.id}).save(null, {method: 'insert'});
 		}
 
 		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, EditionRevision, editionJSON.bbid);
@@ -515,11 +491,9 @@ describe('getOrderedRevisionsForEntityPage', () => {
 
 		// starting from 2 because one revision is created while creating the publisher
 		for (let i = 2; i <= numberOfRevisions; i++) {
-			const revisionId = random.number();
-			const dataId = random.number();
-			await new Revision({authorId: editorJSON.id, createdAt: date.recent(), id: revisionId}).save(null, {method: 'insert'});
-			await new PublisherData({aliasSetId: publisherJSON.aliasSetId, id: dataId}).save(null, {method: 'insert'});
-			await new PublisherRevision({bbid: publisherJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+			const revision = await new Revision({authorId: editorJSON.id, createdAt: date.recent()}).save(null, {method: 'insert'});
+			const data = await new PublisherData({aliasSetId: publisherJSON.aliasSetId}).save(null, {method: 'insert'});
+			await new PublisherRevision({bbid: publisherJSON.bbid, dataId: data.id, id: revision.id}).save(null, {method: 'insert'});
 		}
 
 		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, PublisherRevision, publisherJSON.bbid);
@@ -544,11 +518,9 @@ describe('getOrderedRevisionsForEntityPage', () => {
 
 		// starting from 2 because one revision is created while creating the editionGroup
 		for (let i = 2; i <= numberOfRevisions; i++) {
-			const revisionId = random.number();
-			const dataId = random.number();
-			await new Revision({authorId: editorJSON.id, createdAt: date.recent(), id: revisionId}).save(null, {method: 'insert'});
-			await new EditionGroupData({aliasSetId: editionGroupJSON.aliasSetId, id: dataId}).save(null, {method: 'insert'});
-			await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId, id: revisionId}).save(null, {method: 'insert'});
+			const revision = await new Revision({authorId: editorJSON.id, createdAt: date.recent()}).save(null, {method: 'insert'});
+			const data = await new EditionGroupData({aliasSetId: editionGroupJSON.aliasSetId}).save(null, {method: 'insert'});
+			await new EditionGroupRevision({bbid: editionGroupJSON.bbid, dataId: data.id, id: revision.id}).save(null, {method: 'insert'});
 		}
 
 		const orderedRevisions = await getOrderedRevisionsForEntityPage(orm, 0, numberOfRevisions, EditionGroupRevision, editionGroupJSON.bbid);
@@ -581,7 +553,6 @@ describe('getOrderedRevisionsForEntityPage', () => {
 		// create 10 notes for the revision
 		const promiseArray = [];
 		for (let i = 1; i <= 10; i++) {
-			noteAttrib.id = random.number();
 			noteAttrib.postedAt = date.recent();
 			promiseArray.push(
 				new Note(noteAttrib).save(null, {method: 'insert'})

--- a/test/src/server/routes/editor.js
+++ b/test/src/server/routes/editor.js
@@ -3,7 +3,6 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import {getEditorActivity} from '../../../../src/server/routes/editor.js';
 import orm from '../../../bookbrainz-data';
-import {random} from 'faker';
 
 /* eslint sort-keys: 0 */
 chai.use(chaiHttp);
@@ -40,7 +39,6 @@ describe('getEditorActivity', () => {
 		for (let i = 0; i < 12; i++) {
 			const tempDate = new Date();
 			tempDate.setFullYear(2020, i, 1);
-			revisionAttribs.id = random.number();
 			revisionAttribs.createdAt = tempDate;
 			revisionsPromiseArray.push(
 				new Revision(revisionAttribs).save(null, {method: 'insert'})
@@ -70,7 +68,6 @@ describe('getEditorActivity', () => {
 		for (let i = 0; i < 12; i += 2) {
 			const tempDate = new Date();
 			tempDate.setFullYear(2020, i, 1);
-			revisionAttribs.id = random.number();
 			revisionAttribs.createdAt = tempDate;
 			revisionsPromiseArray.push(
 				new Revision(revisionAttribs).save(null, {method: 'insert'})

--- a/test/test-helpers/create-entities.js
+++ b/test/test-helpers/create-entities.js
@@ -18,6 +18,8 @@
  */
 
 import {internet, random} from 'faker';
+
+import {isNil} from 'lodash';
 import orm from '../bookbrainz-data';
 // eslint-disable-next-line import/no-internal-modules
 import uuidv4 from 'uuid/v4';
@@ -33,17 +35,13 @@ const {
 const {updateLanguageSet} = orm.func.language;
 
 
-const setData = {id: 1};
-
 export const editorTypeAttribs = {
-	id: 1,
 	label: 'test_type'
 };
 
 export const editorAttribs = {
 	cachedMetabrainzName: 'Bob',
 	genderId: 1,
-	id: 1,
 	metabrainzUserId: 1,
 	name: 'bob',
 	revisionsApplied: 0,
@@ -52,7 +50,6 @@ export const editorAttribs = {
 
 const languageAttribs = {
 	frequency: 1,
-	id: 1,
 	isoCode1: 'en',
 	isoCode2b: 'eng',
 	isoCode2t: 'eng',
@@ -61,35 +58,26 @@ const languageAttribs = {
 };
 
 export const aliasData = {
-	id: 1,
 	languageId: 42,
 	name: 'Entity name',
 	sortName: 'Entity sort name'
 };
 
 const identifierData = {
-	...setData,
-	typeId: 1,
 	value: 'Q123456'
 };
 
-const revisionAttribs = {
-	authorId: 1,
-	id: 1
-};
-
+const revisionAttribs = {authorId: 1};
 const identifierTypeData = {
 	description: 'test',
 	displayTemplate: 'test',
 	entityType: 'Work',
-	...setData,
 	label: 'test',
 	validationRegex: 'test'
 };
 
 const relationshipTypeData = {
 	description: 'test descryption',
-	id: 1,
 	label: 'test label',
 	linkPhrase: 'test phrase',
 	reverseLinkPhrase: 'test reverse link phrase',
@@ -110,15 +98,14 @@ const entityAttribs = {
 
 export function createEditor(editorId) {
 	return orm.bookshelf.knex.transaction(async (transacting) => {
-		editorTypeAttribs.id = random.number();
-		await new EditorType(editorTypeAttribs)
+		const editorType = await new EditorType(editorTypeAttribs)
 			.save(null, {method: 'insert', transacting});
-		const gender = await new Gender({...setData, id: random.number(), name: 'test'})
+		const gender = await new Gender({name: 'test'})
 			.save(null, {method: 'insert', transacting});
 
 		editorAttribs.id = editorId || random.number();
-		editorAttribs.genderId = gender.get('id');
-		editorAttribs.typeId = editorTypeAttribs.id;
+		editorAttribs.genderId = gender.id;
+		editorAttribs.typeId = editorType.id;
 		editorAttribs.name = internet.userName();
 		editorAttribs.metabrainzUserId = random.number();
 		editorAttribs.cachedMetabrainzName = editorAttribs.name;
@@ -130,36 +117,34 @@ export function createEditor(editorId) {
 }
 
 async function createAliasAndAliasSet() {
-	aliasData.languageId = random.number();
-	await new Language({...languageAttribs, id: aliasData.languageId})
+	const language = await new Language({...languageAttribs})
 		.save(null, {method: 'insert'})
 		.catch(console.log);
-	const alias = await new Alias({...aliasData, id: random.number()})
+	aliasData.languageId = language.id;
+	const alias = await new Alias({...aliasData})
 		.save(null, {method: 'insert'});
 
-	entityAttribs.aliasSetId = random.number();
-	await new AliasSet({
-		defaultAliasId: alias.get('id'),
-		id: entityAttribs.aliasSetId
+	const aliasSet = await new AliasSet({
+		defaultAliasId: alias.id
 	})
-		.save(null, {method: 'insert'})
-		.then((model) => model.aliases().attach([alias]));
+		.save(null, {method: 'insert'});
+	entityAttribs.aliasSetId = aliasSet.id;
+	await aliasSet.aliases().attach([alias.id]);
 }
 
 async function createIdentifierAndIdentifierSet() {
-	identifierTypeData.id = random.number();
-	await new IdentifierType(identifierTypeData)
+	const identifierType = await new IdentifierType(identifierTypeData)
 		.save(null, {method: 'insert'})
 		.catch(console.log);
 
-	identifierData.typeId = identifierTypeData.id;
-	const identifier = await new Identifier({...identifierData, id: random.number()})
+	identifierData.typeId = identifierType.id;
+	const identifier = await new Identifier(identifierData)
 		.save(null, {method: 'insert'});
 
-	entityAttribs.identifierSetId = random.number();
-	await new IdentifierSet({id: entityAttribs.identifierSetId})
-		.save(null, {method: 'insert'})
-		.then((model) => model.identifiers().attach([identifier]));
+	const identifierSet = await new IdentifierSet()
+		.save(null, {method: 'insert'});
+	entityAttribs.identifierSetId = identifierSet.id;
+	await identifierSet.identifiers().attach([identifier.id]);
 }
 
 async function createRelationshipSet(sourceBbid, targetBbid, targetEntityType = 'Author') {
@@ -170,55 +155,45 @@ async function createRelationshipSet(sourceBbid, targetBbid, targetEntityType = 
 	await new Entity({bbid: safeTargetBbid, type: targetEntityType})
 		.save(null, {method: 'insert'});
 	const EntityModel = orm[`${targetEntityType}`];
-	const revisionId = random.number();
-	await new Revision({authorId: editorAttribs.id, id: revisionId})
+	const revision = await new Revision({authorId: editorAttribs.id})
 		.save(null, {method: 'insert'});
 	await new EntityModel({
-		aliasSetId: entityAttribs.aliasSetId, bbid: safeTargetBbid, revisionId
+		aliasSetId: entityAttribs.aliasSetId, bbid: safeTargetBbid, revisionId: revision.id
 	}).save(null, {method: 'insert'});
 
-	const relationshipData = {
-		id: random.number(),
-		sourceBbid: safeSourceBbid,
-		targetBbid: safeTargetBbid,
-		typeId: relationshipTypeData.id
-	};
 
-	relationshipTypeData.id = random.number();
-	await new RelationshipType(relationshipTypeData)
+	const relationshipType = await new RelationshipType(relationshipTypeData)
 		.save(null, {method: 'insert'})
 		.catch(console.log);
 
-	relationshipData.typeId = relationshipTypeData.id;
-	relationshipData.id = random.number();
+	const relationshipData = {
+		sourceBbid: safeSourceBbid,
+		targetBbid: safeTargetBbid,
+		typeId: relationshipType.id
+	};
 	const relationship = await new Relationship(relationshipData)
 		.save(null, {method: 'insert'});
 
-	entityAttribs.relationshipSetId = random.number();
-	await new RelationshipSet({id: entityAttribs.relationshipSetId})
-		.save(null, {method: 'insert'})
-		.then(
-			(model) =>
-				model.relationships().attach([relationship]).then(() => model)
-		);
+	const relationshipSet = await new RelationshipSet()
+		.save(null, {method: 'insert'});
+	entityAttribs.relationshipSetId = relationshipSet.id;
+	await relationshipSet.relationships().attach([relationship.id]);
 }
 
 
 async function createLanguageSet() {
 	// Create relationships here if you need them
-	const language1Id = random.number();
-	const language2Id = random.number();
-	await new Language({...languageAttribs, id: language1Id})
+	const language1 = await new Language(languageAttribs)
 		.save(null, {method: 'insert'});
-	await new Language({...languageAttribs, id: language2Id})
+	const language2 = await new Language(languageAttribs)
 		.save(null, {method: 'insert'});
 	const languageSet = await updateLanguageSet(
 		orm,
 		null,
 		null,
-		[{id: language1Id}, {id: language2Id}]
+		[{id: language1.id}, {id: language2.id}]
 	);
-	return languageSet.get('id');
+	return languageSet.id;
 }
 
 export function getRandomUUID() {
@@ -232,25 +207,22 @@ async function createEntityPrerequisites(entityBbid, entityType) {
 	await createRelationshipSet(entityBbid, null, entityType);
 
 	const disambiguation = await new Disambiguation({
-		comment: 'Test Disambiguation',
-		id: random.number()
+		comment: 'Test Disambiguation'
 	})
 		.save(null, {method: 'insert'});
-	entityAttribs.disambiguationId = disambiguation.get('id');
+	entityAttribs.disambiguationId = disambiguation.id;
 
-	revisionAttribs.id = random.number();
 	revisionAttribs.authorId = editorAttribs.id;
-	await new Revision(revisionAttribs)
+	const revision = await new Revision(revisionAttribs)
 		.save(null, {method: 'insert'});
-	entityAttribs.revisionId = revisionAttribs.id;
+	entityAttribs.revisionId = revision.id;
 
-	entityAttribs.annotationId = random.number();
-	await new Annotation({
+	const annotation = await new Annotation({
 		content: 'Test Annotation',
-		id: entityAttribs.annotationId,
-		lastRevisionId: revisionAttribs.id
+		lastRevisionId: revision.id
 	})
 		.save(null, {method: 'insert'});
+	entityAttribs.annotationId = annotation.id;
 }
 
 export async function createEdition(optionalBBID, optionalEditionAttribs = {}) {
@@ -264,30 +236,37 @@ export async function createEdition(optionalBBID, optionalEditionAttribs = {}) {
 	return edition;
 }
 
-export async function createWork(optionalBBID, optionalWorkAttribs) {
+export async function createWork(optionalBBID, optionalWorkAttribs = {}) {
 	const bbid = optionalBBID || uuidv4();
 	await new Entity({bbid, type: 'Work'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Work');
 
 	let languageSetId;
-	if (!optionalWorkAttribs?.languageSetId) {
+	if (!optionalWorkAttribs.languageSetId) {
 		languageSetId = await createLanguageSet();
 	}
+	let workType;
+	const optionalWorkTypeAttribs = {};
+	if (!isNil(optionalWorkAttribs.typeId)) {
+		optionalWorkTypeAttribs.id = optionalWorkAttribs.typeId;
+		workType = await new WorkType({id: optionalWorkAttribs.typeId})
+			.fetch({
+				require: false
+			});
+	}
+
+	if (!workType) {
+		workType = await new WorkType({label: `Work Type ${optionalWorkAttribs.typeId || random.number()}`, ...optionalWorkTypeAttribs})
+			.save(null, {method: 'insert'});
+	}
+
 	const workAttribs = {
 		bbid,
 		languageSetId,
-		typeId: random.number(),
+		typeId: workType.id,
 		...optionalWorkAttribs
 	};
-	const workType = await new WorkType({id: workAttribs.typeId, label: `Work Type ${workAttribs.typeId}`})
-		.fetch({
-			require: false
-		});
-	if (!workType) {
-		await new WorkType({id: workAttribs.typeId, label: `Work Type ${workAttribs.typeId}`})
-			.save(null, {method: 'insert'});
-	}
 	const work = await new Work({...entityAttribs, ...workAttribs})
 		.save(null, {method: 'insert'});
 	return work;
@@ -298,13 +277,18 @@ export async function createEditionGroup(optionalBBID, optionalEditionGroupAttri
 	await new Entity({bbid, type: 'EditionGroup'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'EditionGroup');
+	const optionalEditionGroupTypeAttrib = {};
+	if (!isNil(optionalEditionGroupAttrib.typeId)) {
+		optionalEditionGroupTypeAttrib.id = optionalEditionGroupAttrib.typeId;
+	}
+	const editionGroupType = await new EditionGroupType({label: `Edition Group Type ${optionalEditionGroupAttrib.typeId || random.number()}`, ...optionalEditionGroupTypeAttrib})
+		.save(null, {method: 'insert'});
+
 	const editionGroupAttribs = {
 		bbid,
-		typeId: random.number(),
+		typeId: editionGroupType.id,
 		...optionalEditionGroupAttrib
 	};
-	await new EditionGroupType({id: editionGroupAttribs.typeId, label: `Edition Group Type ${editionGroupAttribs.typeId}`})
-		.save(null, {method: 'insert'});
 	const editionGroup = await new EditionGroup({...entityAttribs, ...editionGroupAttribs})
 		.save(null, {method: 'insert'});
 	return editionGroup;
@@ -315,24 +299,10 @@ export async function createAuthor(optionalBBID, optionalAuthorAttribs = {}) {
 	await new Entity({bbid, type: 'Author'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Author');
-	const areaId = random.number();
-	const authorAttribs = {
-		bbid,
-		beginAreaId: areaId,
-		beginDay: 25,
-		beginMonth: 12,
-		beginYear: 2000,
-		endAreaId: areaId,
-		endDay: 10,
-		endMonth: 5,
-		endYear: 2012,
-		ended: true,
-		genderId: editorAttribs.genderId,
-		typeId: 1,
-		...optionalAuthorAttribs
-	};
-	await new Area({gid: uuidv4(), id: areaId, name: 'Rlyeh'})
+
+	const area = await new Area({gid: uuidv4(), name: 'Rlyeh'})
 		.save(null, {method: 'insert'});
+
 	// Front-end requires 'Person' and 'Group' types
 	try {
 		await new AuthorType({id: 1, label: 'Person'})
@@ -348,6 +318,22 @@ export async function createAuthor(optionalBBID, optionalAuthorAttribs = {}) {
 	catch (error) {
 		// Type already exists
 	}
+
+	const authorAttribs = {
+		bbid,
+		beginAreaId: area.id,
+		beginDay: 25,
+		beginMonth: 12,
+		beginYear: 2000,
+		endAreaId: area.id,
+		endDay: 10,
+		endMonth: 5,
+		endYear: 2012,
+		ended: true,
+		genderId: editorAttribs.genderId,
+		typeId: 1,
+		...optionalAuthorAttribs
+	};
 	const author = await new Author({...entityAttribs, ...authorAttribs})
 		.save(null, {method: 'insert'});
 	return author;
@@ -358,8 +344,33 @@ export async function createPublisher(optionalBBID, optionalPublisherAttribs = {
 	await new Entity({bbid, type: 'Publisher'})
 		.save(null, {method: 'insert'});
 	await createEntityPrerequisites(bbid, 'Publisher');
+
+	let area;
+	const optionalAreaAttribs = {};
+	if (!isNil(optionalPublisherAttribs.areaId)) {
+		optionalAreaAttribs.id = optionalPublisherAttribs.areaId;
+		area = await new Area({id: optionalPublisherAttribs.areaId})
+			.fetch({require: false});
+	}
+	if (!area) {
+		area = await new Area({gid: uuidv4(), name: `Area ${optionalPublisherAttribs.areaId || random.number()}`, ...optionalAreaAttribs})
+			.save(null, {method: 'insert'});
+	}
+
+	const optionalPublisherTypeAttribs = {};
+	let publisherType;
+	if (!isNil(optionalPublisherAttribs.typeId)) {
+		optionalPublisherTypeAttribs.id = optionalPublisherAttribs.typeId;
+		publisherType = await new PublisherType({id: optionalPublisherAttribs.typeId})
+			.fetch({require: false});
+	}
+	if (!publisherType) {
+		publisherType = await new PublisherType({label: `Publisher Type ${optionalPublisherAttribs.typeId || random.number()}`, ...optionalPublisherTypeAttribs})
+			.save(null, {method: 'insert'});
+	}
+
 	const publisherAttribs = {
-		areaId: random.number(),
+		areaId: area.id,
 		bbid,
 		beginDay: 25,
 		beginMonth: 12,
@@ -368,22 +379,9 @@ export async function createPublisher(optionalBBID, optionalPublisherAttribs = {
 		endMonth: 5,
 		endYear: 2012,
 		ended: true,
-		typeId: random.number(),
+		typeId: publisherType.id,
 		...optionalPublisherAttribs
 	};
-	const area = await new Area({id: publisherAttribs.areaId, name: `Area ${publisherAttribs.areaId}`})
-		.fetch({require: false});
-	if (!area) {
-		await new Area({gid: uuidv4(), id: publisherAttribs.areaId, name: `Area ${publisherAttribs.areaId}`})
-			.save(null, {method: 'insert'});
-	}
-
-	const publisherType = await new PublisherType({id: publisherAttribs.typeId, label: `Publisher Type ${publisherAttribs.typeId}`})
-		.fetch({require: false});
-	if (!publisherType) {
-		await new PublisherType({id: publisherAttribs.typeId, label: `Publisher Type ${publisherAttribs.typeId}`})
-			.save(null, {method: 'insert'});
-	}
 	const publisher = await new Publisher({...entityAttribs, ...publisherAttribs})
 		.save(null, {method: 'insert'});
 	return publisher;


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Tests were failing erratically because of two reasons:
1. We were assigning an id to pretty much all the test fixtures we created using the ORM, when it's not necessary
2. The random number generator we were using to generate the ids was creating conflicting ids


### Solution
Let the database create ids, which required a few changes in the test helpers.


### Areas of Impact
Tests only.
