### PR TITLE
Editor server cleanup

### DIFF
--- a/src/server/helpers/handler.js
+++ b/src/server/helpers/handler.js
@@ -21,16 +21,20 @@ import * as error from '../../common/helpers/error';
 import log from 'log';
 
 
-export function sendPromiseResult(res, promise, processingCallback) {
-	return promise
-		.then((result) => {
-			res.send(result);
+export async function sendPromiseResult(response, promise, processingCallback) {
+	const result = await promise;
 
-			if (typeof processingCallback === 'function') {
-				return processingCallback(result);
-			}
+	try {
+		response.send(result);
 
-			return result;
-		})
-		.catch((err) => { log.error(err); return error.sendErrorAsJSON(res, err); });
+		if (typeof processingCallback === 'function') {
+			return processingCallback(result);
+		}
+
+		return result;
+	}
+	catch (err) {
+		log.error(err);
+		return error.sendErrorAsJSON(response, err);
+	}
 }

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -136,7 +136,7 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 			});
 
 		// Modify the user to match the updates from the form
-		const titleID = _.get(req.body, 'title', null) || null;
+		const titleID = _.get(req.body, 'title', null);
 		const modifiedEditor = await editor
 			.set('bio', req.body.bio)
 			.set('areaId', req.body.areaId)
@@ -481,15 +481,6 @@ router.post('/:id/achievements/', auth.isAuthenticated, (req, res) => {
 		if (!isCurrentUser(userId, req.user)) {
 			throw new Error('Not authenticated');
 		}
-
-		// Presumably, this is testing that the provided editor ID is valid
-		// prior to attempting to update the ranks. Possibly not needed since
-		// the user must exist if authenticated?
-		await new Editor({id: userId})
-			.fetch({require: true});
-
-		// TODO: missing error handling for possible missing editor - carried
-		// over from old code.
 
 		const rankOnePromise = rankUpdate(orm, userId, req.body.rank1, 1);
 		const rankTwoPromise = rankUpdate(orm, userId, req.body.rank2, 2);

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -213,7 +213,9 @@ export async function getEditorActivity(editorId, startDate, Revision, endDate =
 		});
 
 	const revisionJSON = revisions ? revisions.toJSON() : [];
-	const revisionDates = revisionJSON.map((revision) => format(new Date(revision.createdAt), 'LLL-yy'));
+	const revisionDates = revisionJSON.map(
+		(revision) => format(new Date(revision.createdAt), 'LLL-yy')
+	);
 	const revisionsCount = _.countBy(revisionDates);
 
 	const allMonthsInInterval = eachMonthOfInterval({
@@ -297,9 +299,13 @@ router.get('/:id', async (req, res, next) => {
 // eslint-disable-next-line consistent-return
 router.get('/:id/revisions', async (req, res, next) => {
 	const {Editor, TitleUnlock} = req.app.locals.orm;
+	const DEFAULT_MAX_REVISIONS = 20;
+	const DEFAULT_REVISION_OFFSET = 0;
 
-	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
-	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
+	const size =
+		req.query.size ? parseInt(req.query.size, 10) : DEFAULT_MAX_REVISIONS;
+	const from =
+		req.query.from ? parseInt(req.query.from, 10) : DEFAULT_REVISION_OFFSET;
 
 	try {
 		// get 1 more result to check nextEnabled
@@ -346,8 +352,13 @@ router.get('/:id/revisions', async (req, res, next) => {
 
 // eslint-disable-next-line consistent-return
 router.get('/:id/revisions/revisions', async (req, res, next) => {
-	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
-	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
+	const DEFAULT_MAX_REVISIONS = 20;
+	const DEFAULT_REVISION_OFFSET = 0;
+
+	const size =
+		req.query.size ? parseInt(req.query.size, 10) : DEFAULT_MAX_REVISIONS;
+	const from =
+		req.query.from ? parseInt(req.query.from, 10) : DEFAULT_REVISION_OFFSET;
 
 	try {
 		const orderedRevisions = await getOrderedRevisionForEditorPage(from, size, req);
@@ -499,8 +510,15 @@ router.post('/:id/achievements/', auth.isAuthenticated, (req, res) => {
 // eslint-disable-next-line consistent-return
 router.get('/:id/collections', async (req, res, next) => {
 	const {Editor, TitleUnlock} = req.app.locals.orm;
-	const size = req.query.size ? parseInt(req.query.size, 10) : 20;
-	const from = req.query.from ? parseInt(req.query.from, 10) : 0;
+
+	const DEFAULT_MAX_COLLECTIONS = 20;
+	const DEFAULT_COLLECTION_OFFSET = 0;
+
+	const size =
+		req.query.size ? parseInt(req.query.size, 10) : DEFAULT_MAX_COLLECTIONS;
+	const from =
+		req.query.from ? parseInt(req.query.from, 10) : DEFAULT_COLLECTION_OFFSET;
+
 	let type = req.query.type ? req.query.type : null;
 	const entityTypes = _.keys(commonUtils.getEntityModels(req.app.locals.orm));
 	if (!entityTypes.includes(type) && type !== null) {

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -309,10 +309,15 @@ router.get('/:id/revisions', async (req, res, next) => {
 
 	try {
 		// get 1 more result to check nextEnabled
-		const orderedRevisions = await getOrderedRevisionForEditorPage(from, size + 1, req);
-		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedRevisions, size);
-		const editor = await new Editor({id: req.params.id}).fetch();
-		const editorJSON = await getEditorTitleJSON(editor.toJSON(), TitleUnlock);
+		const orderedRevisionsPromise =
+			getOrderedRevisionForEditorPage(from, size + 1, req);
+		const editorJSONPromise = getIdEditorJSONPromise(req.params.id, req);
+
+		const [orderedRevisions, editorJSON] =
+			await Promise.all(orderedRevisionsPromise, editorJSONPromise);
+
+		const {newResultsArray, nextEnabled} =
+			utils.getNextEnabledAndResultsArray(orderedRevisions, size);
 
 		const props = generateProps(req, res, {
 			editor: editorJSON,

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -313,7 +313,7 @@ router.get('/:id/revisions', async (req, res, next) => {
 		const editorJSONPromise = getIdEditorJSONPromise(req.params.id, req);
 
 		const [orderedRevisions, editorJSON] =
-			await Promise.all(orderedRevisionsPromise, editorJSONPromise);
+			await Promise.all([orderedRevisionsPromise, editorJSONPromise]);
 
 		const {newResultsArray, nextEnabled} =
 			utils.getNextEnabledAndResultsArray(orderedRevisions, size);

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -201,15 +201,7 @@ function getIdEditorJSONPromise(userId, req) {
 			require: true,
 			withRelated: ['type', 'gender', 'area']
 		})
-		.then((editordata) => {
-			let editorJSON = editordata.toJSON();
-
-			if (!isCurrentUser(userId, req.user)) {
-				editorJSON = _.omit(editorJSON, ['password', 'email']);
-			}
-
-			return editorJSON;
-		})
+		.then((editordata) => editordata.toJSON())
 		.then(_.partialRight(getEditorTitleJSON, TitleUnlock))
 		.catch(Editor.NotFoundError, () => {
 			throw new error.NotFoundError('Editor not found', req);

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -298,7 +298,6 @@ router.get('/:id', async (req, res, next) => {
 
 // eslint-disable-next-line consistent-return
 router.get('/:id/revisions', async (req, res, next) => {
-	const {Editor, TitleUnlock} = req.app.locals.orm;
 	const DEFAULT_MAX_REVISIONS = 20;
 	const DEFAULT_REVISION_OFFSET = 0;
 
@@ -355,7 +354,7 @@ router.get('/:id/revisions', async (req, res, next) => {
 	}
 });
 
-// eslint-disable-next-line consistent-return
+
 router.get('/:id/revisions/revisions', async (req, res, next) => {
 	const DEFAULT_MAX_REVISIONS = 20;
 	const DEFAULT_REVISION_OFFSET = 0;
@@ -365,13 +364,10 @@ router.get('/:id/revisions/revisions', async (req, res, next) => {
 	const from =
 		req.query.from ? parseInt(req.query.from, 10) : DEFAULT_REVISION_OFFSET;
 
-	try {
-		const orderedRevisions = await getOrderedRevisionForEditorPage(from, size, req);
-		res.send(orderedRevisions);
-	}
-	catch (err) {
-		return next(err);
-	}
+	const orderedRevisions =
+		await getOrderedRevisionForEditorPage(from, size, req).catch(next);
+
+	res.send(orderedRevisions);
 });
 
 function setAchievementUnlockedField(achievements, unlocks) {
@@ -524,13 +520,14 @@ router.get('/:id/collections', async (req, res, next) => {
 	const from =
 		req.query.from ? parseInt(req.query.from, 10) : DEFAULT_COLLECTION_OFFSET;
 
-	let type = req.query.type ? req.query.type : null;
-	const entityTypes = _.keys(commonUtils.getEntityModels(req.app.locals.orm));
-	if (!entityTypes.includes(type) && type !== null) {
-		throw new error.BadRequestError(`Type ${type} do not exist`);
-	}
+	const type = req.query.type ? req.query.type : null;
 
 	try {
+		const entityTypes = _.keys(commonUtils.getEntityModels(req.app.locals.orm));
+		if (!entityTypes.includes(type) && type !== null) {
+			throw new error.BadRequestError(`Type ${type} do not exist`);
+		}
+
 		// fetch 1 more collections than required to check nextEnabled
 		const orderedCollections = await getOrderedCollectionsForEditorPage(from, size + 1, type, req);
 		const {newResultsArray, nextEnabled} = utils.getNextEnabledAndResultsArray(orderedCollections, size);


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
The code for handling editor route requests currently uses long chains of promises, which can be hard to follow and reason about. The current use of promises also enforces unnecessary serialization of some database operations. Code is duplicated in several places, and some minor bugs are present.

### Solution
This PR mainly re-writes the code using promise chains to use ES6 async/await to express asynchronous code in a flat, linear format. It also refactors some code to pull out commonly used data-fetching snippets into separate functions, which could be migrated to the bookbrainz-data-js package in future. Some other minor code quality improvements are also implemented.


### Areas of Impact
Impacts two files:
* `src/server/routes/editor.js`
* `src/server/helpers/handler.js`

The change to handler.js impacts how responses for POST requests are generated, but shouldn't change functionality. The changes to editor.js affect the following routes, but again, shouldn't change any functionality:

* `/editor/edit`
* `/editor/edit/handler`
* `/editor/:id`
* `/editor/:id/revisions`
* `/editor/:id/revisions/revisions`
* `/editor/:id/achievements`
* `/editor/:id/collections`
* `/editor/:id/collections`