### PR TITLE
fix(merge-annotations): Don't show separator if no previous text

### DIFF
--- a/src/server/routes/merge.js
+++ b/src/server/routes/merge.js
@@ -130,7 +130,7 @@ function entitiesToFormState(entities: any[]) {
 
 	const annotations = entities.reduce((returnValue, entity, index) => {
 		if (entity.annotation && entity.annotation.content) {
-			return `${returnValue}${index > 0 ? '\n——————\n' : ''}${entity.annotation.content}`;
+			return `${returnValue}${returnValue ? '\n——————\n' : ''}${entity.annotation.content}`;
 		}
 		return returnValue;
 	}, '');


### PR DESCRIPTION
In merge page, annotations are concatenated with a separator ('———').
If the first entity doesn't have an annotation, a separator will still be added before the annotation of the following one.
Instead, only add separator if the string is not empty.

Follows PR #508 .