### PR TITLE
fix(relationships): Follow BBID redirects when loading relationships aliases

### DIFF
--- a/src/server/helpers/middleware.js
+++ b/src/server/helpers/middleware.js
@@ -96,10 +96,11 @@ export function loadEntityRelationships(req: $Request, res: $Response, next: Nex
 			entity.relationships = relationshipSet ?
 				relationshipSet.related('relationships').toJSON() : [];
 
-			function getEntityWithAlias(relEntity) {
+			async function getEntityWithAlias(relEntity) {
+				const redirectBbid = await orm.func.entity.recursivelyGetRedirectBBID(orm, relEntity.bbid, null);
 				const model = commonUtils.getEntityModelByType(orm, relEntity.type);
 
-				return model.forge({bbid: relEntity.bbid})
+				return model.forge({bbid: redirectBbid})
 					.fetch({require: false, withRelated: ['defaultAlias'].concat(utils.getAdditionalRelations(relEntity.type))});
 			}
 

--- a/src/server/routes/merge.js
+++ b/src/server/routes/merge.js
@@ -167,10 +167,11 @@ function loadEntityRelationships(entity, orm, transacting): Promise<any> {
 			entity.relationships = relationshipSet ?
 				relationshipSet.related('relationships').toJSON() : [];
 
-			function getEntityWithAlias(relEntity) {
+			async function getEntityWithAlias(relEntity) {
+				const redirectBbid = await orm.func.entity.recursivelyGetRedirectBBID(orm, relEntity.bbid, null);
 				const model = commonUtils.getEntityModelByType(orm, relEntity.type);
 
-				return model.forge({bbid: relEntity.bbid})
+				return model.forge({bbid: redirectBbid})
 					.fetch({withRelated: 'defaultAlias'});
 			}
 


### PR DESCRIPTION
When loading relationships, follow the redirected BBID of potential merges to fetch with alias