### PR TITLE
Deletion form note improvements

### DIFF
--- a/src/client/components/forms/deletion.js
+++ b/src/client/components/forms/deletion.js
@@ -48,9 +48,11 @@ class EntityDeletionForm extends React.Component {
 			error: null,
 			waiting: true
 		});
-
+		const data = {
+			note: this.note.getValue()
+		};
 		request.post(this.deleteUrl)
-			.send()
+			.send(data)
 			.then(() => {
 				window.location.href = this.entityUrl;
 			})

--- a/src/client/components/forms/deletion.js
+++ b/src/client/components/forms/deletion.js
@@ -17,12 +17,12 @@
  */
 
 import * as bootstrap from 'react-bootstrap';
-
 import CustomInput from '../../input';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import LoadingSpinner from '../loading-spinner';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ValidationLabel from '../../entity-editor/common/validation-label';
 import {kebabCase as _kebabCase} from 'lodash';
 import request from 'superagent';
 
@@ -35,24 +35,36 @@ class EntityDeletionForm extends React.Component {
 
 		this.state = {
 			error: null,
+			note: null,
 			waiting: false
 		};
 
 		this.handleSubmit = this.handleSubmit.bind(this);
+		this.handleNoteChange = this.handleNoteChange.bind(this);
+	}
+
+	handleNoteChange(event) {
+		this.setState({note: event.target.value});
 	}
 
 	handleSubmit(event) {
+		const {note} = this.state;
 		event.preventDefault();
 
+		if (!note || !note.length) {
+			this.setState({
+				error: `We require users to leave a note explaining the reasons why they are deleting an entity.
+				Please provide an explanation in the text area above.`,
+				waiting: false
+			});
+			return;
+		}
 		this.setState({
 			error: null,
 			waiting: true
 		});
-		const data = {
-			note: this.note.getValue()
-		};
 		request.post(this.deleteUrl)
-			.send(data)
+			.send({note})
 			.then(() => {
 				window.location.href = this.entityUrl;
 			})
@@ -68,6 +80,7 @@ class EntityDeletionForm extends React.Component {
 
 	render() {
 		const {entity} = this.props;
+		const {note} = this.state;
 
 		this.entityUrl = `/${_kebabCase(entity.type)}/${entity.bbid}`;
 		this.deleteUrl = `${this.entityUrl}/delete/handler`;
@@ -80,11 +93,13 @@ class EntityDeletionForm extends React.Component {
 
 		const loadingComponent = this.state.waiting ? <LoadingSpinner/> : null;
 
+		const hasNote = note && note.length;
 		const footerComponent = (
 			<span className="clearfix">
 				<Button
 					bsStyle="danger"
 					className="pull-right"
+					disabled={!hasNote}
 					type="submit"
 				>
 					<FontAwesomeIcon icon="trash-alt"/> Delete
@@ -100,6 +115,12 @@ class EntityDeletionForm extends React.Component {
 
 		const entityName =
 			entity.defaultAlias ? entity.defaultAlias.name : '(unnamed)';
+
+		const noteLabel = (
+			<ValidationLabel error={!hasNote}>
+				Note
+			</ValidationLabel>
+		);
 
 		return (
 			<div id="deletion-form">
@@ -133,17 +154,37 @@ class EntityDeletionForm extends React.Component {
 									</p>
 									<p>If you are certain it should be deleted, please enter a
 									revision note below to explain why and confirm the deletion.
+									If you are not sure, you can get feedback from the community&nbsp;
+									<a
+										href="//community.metabrainz.org/c/bookbrainz"
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										on our forums
+									</a>
+									&nbsp;or on our&nbsp;
+									<a
+										href="//webchat.freenode.net/?channels=#metabrainz"
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										IRC channel
+									</a>.
 									</p>
 									<p className="text-muted">
 									If this {entity.type} is a duplicate, click <a href={`/merge/add/${entity.bbid}`}>this link</a>
-									to select it to be merged instead.
+									&nbsp;to select it to be merged instead.
 									</p>
-
+									<hr/>
 									<CustomInput
-										ref={(ref) => this.note = ref}
+										help="* A note is required"
+										label={noteLabel}
 										rows="5"
+										tooltipText="Please explain why you are deleting this entity. This is required."
 										type="textarea"
+										value={note}
 										wrapperClassName="margin-top-1"
+										onChange={this.handleNoteChange}
 									/>
 									{errorComponent}
 								</Panel.Body>

--- a/src/server/routes/entity/entity.js
+++ b/src/server/routes/entity/entity.js
@@ -421,6 +421,10 @@ export function handleDelete(
 	const {body}: {body: any} = req;
 
 	const entityDeletePromise = bookshelf.transaction(async (transacting) => {
+		if (!body.note || !body.note.length) {
+			throw new error.FormSubmissionError('A revision note is required when deleting an entity');
+		}
+
 		const otherEntities = await deleteRelationships(orm, transacting, entity);
 
 		const newRevision = await new Revision({


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
[BB-560:](https://tickets.metabrainz.org/browse/BB-560) Make revision note mandatory when deleting an entity
[BB-566:](https://tickets.metabrainz.org/browse/BB-566) Revision notes aren't being saved when deleting an entity

### Solution

Send note content (duh!) when submitting deletion, add some simple form validation and feedback to make the note compulsory, and add a bit of text to invite unsure user to contact the forums or IRC channel

<img width="509" alt="Capture d’écran 2020-11-11 à 19 17 32" src="https://user-images.githubusercontent.com/6179856/98848988-ce2e6f80-2452-11eb-9dd4-65c96d4bb55e.png">
