### PR TITLE
fix(ORG-45): Add blog link to readme and API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ directories will exist:
 * `static/js` - minified JavaScript files which are referred to by the site
   pages.
   
+## Contact and updates
+
+Any questions? You can get in contact with the community on [our IRC channel](https://webchat.freenode.net/?channels=#bookbrainz) or [our forums](https://community.metabrainz.org/c/bookbrainz), or send us [an email](mailto:bookbrainz@metabrainz.org)
+
+Breaking changes to the database schema or our API will be announced on
+[our blog](https://blog.metabrainz.org/category/bookbrainz/), along with our other major updates,
+so consider following that.
+
+
 ## Contributing
 We welcome any and all contributions ! Whether you want to add or improve entries on [bookbrainz.org](https://bookbrainz.org), fix an issue on the website or provide new functionnality, we'll be happy to have your help and count you part of our ranks !
 If you are new to open source contribution workflows, have a look at [this beginner's guide](https://akrabat.com/the-beginners-guide-to-contributing-to-a-github-project/) and our [contribution guidelines](CONTRIBUTING.md).

--- a/src/api/swagger.js
+++ b/src/api/swagger.js
@@ -19,7 +19,8 @@ const swaggerOptions = {
 				name: 'BookBrainz',
 				url: 'https://bookbrainz.org/'
 			},
-			description: 'OpenAPI 3 documentation for the BookBrainz REST API. https://bookbrainz.org',
+			description: `OpenAPI 3 documentation for the BookBrainz REST API.<br/>
+			Breaking changes to the API will be announced <a href="https://blog.metabrainz.org/category/bookbrainz/" target="_blank">on our blog</a>.`,
 			title: 'BookBrainz API Documentation',
 			version: '0.2.0'
 		},


### PR DESCRIPTION
See https://tickets.metabrainz.org/browse/ORG-45 following summit discussions.