### PR TITLE
fix(test): add 500ms timeout after deleting a collection

### DIFF
--- a/test/src/server/routes/collection.js
+++ b/test/src/server/routes/collection.js
@@ -570,6 +570,7 @@ describe('POST /collection/collectionID/delete', () => {
 		await generateIndex(orm);
 		const oldResult = await searchByName(orm, collectionData.name, 'Collection', 10, 0);
 		const res = await agent.post(`/collection/${collection.get('id')}/delete/handler`).send();
+		await new Promise(resolve => setTimeout(resolve, 500));
 		await refreshIndex();
 		const newResult = await searchByName(orm, collectionData.name, 'Collection', 10, 0);
 		const collections = await new UserCollection().where('id', collection.get('id')).fetchAll({require: false});


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
One test was inconsistent and showing false negative. Adding timeout after deleting a collection will make sure that ES index is updated
<!-- What are you trying to solve? -->


### Solution
wait 500ms after deleting a collection to make sure ES index is updated
<!-- What does this PR do to fix the problem? -->


### Areas of Impact
test/src/server/routes/collection.js
<!-- What parts of the codebase and which behaviors are affected? -->
