### PR TITLE
Name deduplication improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4548,25 +4548,25 @@
       }
     },
     "bookbrainz-data": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/bookbrainz-data/-/bookbrainz-data-2.6.2.tgz",
-      "integrity": "sha512-PjYE2j6Mjv3X7weZjVyUib1nWOSblPUqAJz2moC32GuxMv6IJ3WQRr9iJQ7J5cyOLbpT4EGY5/5/VDksHarqyA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bookbrainz-data/-/bookbrainz-data-2.7.0.tgz",
+      "integrity": "sha512-UovOAzX+5KMjzRZxzIK8aucRIYNupmQdQAMBWLk+iMu9ueOip6XkW4d7xj3CLtUKQicPMdRNrDZrByrOyFsKfA==",
       "requires": {
         "bluebird": "^3.7.2",
         "bookshelf": "^1.2.0",
         "bookshelf-virtuals-plugin": "^0.1.1",
         "deep-diff": "^1.0.2",
         "immutable": "^3.8.2",
-        "knex": "^0.21.1",
+        "knex": "^0.21.5",
         "lodash": "^4.17.20",
-        "moment": "^2.26.0",
+        "moment": "^2.29.0",
         "pg": "^7.18.2"
       },
       "dependencies": {
         "moment": {
-          "version": "2.29.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
-          "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "body-parser": "^1.14.1",
-    "bookbrainz-data": "^2.6.2",
+    "bookbrainz-data": "^2.7.0",
     "chai-arrays": "^2.2.0",
     "chai-sorted": "^0.2.0",
     "chart.js": "^2.9.3",
@@ -85,9 +85,9 @@
     "redux-thunk": "^2.2.0",
     "serve-favicon": "^2.4.3",
     "serve-static": "^1.14.1",
+    "snyk": "^1.385.0",
     "superagent": "^5.3.1",
-    "validator": "^9.1.2",
-    "snyk": "^1.385.0"
+    "validator": "^9.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/src/client/entity-editor/common/linked-entity.js
+++ b/src/client/entity-editor/common/linked-entity.js
@@ -19,7 +19,7 @@
 
 // @flow
 
-import {kebabCase as _kebabCase, has} from 'lodash';
+import {kebabCase as _kebabCase, has, isFunction} from 'lodash';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -36,7 +36,9 @@ class LinkedEntity extends React.Component {
 
 	handleParentEvent(event) {
 		const option = this.getSafeOptionValue(this.props.option);
-		this.props.onSelect(option, event);
+		if (isFunction(this.props.onSelect)) {
+			this.props.onSelect(option, event);
+		}
 	}
 
 	handleChildEvent(event) {

--- a/src/client/entity-editor/edition-section/actions.js
+++ b/src/client/entity-editor/edition-section/actions.js
@@ -53,7 +53,7 @@ export const UPDATE_WIDTH = 'UPDATE_WIDTH';
 export const UPDATE_HEIGHT = 'UPDATE_HEIGHT';
 export const UPDATE_DEPTH = 'UPDATE_DEPTH';
 export const SHOW_PHYSICAL = 'SHOW_PHYSICAL';
-export const SHOW_EDITION_GROUP = 'SHOW_EDITION_GROUP';
+export const TOGGLE_SHOW_EDITION_GROUP = 'TOGGLE_SHOW_EDITION_GROUP';
 export const UPDATE_WARN_IF_EDITION_GROUP_EXISTS = 'UPDATE_WARN_IF_EDITION_GROUP_EXISTS';
 
 /**
@@ -134,11 +134,14 @@ export function showPhysical(): Action {
  * Produces an action indicating that the Edition Group section of the edition
  * form should be shown.
  *
- * @returns {Action} The resulting SHOW_EDITION_GROUP action.
+ * @param {boolean} showEGSection: Whether to show the Edition Group selection section or not
+ *
+ * @returns {Action} The resulting TOGGLE_SHOW_EDITION_GROUP action.
  */
-export function showEditionGroup(): Action {
+export function toggleShowEditionGroup(showEGSection: boolean): Action {
 	return {
-		type: SHOW_EDITION_GROUP
+		payload: showEGSection,
+		type: TOGGLE_SHOW_EDITION_GROUP
 	};
 }
 
@@ -165,7 +168,7 @@ export function updatePublisher(newPublisher: Publisher): Action {
  *                      for the edition.
  * @returns {Action} The resulting UPDATE_EDITION_GROUP action.
  */
-export function updateEditionGroup(newEditionGroup: EditionGroup): Action {
+export function updateEditionGroup(newEditionGroup: EditionGroup | null): Action {
 	return {
 		payload: newEditionGroup,
 		type: UPDATE_EDITION_GROUP

--- a/src/client/entity-editor/edition-section/edition-section.js
+++ b/src/client/entity-editor/edition-section/edition-section.js
@@ -212,8 +212,9 @@ function EditionSection({
 
 	const getEditionGroupSearchSelect = () => (
 		<React.Fragment>
-			<Col md={6} mdOffset={showMatchingEditionGroups ? 0 : 3}>
+			<Col className="margin-bottom-2" md={6} mdOffset={showMatchingEditionGroups ? 0 : 3}>
 				<EntitySearchFieldOption
+					clearable={false}
 					error={!validateEditionSectionEditionGroup(editionGroupValue, true)}
 					help="Group with other Editions of the same book"
 					instanceId="edition-group"

--- a/src/client/entity-editor/edition-section/edition-section.js
+++ b/src/client/entity-editor/edition-section/edition-section.js
@@ -232,7 +232,7 @@ function EditionSection({
 					// eslint-disable-next-line react/jsx-no-bind
 					onClick={onToggleShowEditionGroupSection.bind(this, false)}
 				>
-					Click here to automatically create one instead
+					<FontAwesomeIcon icon="clone"/>&nbsp;Automatically create an Edition Group
 				</Button>
 			</Col>
 		</React.Fragment>
@@ -244,23 +244,24 @@ function EditionSection({
 				What else do you know about the Edition?
 			</h2>
 			<p className="text-muted">
-				Edition Group is required — this cannot be blank
+				Edition Group is required — this cannot be blank. You can search for and choose an existing Edition Group,
+				or choose to automatically create one instead.
 			</p>
 			<Row className="margin-bottom-3">
 				{
 					showAutoCreateEditionGroupMessage ?
 						<Col md={6} mdOffset={showMatchingEditionGroups ? 0 : 3}>
-							<Alert>
-								A new Edition Group with the same name will be created automatically.
+							<Alert bsStyle="success">
+								<p>A new Edition Group with the same name will be created automatically.</p>
 								<br/>
 								<Button
 									block
-									bsStyle="primary"
+									bsStyle="success"
 									className="wrap"
 									// eslint-disable-next-line react/jsx-no-bind
 									onClick={onToggleShowEditionGroupSection.bind(this, true)}
 								>
-									Click here to search for an existing one instead
+									<FontAwesomeIcon icon="search"/>&nbsp;Search for an existing Edition Group
 								</Button>
 							</Alert>
 						</Col> :

--- a/src/client/entity-editor/edition-section/edition-section.js
+++ b/src/client/entity-editor/edition-section/edition-section.js
@@ -26,8 +26,8 @@ import {
 	debouncedUpdateReleaseDate,
 	debouncedUpdateWeight,
 	debouncedUpdateWidth,
-	showEditionGroup,
 	showPhysical,
+	toggleShowEditionGroup,
 	updateEditionGroup,
 	updateFormat,
 	updateLanguages,
@@ -35,7 +35,7 @@ import {
 	updateStatus
 } from './actions';
 
-import {Alert, Button, Col, Row} from 'react-bootstrap';
+import {Alert, Button, Col, ListGroup, ListGroupItem, Row} from 'react-bootstrap';
 import type {List, Map} from 'immutable';
 import {
 	validateEditionSectionDepth,
@@ -51,12 +51,13 @@ import DateField from '../common/new-date-field';
 import EntitySearchFieldOption from '../common/entity-search-field-option';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import LanguageField from '../common/language-field';
+import LinkedEntity from '../common/linked-entity';
 import NumericField from '../common/numeric-field';
 import React from 'react';
-import SearchResults from '../../components/pages/parts/search-results';
 import Select from 'react-select';
 import _ from 'lodash';
 import {connect} from 'react-redux';
+import {entityToOption} from '../../../server/helpers/utils';
 import {isNullDate} from '../../helpers/utils';
 import makeImmutable from '../common/make-immutable';
 
@@ -120,7 +121,7 @@ type DispatchProps = {
 	onPagesChange: (SyntheticInputEvent<>) => mixed,
 	onPhysicalButtonClick: () => mixed,
 	onPublisherChange: (Publisher) => mixed,
-	onEditionGroupButtonClick: () => mixed,
+	onToggleShowEditionGroupSection: (showEGSection: boolean) => mixed,
 	onEditionGroupChange: (EditionGroup) => mixed,
 	onReleaseDateChange: (SyntheticInputEvent<>) => mixed,
 	onStatusChange: (?{value: number}) => mixed,
@@ -165,7 +166,7 @@ function EditionSection({
 	onPhysicalButtonClick,
 	onReleaseDateChange,
 	onPagesChange,
-	onEditionGroupButtonClick,
+	onToggleShowEditionGroupSection,
 	onEditionGroupChange,
 	onPublisherChange,
 	onStatusChange,
@@ -201,56 +202,40 @@ function EditionSection({
 	const {isValid: isValidReleaseDate, errorMessage: dateErrorMessage} = validateEditionSectionReleaseDate(releaseDateValue);
 
 	const hasmatchingNameEditionGroups = Array.isArray(matchingNameEditionGroups) && matchingNameEditionGroups.length > 0;
-	const getEditionGroupSearchSelect = () => (
-		<React.Fragment>
-			<Row style={{marginBottom: '2em'}}>
-				<Col md={6} mdOffset={3}>
-					<EntitySearchFieldOption
-						error={!validateEditionSectionEditionGroup(editionGroupValue, true)}
-						help="Group with other Editions of the same book"
-						instanceId="edition-group"
-						label="Edition Group"
-						tooltipText="Group together different Editions of the same book.
-						<br>For example paperback, hardcover and e-book editions."
-						type="edition-group"
-						value={editionGroupValue}
-						onChange={onEditionGroupChange}
-					/>
-					{hasmatchingNameEditionGroups &&
-						<Alert bsStyle="warning">
-							{matchingNameEditionGroups.length > 1 ?
-								'Edition Groups with the same name as this Edition already exist' :
-								'An existing Edition Group with the same name as this Edition already exists'
-							}:
-							<br/>
-							<small>The first match has been selected automatically. Please review the choice:
-								<br/>Click on an item to open it (Ctrl/Cmd + click to open in a new tab)
-							</small>
-							<SearchResults condensed results={matchingNameEditionGroups}/>
-						</Alert>
-					}
-				</Col>
-				<Col md={3}>
-					<Button
-						block
-						bsStyle="success"
-						href="/edition-group/create"
-						style={{marginTop: '1.8em'}}
-						target="_blank"
-					>
-						<FontAwesomeIcon icon="plus"/>
-						&nbsp;New Edition Group
-					</Button>
-				</Col>
-			</Row>
-		</React.Fragment>
-	);
 
-	const alertAutoCreateEditionGroup =
+	const showAutoCreateEditionGroupMessage =
 		!editionGroupValue &&
 		!editionGroupVisible &&
-		!editionGroupRequired &&
-		!hasmatchingNameEditionGroups;
+		!editionGroupRequired;
+
+	const showMatchingEditionGroups = hasmatchingNameEditionGroups && !editionGroupValue;
+
+	const getEditionGroupSearchSelect = () => (
+		<React.Fragment>
+			<Col md={6} mdOffset={showMatchingEditionGroups ? 0 : 3}>
+				<EntitySearchFieldOption
+					error={!validateEditionSectionEditionGroup(editionGroupValue, true)}
+					help="Group with other Editions of the same book"
+					instanceId="edition-group"
+					label="Edition Group"
+					tooltipText="Group together different Editions of the same book.
+					<br>For example paperback, hardcover and e-book editions."
+					type="edition-group"
+					value={editionGroupValue}
+					onChange={onEditionGroupChange}
+				/>
+				<Button
+					block
+					bsStyle="primary"
+					className="wrap"
+					// eslint-disable-next-line react/jsx-no-bind
+					onClick={onToggleShowEditionGroupSection.bind(this, false)}
+				>
+					Click here to automatically create one instead
+				</Button>
+			</Col>
+		</React.Fragment>
+	);
 
 	return (
 		<form>
@@ -260,10 +245,10 @@ function EditionSection({
 			<p className="text-muted">
 				Edition Group is required — this cannot be blank
 			</p>
-			{
-				alertAutoCreateEditionGroup ?
-					<Row>
-						<Col md={6} mdOffset={3}>
+			<Row className="margin-bottom-3">
+				{
+					showAutoCreateEditionGroupMessage ?
+						<Col md={6} mdOffset={showMatchingEditionGroups ? 0 : 3}>
 							<Alert>
 								A new Edition Group with the same name will be created automatically.
 								<br/>
@@ -271,15 +256,41 @@ function EditionSection({
 									block
 									bsStyle="primary"
 									className="wrap"
-									onClick={onEditionGroupButtonClick}
+									// eslint-disable-next-line react/jsx-no-bind
+									onClick={onToggleShowEditionGroupSection.bind(this, true)}
 								>
 									Click here to search for an existing one instead
 								</Button>
 							</Alert>
-						</Col>
-					</Row> :
-					getEditionGroupSearchSelect()
-			}
+						</Col> :
+						getEditionGroupSearchSelect()
+				}
+				{showMatchingEditionGroups &&
+					<Col md={6}>
+						<Alert bsStyle="warning">
+							{matchingNameEditionGroups.length > 1 ?
+								'Edition Groups with the same name as this Edition already exist' :
+								'An existing Edition Group with the same name as this Edition already exists'
+							}
+							<br/>
+							Please review the Edition Groups below and select the one that corresponds to your Edition.
+							<br/>
+							<small>
+								If no Edition Group is selected, an new one will be created automatically.
+								<br/>
+								Click on the <FontAwesomeIcon icon="external-link-alt"/> icon open in a new tab, and click an item to select.
+							</small>
+							<ListGroup>
+								{matchingNameEditionGroups.map(eg => (
+									<ListGroupItem key={eg.bbid}>
+										<LinkedEntity option={entityToOption(eg)} onSelect={onEditionGroupChange}/>
+									</ListGroupItem>
+								))}
+							</ListGroup>
+						</Alert>
+					</Col>
+				}
+			</Row>
 			<p className="text-muted">
 				Below fields are optional — leave something blank if you
 				don&rsquo;t know it
@@ -441,7 +452,6 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 		onDepthChange: (event) => dispatch(debouncedUpdateDepth(
 			event.target.value ? parseInt(event.target.value, 10) : null
 		)),
-		onEditionGroupButtonClick: () => dispatch(showEditionGroup()),
 		onEditionGroupChange: (value) => dispatch(updateEditionGroup(value)),
 		onFormatChange: (value: ?{value: number}) =>
 			dispatch(updateFormat(value && value.value)),
@@ -459,6 +469,12 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 			dispatch(debouncedUpdateReleaseDate(releaseDate)),
 		onStatusChange: (value: ?{value: number}) =>
 			dispatch(updateStatus(value && value.value)),
+		onToggleShowEditionGroupSection: (showEGSection: boolean) => {
+			if (showEGSection === false) {
+				dispatch(updateEditionGroup(null));
+			}
+			return dispatch(toggleShowEditionGroup(showEGSection));
+		},
 		onWeightChange: (event) => dispatch(debouncedUpdateWeight(
 			event.target.value ? parseInt(event.target.value, 10) : null
 		)),

--- a/src/client/entity-editor/edition-section/edition-section.js
+++ b/src/client/entity-editor/edition-section/edition-section.js
@@ -276,11 +276,11 @@ function EditionSection({
 							Please review the Edition Groups below and select the one that corresponds to your Edition.
 							<br/>
 							<small>
-								If no Edition Group is selected, an new one will be created automatically.
+								If no Edition Group is selected, a new one will be created automatically.
 								<br/>
 								Click on the <FontAwesomeIcon icon="external-link-alt"/> icon open in a new tab, and click an item to select.
 							</small>
-							<ListGroup>
+							<ListGroup className="margin-top-1">
 								{matchingNameEditionGroups.map(eg => (
 									<ListGroupItem key={eg.bbid}>
 										<LinkedEntity option={entityToOption(eg)} onSelect={onEditionGroupChange}/>

--- a/src/client/entity-editor/edition-section/reducer.js
+++ b/src/client/entity-editor/edition-section/reducer.js
@@ -23,8 +23,8 @@ import * as _ from 'lodash';
 
 import {
 	type Action,
-	SHOW_EDITION_GROUP,
 	SHOW_PHYSICAL,
+	TOGGLE_SHOW_EDITION_GROUP,
 	UPDATE_DEPTH,
 	UPDATE_EDITION_GROUP,
 	UPDATE_FORMAT,
@@ -56,8 +56,8 @@ function reducer(
 	switch (type) {
 		case SHOW_PHYSICAL:
 			return state.set('physicalVisible', true);
-		case SHOW_EDITION_GROUP:
-			return state.set('editionGroupVisible', true);
+		case TOGGLE_SHOW_EDITION_GROUP:
+			return state.set('editionGroupVisible', payload);
 		case UPDATE_LANGUAGES:
 			return state.set('languages', Immutable.fromJS(payload));
 		case UPDATE_FORMAT:
@@ -84,14 +84,7 @@ function reducer(
 			if (!Array.isArray(payload) || !payload.length) {
 				return state.set('matchingNameEditionGroups', []);
 			}
-			return state.set('matchingNameEditionGroups', payload)
-				.set('editionGroup', Immutable.fromJS({
-					disambiguation: _.get(payload[0], ['disambiguation', 'comment']),
-					id: payload[0].bbid,
-					text: _.get(payload[0], ['defaultAlias', 'name']),
-					type: payload[0].type,
-					value: payload[0].bbid
-				}));
+			return state.set('matchingNameEditionGroups', payload);
 		// no default
 	}
 	return state;

--- a/src/client/entity-editor/name-section/actions.js
+++ b/src/client/entity-editor/name-section/actions.js
@@ -122,7 +122,10 @@ export function checkIfNameExists(
 	 * @param  {function} dispatch - The redux dispatch function.
 	 */
 	return (dispatch) => {
-		if (!name || _snakeCase(entityType) === 'edition' || _snakeCase(entityType) === 'edition_group') {
+		if (!name ||
+			_snakeCase(entityType) === 'edition' ||
+			(_snakeCase(entityType) === 'edition_group' && action === UPDATE_WARN_IF_EXISTS)
+		) {
 			dispatch({
 				payload: null,
 				type: action || UPDATE_WARN_IF_EXISTS

--- a/src/client/entity-editor/name-section/actions.js
+++ b/src/client/entity-editor/name-section/actions.js
@@ -122,7 +122,7 @@ export function checkIfNameExists(
 	 * @param  {function} dispatch - The redux dispatch function.
 	 */
 	return (dispatch) => {
-		if (!name) {
+		if (!name || _snakeCase(entityType) === 'edition' || _snakeCase(entityType) === 'edition_group') {
 			dispatch({
 				payload: null,
 				type: action || UPDATE_WARN_IF_EXISTS

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -97,12 +97,6 @@ class NameSection extends React.Component {
 		this.props.onNameChange(event.target.value);
 		this.props.onNameChangeCheckIfExists(event.target.value);
 		this.props.onNameChangeSearchName(event.target.value);
-		if (
-			_.toLower(this.props.entityType) === 'edition' &&
-			this.props.searchForExistingEditionGroup
-		) {
-			this.props.onNameChangeCheckIfEditionGroupExists(event.target.value);
-		}
 	}
 
 	updateNameFieldInputRef(inputRef) {
@@ -119,8 +113,10 @@ class NameSection extends React.Component {
 			nameValue,
 			sortNameValue,
 			onLanguageChange,
+			onNameChangeCheckIfEditionGroupExists,
 			onSortNameChange,
 			onDisambiguationChange,
+			searchForExistingEditionGroup,
 			searchResults
 		} = this.props;
 
@@ -130,6 +126,9 @@ class NameSection extends React.Component {
 		}));
 
 		const warnIfExists = !_.isEmpty(exactMatches);
+		if (_.toLower(entityType) === 'edition' && searchForExistingEditionGroup) {
+			onNameChangeCheckIfEditionGroupExists(nameValue);
+		}
 
 		return (
 			<div>

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -126,6 +126,9 @@ class NameSection extends React.Component {
 		}));
 
 		const warnIfExists = !_.isEmpty(exactMatches);
+
+		// Search for Edition Groups that match the name, if the entity is an Edition
+		// Will react to name changes and searchForExistingEditionGroup (which reacts to editionGroupBBID field)
 		if (_.toLower(entityType) === 'edition' && searchForExistingEditionGroup) {
 			onNameChangeCheckIfEditionGroupExists(nameValue);
 		}

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -292,7 +292,8 @@ function mapStateToProps(rootState) {
 	};
 }
 
-function mapDispatchToProps(dispatch, {entityType}) {
+function mapDispatchToProps(dispatch, {entity, entityType}) {
+	const entityBBID = entity && entity.bbid;
 	return {
 		onDisambiguationChange: (event) =>
 			dispatch(debouncedUpdateDisambiguationField(event.target.value)),
@@ -301,13 +302,13 @@ function mapDispatchToProps(dispatch, {entityType}) {
 		onNameChange: (value) =>
 			dispatch(debouncedUpdateNameField(value)),
 		onNameChangeCheckIfEditionGroupExists: _.debounce((value) => {
-			dispatch(checkIfNameExists(value, 'EditionGroup', UPDATE_WARN_IF_EDITION_GROUP_EXISTS));
+			dispatch(checkIfNameExists(value, entityBBID, 'EditionGroup', UPDATE_WARN_IF_EDITION_GROUP_EXISTS));
 		}, 1500),
 		onNameChangeCheckIfExists: _.debounce((value) => {
-			dispatch(checkIfNameExists(value, entityType));
+			dispatch(checkIfNameExists(value, entityBBID, entityType));
 		}, 500),
 		onNameChangeSearchName: _.debounce((value) => {
-			dispatch(searchName(value, entityType));
+			dispatch(searchName(value, entityBBID, entityType));
 		}, 500),
 		onSortNameChange: (event) =>
 			dispatch(debouncedUpdateSortNameField(event.target.value))

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -78,6 +78,7 @@ class NameSection extends React.Component {
 		super(props);
 		this.updateNameFieldInputRef = this.updateNameFieldInputRef.bind(this);
 		this.handleNameChange = this.handleNameChange.bind(this);
+		this.searchForMatchindEditionGroups = this.searchForMatchindEditionGroups.bind(this);
 	}
 
 	/*
@@ -93,10 +94,33 @@ class NameSection extends React.Component {
 		}
 	}
 
+	componentDidUpdate(prevProps) {
+		const {nameValue, searchForExistingEditionGroup} = this.props;
+		if (prevProps.searchForExistingEditionGroup === searchForExistingEditionGroup ||
+			searchForExistingEditionGroup === false) {
+			return;
+		}
+		this.searchForMatchindEditionGroups(nameValue);
+	}
+
 	handleNameChange(event) {
 		this.props.onNameChange(event.target.value);
 		this.props.onNameChangeCheckIfExists(event.target.value);
 		this.props.onNameChangeSearchName(event.target.value);
+		this.searchForMatchindEditionGroups(event.target.value);
+	}
+
+	searchForMatchindEditionGroups(nameValue) {
+		const {
+			entityType,
+			onNameChangeCheckIfEditionGroupExists,
+			searchForExistingEditionGroup
+		} = this.props;
+		// Search for Edition Groups that match the name, if the entity is an Edition
+		// Will react to name changes and searchForExistingEditionGroup (which reacts to editionGroupBBID field)
+		if (_.toLower(entityType) === 'edition' && searchForExistingEditionGroup && !_.isNil(nameValue)) {
+			onNameChangeCheckIfEditionGroupExists(nameValue);
+		}
 	}
 
 	updateNameFieldInputRef(inputRef) {
@@ -113,10 +137,8 @@ class NameSection extends React.Component {
 			nameValue,
 			sortNameValue,
 			onLanguageChange,
-			onNameChangeCheckIfEditionGroupExists,
 			onSortNameChange,
 			onDisambiguationChange,
-			searchForExistingEditionGroup,
 			searchResults
 		} = this.props;
 
@@ -127,11 +149,6 @@ class NameSection extends React.Component {
 
 		const warnIfExists = !_.isEmpty(exactMatches);
 
-		// Search for Edition Groups that match the name, if the entity is an Edition
-		// Will react to name changes and searchForExistingEditionGroup (which reacts to editionGroupBBID field)
-		if (_.toLower(entityType) === 'edition' && searchForExistingEditionGroup) {
-			onNameChangeCheckIfEditionGroupExists(nameValue);
-		}
 
 		return (
 			<div>

--- a/src/client/entity-editor/validators/edition.js
+++ b/src/client/entity-editor/validators/edition.js
@@ -105,7 +105,7 @@ export function validateEditionSection(data: any): boolean {
 		validateEditionSectionPages(get(data, 'pages', null)) &&
 		validateEditionSectionEditionGroup(
 			get(data, 'editionGroup', null),
-			get(data, 'editionGroupRequired', null) || get(data, 'matchingNameEditionGroups', []).length
+			get(data, 'editionGroupRequired', null)
 		) &&
 		validateEditionSectionPublisher(get(data, 'publisher', null)) &&
 		validateEditionSectionReleaseDate(get(data, 'releaseDate', null)).isValid &&

--- a/src/client/helpers/setupIconLibrary.js
+++ b/src/client/helpers/setupIconLibrary.js
@@ -19,7 +19,7 @@
 import {config, library} from '@fortawesome/fontawesome-svg-core';
 import {
 	faAngleDoubleLeft, faAngleDoubleUp, faBook, faCalendarAlt, faChartLine, faCheck, faCircle,
-	faCircleNotch, faCodeBranch, faComment, faCommentDots, faComments, faEnvelope, faExclamationTriangle,
+	faCircleNotch, faClone, faCodeBranch, faComment, faCommentDots, faComments, faEnvelope, faExclamationTriangle,
 	faExternalLinkAlt, faGlobe, faGripVertical, faHistory, faInfo, faListUl, faPenNib, faPencilAlt, faPencilRuler,
 	faPlus, faQuestionCircle, faRemoveFormat, faSave, faSearch, faSignInAlt,
 	faSignOutAlt, faSlash, faTasks, faTimes, faTimesCircle, faTrashAlt, faUndo,
@@ -38,7 +38,7 @@ config.autoAddCss = true;
 // Add Icons to FontAwesome library
 library.add(
 	fab, faAngleDoubleLeft, faAngleDoubleUp, faBook, faCalendarAlt, faChartLine, faCheck, faCircle,
-	faCircleNotch, faCodeBranch, faComment, faCommentDots, faComments, faEnvelope, faExclamationTriangle,
+	faCircleNotch, faClone, faCodeBranch, faComment, faCommentDots, faComments, faEnvelope, faExclamationTriangle,
 	faExternalLinkAlt, faGlobe, faGripVertical, faHistory, faInfo, faListUl, faPenNib, faPencilAlt, faPencilRuler,
 	faPlus, faQuestionCircle, faRemoveFormat, faSave, faSearch, faSignInAlt,
 	faSignOutAlt, faSlash, faTasks, faTimes, faTimesCircle, faTrashAlt, faUndo,

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -327,7 +327,8 @@ function editionToFormState(edition) {
 	const editionSection = {
 		depth: edition.depth,
 		editionGroup,
-		editionGroupRequired: true,
+		// Determines whether the EG can be left blank (an EG will be auto-created) for existing Editions
+		editionGroupRequired: false,
 		editionGroupVisible: true,
 		format: edition.editionFormat && edition.editionFormat.id,
 		height: edition.height,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
This PR addresses a few issues with name deduplication and other search-related mechanisms in the entity editor:

- [BB-356](https://tickets.metabrainz.org/browse/BB-356): Editions with the same name should be allowed
- [BB-413](https://tickets.metabrainz.org/browse/BB-413): Name deduplication triggers for the entity being edited
- [BB-537](https://tickets.metabrainz.org/browse/BB-537): Don't auto-select matching Edition Group

### Solution
1) Allow Editions and Edition Groups with the same name (without requiring a disambiguation)
2) Autocomplete and deduplication mechanisms should filter out the entity being edited from its results to avoid conflict with itself.
3) For an Edition with a name matching that of an Edition Group, instead of auto-selecting the first exact match, display a list of exact matches to allow the editor to select one, or opt for searching for another one or automatically creating one; once an EG is selected, hide the list of matches:

Here a match is shown, but not selected yet, and an EG will be created automatically.
<img width="1140" alt="Capture d’écran 2020-10-09 à 12 40 45" src="https://user-images.githubusercontent.com/6179856/95574182-db5bd700-0a2c-11eb-9c18-f596436c1b24.png">

Here the editor chose to search for an existing one and can select one or choose to revert to auto-creation.
<img width="1143" alt="Capture d’écran 2020-10-09 à 12 43 08" src="https://user-images.githubusercontent.com/6179856/95574296-03e3d100-0a2d-11eb-8c03-d2eca02c37d6.png">


Here the exact match was selected. If any EG is selected, we hide the list of matches (we don't want to confuse editors with a warning-colour thing when everything is all right)
<img width="1142" alt="Capture d’écran 2020-10-09 à 12 41 04" src="https://user-images.githubusercontent.com/6179856/95574204-e1ea4e80-0a2c-11eb-87b5-e496176d6f09.png">

### Areas of Impact
EntityEditor component, mainly EditionSection and NameSection.
