### PR TITLE
feat(editor): Add "send email" link to user profile

### DIFF
--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -54,9 +54,19 @@ class EditorProfileTab extends React.Component {
 		let musicbrainzAccount = 'No Linked MusicBrainz Account';
 		if (cachedMetabrainzName) {
 			musicbrainzAccount = (
-				<a href={`http://musicbrainz.org/user/${cachedMetabrainzName}`}>
-					{cachedMetabrainzName}
-				</a>
+				<span>
+					<a href={`http://musicbrainz.org/user/${cachedMetabrainzName}`}>
+						{cachedMetabrainzName}
+					</a>
+					&nbsp;(
+					<a
+						href={`http://musicbrainz.org/user/${cachedMetabrainzName}/contact`}
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+					send email <FontAwesomeIcon icon="external-link-alt"/>
+					</a>)
+				</span>
 			);
 		}
 		else if (metabrainzUserId) {


### PR DESCRIPTION
Following some recent forum drama, it has become more pressing to have a messaging system available on the website.
This PR aims to be a stopgap using the existing MusicBrainz infrastructure until a messaging system is developed for BookBrainz.

This new link redirects to the MusicBrainz email contact page/form (in a new tab).

<img width="445" alt="Capture d’écran 2020-11-11 à 16 19 02" src="https://user-images.githubusercontent.com/6179856/98829592-a848a100-2439-11eb-8ec8-f0753c59dbf6.png">
