### PR TITLE
fix(entity-editor): Remove use of log package in client code

### DIFF
--- a/src/client/entity-editor/name-section/actions.js
+++ b/src/client/entity-editor/name-section/actions.js
@@ -19,7 +19,6 @@
 // @flow
 
 import {snakeCase as _snakeCase, isString, remove, uniqBy} from 'lodash';
-import log from 'log';
 import request from 'superagent';
 
 
@@ -156,7 +155,8 @@ export function checkIfNameExists(
 			});
 		}
 		catch (error) {
-			log.error(error);
+			// eslint-disable-next-line no-console
+			console.error(error);
 		}
 	};
 }


### PR DESCRIPTION
The introduction of Typescript in PR #531 has unearthed an unexpected use of the `log` package (server-side logging utility) in the client code, which we do not want.

This was the only use of in in the client code, in the entity editor's name section redux actions.