### PR TITLE
fix(BB-452): Index auto-created Edition Groups

### DIFF
--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -936,6 +936,28 @@ function fetchEntitiesForRelationships(
 	));
 }
 
+/**
+ * @param  {any} orm -  The BookBrainz ORM
+ * @param  {any} newEdition - The ORM model of the newly created Edition
+ * @description Edition Groups will be created automatically by the ORM if no EditionGroup BBID is set on a new Edition.
+ * This method fetches and indexes (search) those potential new EditionGroups that may have been created automatically.
+ */
+async function indexAutoCreatedEditionGroup(orm, newEdition) {
+	const {EditionGroup} = orm;
+	const bbid = newEdition.get('editionGroupBbid');
+	try {
+		const editionGroup = await new EditionGroup({bbid})
+			.fetch({
+				require: true,
+				withRelated: 'aliasSet.aliases'
+			});
+		await search.indexEntity(editionGroup.toJSON());
+	}
+	catch (err) {
+		log.error('Could not reindex edition group after edition creation:', err);
+	}
+}
+
 export function handleCreateOrEditEntity(
 	req: PassportRequest,
 	res: $Response,
@@ -1044,7 +1066,13 @@ export function handleCreateOrEditEntity(
 			/* New entities will lack some attributes like 'type' required for search indexing */
 			if (isNew) {
 				await savedMainEntity.refresh({transacting});
+
+				/* fetch and reindex EditionGroups that may have been created automatically by the ORM and not indexed */
+				if (savedMainEntity.get('type') === 'Edition') {
+					indexAutoCreatedEditionGroup(orm, savedMainEntity);
+				}
 			}
+
 
 			return savedMainEntity.toJSON();
 		}


### PR DESCRIPTION
Edition Groups created automatically by the ORM ([when no EG is set on a  new Edition](https://github.com/bookbrainz/bookbrainz-data-js/blob/master/src/util.js#L249-L262)) were not being indexed for search.