### PR TITLE
Hierarchy and help text for relationships

### DIFF
--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -310,6 +310,7 @@ class RelationshipModal
 			defaultAlias: {
 				name: _.get(this.state, ['targetEntity', 'text'])
 			},
+			disambiguation: _.get(this.state, ['targetEntity', 'disambiguation']),
 			type: _.get(this.state, ['targetEntity', 'type'])
 		};
 

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -298,6 +298,7 @@ class RelationshipModal
 				href={link}
 				rel="noreferrer noopener"
 				target="_blank"
+				title="Open in a new tab"
 			>
 				<FontAwesomeIcon icon="external-link-alt"/>
 			</Button>

--- a/src/client/entity-editor/relationship-editor/relationship-editor.js
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.js
@@ -23,6 +23,7 @@ import {
 	Col,
 	ControlLabel,
 	FormGroup,
+	HelpBlock,
 	Modal,
 	ProgressBar,
 	Row
@@ -301,6 +302,9 @@ class RelationshipModal
 					valueRenderer={Relationship}
 					onChange={this.handleRelationshipTypeChange}
 				/>
+				{this.state.relationshipType &&
+					<HelpBlock>{this.state.relationshipType.description}</HelpBlock>
+				}
 			</FormGroup>
 		);
 	}

--- a/src/client/entity-editor/relationship-editor/relationship-section.js
+++ b/src/client/entity-editor/relationship-editor/relationship-section.js
@@ -151,6 +151,7 @@ function RelationshipSection({
 		defaultAlias: {
 			name: entityName
 		},
+		disambiguation: _.get(entity, ['disambiguation', 'comment']),
 		type: _.upperFirst(entityType)
 	};
 

--- a/src/client/entity-editor/relationship-editor/relationship.js
+++ b/src/client/entity-editor/relationship-editor/relationship.js
@@ -29,7 +29,10 @@ import {getEntityLink} from '../../../server/helpers/utils';
 function getEntityObjectForDisplay(entity: _Entity, makeLink: boolean) {
 	const link = makeLink && entity.bbid &&
 		getEntityLink({bbid: entity.bbid, type: entity.type});
-	const disambiguation = _.get(entity, ['disambiguation']);
+	let disambiguation = _.get(entity, ['disambiguation']);
+	if (_.has(disambiguation, 'comment')) {
+		disambiguation = disambiguation.comment;
+	}
 	return {
 		disambiguation,
 		link,

--- a/src/client/entity-editor/relationship-editor/relationship.js
+++ b/src/client/entity-editor/relationship-editor/relationship.js
@@ -50,7 +50,7 @@ type RelationshipProps = {
 function Relationship({
 	contextEntity, link, relationshipType, sourceEntity, targetEntity
 }: RelationshipProps) {
-	const {description, id, linkPhrase, reverseLinkPhrase} = relationshipType;
+	const {depth, description, id, linkPhrase, reverseLinkPhrase} = relationshipType;
 
 	const reversed = contextEntity &&
 		(_.get(contextEntity, 'bbid') === _.get(targetEntity, 'bbid'));
@@ -64,13 +64,19 @@ function Relationship({
 
 	const usedLinkPhrase = reversed ? reverseLinkPhrase : linkPhrase;
 
+	// If there is a depth structure, indent accordingly by setting a margin on the left
+	let indentationClass = '';
+	if (typeof depth !== 'undefined') {
+		indentationClass = `margin-left-d${8 * depth}`;
+	}
+
 	return (
 		<OverlayTrigger
 			delayShow={50}
 			overlay={<Tooltip id={`tooltip-${id}`}>{description}</Tooltip>}
 			placement="bottom"
 		>
-			<div aria-label={description}>
+			<div aria-label={description} className={indentationClass}>
 				<Entity {...sourceObject}/>
 				{` ${usedLinkPhrase} `}
 				<Entity {...targetObject}/>

--- a/src/client/entity-editor/relationship-editor/relationship.js
+++ b/src/client/entity-editor/relationship-editor/relationship.js
@@ -29,7 +29,7 @@ import {getEntityLink} from '../../../server/helpers/utils';
 function getEntityObjectForDisplay(entity: _Entity, makeLink: boolean) {
 	const link = makeLink && entity.bbid &&
 		getEntityLink({bbid: entity.bbid, type: entity.type});
-	const disambiguation = _.get(entity, ['disambiguation', 'comment']);
+	const disambiguation = _.get(entity, ['disambiguation']);
 	return {
 		disambiguation,
 		link,

--- a/src/client/entity-editor/relationship-editor/relationship.js
+++ b/src/client/entity-editor/relationship-editor/relationship.js
@@ -18,6 +18,7 @@
 
 // @flow
 
+import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import type {RelationshipType, Entity as _Entity} from './types';
 import Entity from '../common/entity';
 import React from 'react';
@@ -49,7 +50,7 @@ type RelationshipProps = {
 function Relationship({
 	contextEntity, link, relationshipType, sourceEntity, targetEntity
 }: RelationshipProps) {
-	const {linkPhrase, reverseLinkPhrase} = relationshipType;
+	const {description, id, linkPhrase, reverseLinkPhrase} = relationshipType;
 
 	const reversed = contextEntity &&
 		(_.get(contextEntity, 'bbid') === _.get(targetEntity, 'bbid'));
@@ -64,11 +65,17 @@ function Relationship({
 	const usedLinkPhrase = reversed ? reverseLinkPhrase : linkPhrase;
 
 	return (
-		<div>
-			<Entity {...sourceObject}/>
-			{` ${usedLinkPhrase} `}
-			<Entity {...targetObject}/>
-		</div>
+		<OverlayTrigger
+			delayShow={50}
+			overlay={<Tooltip id={`tooltip-${id}`}>{description}</Tooltip>}
+			placement="bottom"
+		>
+			<div aria-label={description}>
+				<Entity {...sourceObject}/>
+				{` ${usedLinkPhrase} `}
+				<Entity {...targetObject}/>
+			</div>
+		</OverlayTrigger>
 	);
 }
 Relationship.displayName = 'Relationship';

--- a/src/client/entity-editor/relationship-editor/types.js
+++ b/src/client/entity-editor/relationship-editor/types.js
@@ -32,6 +32,7 @@ export type RelationshipType = {
 	id: number,
 	childOrder: number,
 	deprecated: boolean,
+	depth?: number,
 	description: string,
 	label: string,
 	linkPhrase: string,


### PR DESCRIPTION
Deployed on test.bookbrainz.org for testing.

This PR adds a few new features to improve the relationship editor:

1. hierarchy in relationships in the relationship editor:
<img width="592" alt="Capture d’écran 2020-09-23 à 15 55 58" src="https://user-images.githubusercontent.com/6179856/94037824-0a840e80-fdc6-11ea-919a-691a2faa7df1.png">

2. help tooltips when hovering over a relationship, both in the rel editor and the entity pages:
<img width="512" alt="Capture d’écran 2020-09-22 à 18 22 22" src="https://user-images.githubusercontent.com/6179856/94037917-27b8dd00-fdc6-11ea-927d-5255c1ed4211.png">
<img width="482" alt="Capture d’écran 2020-09-23 à 16 48 35" src="https://user-images.githubusercontent.com/6179856/94037935-2c7d9100-fdc6-11ea-9bda-794834142982.png">

3. Help text under the relationship select, once a relationship has been selected

4. Disambiguation is shown in relationship select (for entities with the same name)

5. An "open in a new tab" button next to the entity select in the relationship editor
<img width="596" alt="Capture d’écran 2020-09-24 à 15 14 58" src="https://user-images.githubusercontent.com/6179856/94271913-9a4ec780-ff42-11ea-985e-52389dbb909e.png">


