### PR TITLE
fix(BB-545): Allow relationship sets to be null (empty)

### DIFF
--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -1047,10 +1047,11 @@ export function handleCreateOrEditEntity(
 
 			_.forEach(allEntities, (entityModel) => {
 				const bbid: string = entityModel.get('bbid');
-				if (_.has(relationshipSets, bbid) && !_.isNil(relationshipSets[bbid])) {
+				if (_.has(relationshipSets, bbid)) {
 					entityModel.set(
 						'relationshipSetId',
-						relationshipSets[bbid].get('id')
+						// Set to relationshipSet id or null if empty set
+						relationshipSets[bbid] && relationshipSets[bbid].get('id')
 					);
 				}
 			});


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
Bug introduced in commit e7cbb20f01f5ee4032bee1eba8ca58ec95054d66, which does not allow setting relationshipSetId to `null` (for entities where all relationships have been deleted)


### Solution
Allow setting relationshipSetId to `null`

