### PR TITLE
Collections public dumps

### DIFF
--- a/DEPENDENCIES_MANUAL_INSTALL.md
+++ b/DEPENDENCIES_MANUAL_INSTALL.md
@@ -44,22 +44,26 @@ No setup is required for Redis or Elasticsearch. However, it is necessary to
 perform some initialization for PostgreSQL and import the latest BookBrainz
 database dump.
 
-Firstly, begin downloading the [latest BookBrainz dump](http://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.sql.bz2).
+Firstly, begin downloading the [latest BookBrainz dump](http://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.tar.gz).
 
-Then, uncompress the `latest.sql.bz2` file, using the bzip2 command:
+Then, unzip the `latest.tar.gz` file, using the `tar` command (on unix systems):
 
-    bzip2 -d latest.sql.bz2
+    tar -xf latest.tar.gz
 
-This will give you a file that you can restore into PostgreSQL, which will
+This will give you two files that you can restore into PostgreSQL, which will
 set up data identical to the data we have on the bookbrainz.org website. First, you must create the necessary role and database with these two commands:
 
-	psql -h localhost -U postgres --command="CREATE ROLE bookbrainz"	
+	psql -h localhost -U postgres --command="CREATE ROLE bookbrainz"
 	psql -h localhost -U postgres --command="CREATE DATABASE bookbrainz"
 
 Then you can restore the database from the lates dump you dowloaded. To do
-this, run:
+this, run (replace [DATE] for the corresponding file name):
 
-    psql -h localhost -U postgres -d bookbrainz -f latest.sql
+    psql -h localhost -U postgres -d bookbrainz -f bookbrainz-dump-[DATE].sql
+
+The user collections are imported separately (to ensure we do'nt export private colelctions). Run this command to import them:
+
+    psql -h localhost -U postgres -d bookbrainz -f bookbrainz-public-collections-dump-[DATE].sql
 
 At this point, the database is set up, and the following command should give
 you a list of usernames of BookBrainz editors (after entering the password from

--- a/INSTALLATION_TROUBLESHOOTING.md
+++ b/INSTALLATION_TROUBLESHOOTING.md
@@ -6,12 +6,12 @@
 
         `sudo apt update`
 	
-	2. Error: `Can't open input file latest.sql.bz2: No such file or directory` 
-	After downloading the data dumps, you may realize that an attempt to uncompress it using the command `bzip2 -d  	latest.sql.bz2` doesn’t work and gives the above error. 
+	2. Error: `Can't open input file latest.tar.gz: No such file or directory`
+	After downloading the data dumps, you may realize that an attempt to uncompress it using the command `tar -xf  	latest.tar.gz` doesn’t work and gives the above error.
 	
-	    It can be solved by giving the actual path of the latest.sql.bz2 file in place of the file name such as:
+	    It can be solved by giving the actual path of the latest.tar.gz file in place of the file name such as:
 	
-        `/ home/user/Desktop/latest.sql.bz2`
+        `/home/user/Desktop/latest.tar.gz`
   
 	3. Error: `fatal: unable to access 'https://github.com/path/to/repo.git/': gnutls_handshake() failed: Error in the pull function` after entering the `git clone --recursive https://github.com/bookbrainz/bookbrainz-site.git` command. 
 At this point, you should check your internet connection. If it persists, make sure you are not working behind a proxy.
@@ -21,7 +21,7 @@ At this point, you should check your internet connection. If it persists, make s
 
 * ElasticSearch
 
-    1. ElasticSearch requires runtime Java installed on your local machine, 
+    1. ElasticSearch requires runtime Java installed on your local machine,
 	so you have to install it by
 	
 	    For ubuntu users
@@ -32,11 +32,11 @@ At this point, you should check your internet connection. If it persists, make s
 
         `java -version`
 
-    2. When you run ElasticSearch, it seems that the process takes a very long time. 
+    2. When you run ElasticSearch, it seems that the process takes a very long time.
 	To proceed the process, just let ElasticSearch to run
     on its own terminal, and proceed the building process by making another window of terminal
 
-	3. If you run into an error on Docker Toolbox with Elastic Search stating an error message along the lines of:  
+	3. If you run into an error on Docker Toolbox with Elastic Search stating an error message along the lines of:
 	
 		`Waiting for elasticsearch:9200  .elasticsearch: forward host lookup failed: Unknown host`  
 		
@@ -52,12 +52,13 @@ At this point, you should check your internet connection. If it persists, make s
 	   
 	   ```
 	   # There is insufficient memory for the Java Runtime Environment to continue. 
+	   # There is insufficient memory for the Java Runtime Environment to continue.
 	   # Native memory allocation (mmap) failed to map 2060255232 bytes for committing reserved memory.
 	   ```
 	     
 	   Please try recreating the default docker machine by:
 	   
-	   		i. Remove default docker-machine with the command:  
+	   		i. Remove default docker-machine with the command:
 			
 				`docker-machine rm default`  
 				
@@ -65,13 +66,12 @@ At this point, you should check your internet connection. If it persists, make s
 			
 				```
 				docker-machine create -d virtualbox --virtualbox-cpu-count=2 --virtualbox-memory=4096 --virtualbox-disk-size=50000 default
-				```  
-			iii. Restart your docker environment with the commands: 
+				```
 			
 				```
 				docker-machine stop
 				exit
-				```  
+				```
 
     4. To check if port is already is in use or not run
     `netstat -anp tcp | grep <port-number>`
@@ -83,7 +83,7 @@ At this point, you should check your internet connection. If it persists, make s
         `/etc/init.d/redis-server stop`
 
     2. Sometimes the port 6379 on which redis server runs is used by TCP. So to terminate this process run
-        `sudo kill sudo 'lsof -t -i:5432'` 
+        `sudo kill sudo 'lsof -t -i:5432'`
 
 * PostgreSQL
 
@@ -92,7 +92,7 @@ At this point, you should check your internet connection. If it persists, make s
 
         `sudo -u postgres psql`
 
-        then 
+        then
         ```
         psql (12.3)
         Type "help" for help.
@@ -107,7 +107,7 @@ At this point, you should check your internet connection. If it persists, make s
 
         then
 
-        `Password for user <username>: ` 
+        `Password for user <username>: `
 	
 	    will appear.
         Use the username for the config later on config.json.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ database dump.
 Luckily, we have a script that does just that: from the command line, in the `bookbrainz-site` folder, type and run `./scripts/database-init-docker.sh`.
 The process may take a while as Docker downloads and builds the images. Let that run until the command returns.
 
-The latest database dump can be found [at this address](http://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.sql.bz2)
+The latest database dump can be found [at this address](http://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.tar.gz) and contains two files: a main database dump file and a separate one for public user collections.
 
 ## Running the web server
 

--- a/scripts/clean-public-collection-dump-tables.sql
+++ b/scripts/clean-public-collection-dump-tables.sql
@@ -1,0 +1,3 @@
+DROP TABLE public_user_collection;
+DROP TABLE public_user_collection_item;
+DROP TABLE public_user_collection_collaborator;

--- a/scripts/create-dumps.sh
+++ b/scripts/create-dumps.sh
@@ -9,6 +9,7 @@ pushd /home/bookbrainz/data/dumps
 
 
 DUMP_FILE=bookbrainz-dump-`date -I`.sql
+COLLECTIONS_DUMP_FILE=bookbrainz-collections-dump-`date -I`.sql
 
 echo "Creating data dump..."
 
@@ -18,30 +19,63 @@ pg_dump\
 	-p $POSTGRES_PORT \
 	-U bookbrainz \
 	-T _editor_entity_visits\
+	-T user_collection\
+	-T user_collection_collaborator\
+	-T user_collection_item\
 	 --serializable-deferrable\
 	 bookbrainz > /tmp/$DUMP_FILE
-echo "Dump created!"
+echo "Main dump created!"
 
-# Compress new backup and move to dump dir
-echo "Compressing..."
-rm -f /tmp/$DUMP_FILE.bz2
-bzip2 /tmp/$DUMP_FILE
-mv /tmp/$DUMP_FILE.bz2 .
+echo "Creating public collections dump..."
+# Create tables with public collections and items
+psql -h $POSTGRES_HOST \
+	-p $POSTGRES_PORT \
+	-U bookbrainz \
+	-d bookbrainz \
+	< /home/bookbrainz/bookbrainz-site/scripts/create-public-collection-dumps.sql
+	
+# Dump public collections backup to /tmp
+pg_dump\
+	-h $POSTGRES_HOST \
+	-p $POSTGRES_PORT \
+	-U bookbrainz \
+	-t public_user_collection\
+	-t public_user_collection_item\
+	-t public_user_collection_collaborator\
+	--serializable-deferrable\
+	bookbrainz \
+	| sed 's/public_user_collection/user_collection/' > /tmp/$COLLECTIONS_DUMP_FILE
+echo "Public collections dump created!"
+
+echo "Cleaning up temporary public collections tables"
+psql\
+	-h $POSTGRES_HOST \
+	-p $POSTGRES_PORT \
+	-U bookbrainz \
+	bookbrainz < /home/bookbrainz/bookbrainz-site/scripts/clean-public-collection-dump-tables.sql
+echo "Temporary public collections tables removed"
+
+
+# Compress new backups and move to dump dir
+echo "Combining and compressing..."
+rm -f /tmp/$DUMP_FILE.tar.gz
+tar -czvf /tmp/$DUMP_FILE.tar.gz /tmp/$DUMP_FILE /tmp/$COLLECTIONS_DUMP_FILE
+mv /tmp/$DUMP_FILE.tar.gz .
 echo "Compressed!"
 
 echo "Removing old dumps..."
 rm -f /tmp/*.sql
 # Remove backups older than 8 days
-find ./ -name '*.sql.bz2' -type f -mtime +7 -print | xargs /bin/rm -f
+find ./ -name '*.tar.gz' -type f -mtime +7 -print | xargs /bin/rm -f
 echo "Done!"
 
-rm -f latest.sql.bz2
-ln -s $DUMP_FILE.bz2 latest.sql.bz2
+rm -f latest.tar.gz
+ln -s $DUMP_FILE.tar.gz latest.tar.gz
 
 # Generate hashes
 echo "Generating hashes..."
-md5sum *.sql.bz2 > MD5SUMS
-sha256sum *.sql.bz2 > SHA256SUMS
+md5sum *.sql.tar.gz > MD5SUMS
+sha256sum *.sql.tar.gz > SHA256SUMS
 echo "Done!"
 
 chown bookbrainz:bookbrainz ./*

--- a/scripts/create-public-collection-dumps.sql
+++ b/scripts/create-public-collection-dumps.sql
@@ -1,0 +1,8 @@
+CREATE table if not exists public_user_collection AS
+select * from bookbrainz.user_collection uc where uc.public is true;
+
+CREATE table if not exists public_user_collection_item AS
+select uci.* from user_collection_item uci right join public_user_collection on uci.collection_id = public_user_collection.id;
+
+CREATE table if not exists public_user_collection_collaborator AS
+select ucc.* from user_collection_collaborator ucc inner join public_user_collection on ucc.collection_id = public_user_collection.id;

--- a/scripts/download-import-dump.sh
+++ b/scripts/download-import-dump.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 DUMP_DIR=/tmp/bookbrainz-dumps
-DUMP_FILE=$DUMP_DIR/latest.sql.bz2
+DUMP_FILE=$DUMP_DIR/latest.tar.gz
 
 if [ -f $DUMP_FILE ]; then
     echo "A bookbrainz dump file, already exists. Using that to import."
     echo "To force a re-download of the data, please remove $DUMP_FILE"
 else
     mkdir -p $DUMP_DIR
-    curl -o $DUMP_FILE ftp://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.sql.bz2
+    curl -o $DUMP_FILE ftp://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.tar.gz
     if [ $? -ne 0 ]
     then
         echo "Downloading the bookbrainz data dump failed."
@@ -16,7 +16,13 @@ else
     fi
 fi
 
-bzcat $DUMP_FILE | psql -h postgres -U postgres -d bookbrainz
+tar -xf $DUMP_FILE --directory $DUMP_DIR
+
+for dumpfile in $DUMP_DIR/tmp/*
+do
+	psql -h localhost -U postgres -d bookbrainz < $dumpfile
+done
+
 if [ $? -ne 0 ]
 then
     echo "Importing the bookbrainz database failed."
@@ -24,4 +30,4 @@ then
 fi
 
 # Clean up the dump file if it imported correctly.
-rm -f $DUMP_FILE
+rm -rf $DUMP_FILE $DUMP_DIR/tmp

--- a/src/client/components/pages/about.js
+++ b/src/client/components/pages/about.js
@@ -70,7 +70,7 @@ function AboutPage() {
 			</p>
 			<p>
 				Regular database dumps (Postgres) can be found
-				<a href="http://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.sql.bz2"> at this address.</a>
+				<a href="http://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.tar.gz"> at this address.</a>
 			</p>
 			<p>
 				We also have a webservice (or API) under development with

--- a/src/client/components/pages/develop.js
+++ b/src/client/components/pages/develop.js
@@ -56,7 +56,7 @@ function DevelopPage() {
 				The database dumps will be useful if you need to process a
 				lot of data quickly &mdash; in cases where the web service
 				is not able to respond quickly enough.
-				The latest database dump can be found <a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.sql.bz2">at this address</a>.
+				The latest database dump can be found <a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/bookbrainz/latest.tar.gz">at this address</a>.
 				A dump is made every week.
 			</p>
 			<h2>Source Code</h2>


### PR DESCRIPTION
### Problem
With the introduction of user collections, private collections are currently going to be exported in the dumps.


### Solution
This PR aims to create a database dump without collections, and another dump with *only* the public collections.
For that purpose, we create temporary tables (ie `user_collection` -> `public_user_collection`) with the appropriate select statements to ignore private collections its items and collaborators, and dump those three tables to a file before removing them.

We also want to rename the table names in the collections dump file once it has been created (for example to rename `bookbrainz.public_user_collection` -> `bookbrainz.user_collection`