### PR TITLE
BB-554: Issues when merging Publishers without Editions

### DIFF
--- a/src/client/helpers/entity.js
+++ b/src/client/helpers/entity.js
@@ -202,7 +202,7 @@ export function getEditionPublishers(edition) {
 		return edition.publisherSet.publishers.map(
 			(publisher) => (
 				<a href={`/publisher/${publisher.bbid}`} key={publisher.bbid}>
-					{publisher.defaultAlias.name}
+					{_get(publisher, 'defaultAlias.name', publisher.bbid)}
 				</a>
 			)
 		);

--- a/src/common/helpers/error.js
+++ b/src/common/helpers/error.js
@@ -140,7 +140,7 @@ export function getErrorToSend(err) {
 	 * instead and return a new generic SiteError
 	 */
 	_logError(err);
-	return new SiteError();
+	return new SiteError(err.message);
 }
 
 export function sendErrorAsJSON(res, err) {

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -619,6 +619,7 @@ export async function processMergeOperation(orm, transacting, session, mainEntit
 		}
 		catch (err) {
 			log.error(err);
+			throw err;
 		}
 	}
 

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -599,11 +599,13 @@ export async function processMergeOperation(orm, transacting, session, mainEntit
 		try {
 			const editionsToSetCollections = await Promise.all(entitiesModelsToMerge.map(entitiesModel => entitiesModel.editions()));
 			// eslint-disable-next-line consistent-return
-			const editionsToSet = _.flatMap(editionsToSetCollections, edition => {
+			let editionsToSet = _.flatMap(editionsToSetCollections, edition => {
 				if (edition.models && edition.models.length) {
 					return edition.models;
 				}
 			});
+			// Remove 'undefined' entries (no editions in those publishers)
+			editionsToSet = _.reject(editionsToSet, _.isNil);
 			await Promise.all(editionsToSet.map(async (edition) => {
 				// Fetch current PublisherSet
 				const oldPublisherSet = await edition.publisherSet();


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->
https://tickets.metabrainz.org/browse/BB-554

### Problem
A couple of compounded issues:
1. Part of the merge operation fails when merging a Publisher without editions
2. That error is swallowed, and the operation finishes successfully instead of throwing error to user
3. Error message was not shown to end users, just a generic message
4. Front-end: Edition display page was throwing error if publisher had no defaultalias


### Solution
1. Don't call Edition model methods if there is no edition at all (duh.)
2. Throw error down the await/async chain
3. Create SiteError with the actual error message
4. Safely read defaultAlias.name and otherwise show bbid instead
