### PR TITLE
fix: convert collectionType to appropiate format before param-validation

### DIFF
--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -215,7 +215,7 @@ export async function validateCollectionParams(req, res, next) {
 		return next(new error.BadRequestError('Invalid collection name: Empty string not allowed', req));
 	}
 	const entityTypes = _.keys(commonUtils.getEntityModels(orm));
-	if (!entityTypes.includes(entityType)) {
+	if (!entityTypes.includes(_.upperFirst(_.camelCase(entityType)))) {
 		return next(new error.BadRequestError(`Invalid entity type: ${entityType} does not exist`, req));
 	}
 	const collaboratorIds = collaborators.map(collaborator => collaborator.id);

--- a/test/src/server/routes/collection.js
+++ b/test/src/server/routes/collection.js
@@ -1,7 +1,6 @@
 import {createAuthor, createEditor, truncateEntities} from '../../../test-helpers/create-entities';
 import {generateIndex, refreshIndex, searchByName} from '../../../../src/common/helpers/search';
 
-import _ from 'lodash';
 import app from '../../../../src/server/app';
 import assertArrays from 'chai-arrays';
 import chai from 'chai';
@@ -72,7 +71,7 @@ describe('POST /collection/create', () => {
 		expect(collection.get('id')).to.equal(res.body.id);
 		expect(collection.get('ownerId')).to.equal(collectionOwner.get('id'));
 		expect(collection.get('name')).to.equal(data.name);
-		expect(collection.get('entityType')).to.equal(_.upperFirst(_.camelCase(data.entityType)));
+		expect(collection.get('entityType')).to.equal('EditionGroup');
 		expect(collection.get('description')).to.equal(data.description);
 		expect(collection.get('public')).to.equal(true);
 		expect(res.status).to.equal(200);
@@ -254,7 +253,7 @@ describe('POST collection/edit', () => {
 
 		expect(res.status).to.equal(200);
 		expect(updatedCollectionJSON.name).to.equal(newData.name);
-		expect(updatedCollectionJSON.entityType).to.equal(_.upperFirst(_.camelCase(newData.entityType)));
+		expect(updatedCollectionJSON.entityType).to.equal('EditionGroup');
 		expect(updatedCollectionJSON.description).to.equal(newData.description);
 		expect(updatedCollectionJSON.collaborators.length).to.equal(1);
 		expect(updatedCollectionJSON.collaborators[0].collaboratorId).to.equal(newCollaborator.get('id'));


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
An error was occurring while creating Edition-Group collection.
<!-- What are you trying to solve? -->


### Solution
In the `paramValidation` middleware, I forgot to take convert entityType to `camel-case` before validating it.
<!-- What does this PR do to fix the problem? -->


### Areas of Impact
src/server/helpers/middleware.js
test/src/server/routes/collection.js
<!-- What parts of the codebase and which behaviors are affected? -->
