### PR TITLE
BB-544: Improve Editor form and error handling

### DIFF
--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -39,12 +39,15 @@ class ProfileForm extends React.Component {
 		this.state = {
 			area: props.editor.area ?
 				props.editor.area : null,
+			areaId: props.editor.area ?
+				props.editor.area.id : null,
 			bio: props.editor.bio,
 			error: null,
-			gender: props.editor.gender ?
-				props.editor.gender : null,
+			genderId: props.editor.gender ?
+				props.editor.gender.id : null,
 			genders: props.genders,
 			name: props.editor.name,
+			titleId: props.editor.titleUnlockId,
 			titles: props.titles,
 			waiting: false
 		};
@@ -55,19 +58,18 @@ class ProfileForm extends React.Component {
 		if (!this.valid()) {
 			return;
 		}
-		const area = this.area.getValue();
-		const gender = this.gender.getValue();
-		const title = this.title && this.title.getValue();
-		const name = this.name.getValue().trim();
-		const bio = this.bio.getValue().trim();
+		if (!this.hasChanged()) {
+			return;
+		}
+		const {name, bio, areaId, titleId, genderId} = this.state;
 
 		const data = {
-			areaId: area ? parseInt(area, 10) : null,
-			bio,
-			genderId: gender ? parseInt(gender, 10) : null,
+			areaId,
+			bio: bio.trim(),
+			genderId,
 			id: this.props.editor.id,
-			name,
-			title
+			name: name.trim(),
+			title: titleId
 		};
 		this.setState({
 			waiting: true
@@ -94,8 +96,28 @@ class ProfileForm extends React.Component {
 		}
 	};
 
-	valid = () => this.name.getValue();
+	valid = () => {
+		const {name} = this.state;
+		return name?.length;
+	};
 
+	hasChanged = () => {
+		const {name, bio, areaId, titleId, genderId} = this.state;
+
+		return this.props.editor?.area.id !== areaId ||
+			this.props.editor?.bio !== bio ||
+			this.props.editor?.gender?.id !== genderId ||
+			this.props.editor?.name !== name ||
+			this.props.editor?.titleUnlockId !== titleId;
+	};
+
+	handleValueChange =(event) => {
+		this.setState({[event.target.name]: event.target.value});
+	};
+
+	handleSelectChange = (value, idAttribute) => {
+		this.setState({[idAttribute]: value});
+	};
 
 	render() {
 		const loadingElement =
@@ -109,11 +131,9 @@ class ProfileForm extends React.Component {
 			title.unlockId = unlock.id;
 			return title;
 		});
+		const {area, genderId, titleId, name, bio} = this.state;
 
-		const initialDisplayName = this.state.name;
-		const initialGender = this.state.gender ? this.state.gender.id : null;
-		const initialBio = this.state.bio;
-		const initialArea = injectDefaultAliasName(this.state.area);
+		const transformedArea = injectDefaultAliasName(area);
 
 		let errorComponent = null;
 		if (this.state.error) {
@@ -121,67 +141,74 @@ class ProfileForm extends React.Component {
 				<Alert bsStyle="danger">{this.state.error.message}</Alert>;
 		}
 
+		const hasChanged = this.hasChanged();
+
 		return (
 			<div>
 				<Row className="margin-top-2">
-					<h1>Edit Profile</h1>
 					{loadingElement}
 					<Col md={8} mdOffset={2}>
 						<form onSubmit={this.handleSubmit}>
 							<Panel>
 								<Panel.Heading>
 									<Panel.Title>
-										Edit your public profile
+										<span className="h3">Edit your public profile</span>
 									</Panel.Title>
 								</Panel.Heading>
 								<Panel.Body>
 									<CustomInput
-										defaultValue={initialDisplayName}
-										label="Display Name"
-										ref={(ref) => this.name = ref}
+										defaultValue={name}
+										label="Display Name *"
+										name="name"
 										type="text"
+										onChange={this.handleValueChange}
 									/>
 									<CustomInput
-										defaultValue={initialBio}
+										defaultValue={bio}
 										label="Bio"
-										ref={(ref) => this.bio = ref}
+										name="bio"
 										type="textarea"
+										onChange={this.handleValueChange}
 									/>
 									{titleOptions.length > 0 &&
 										<SelectWrapper
 											base={ReactSelect}
+											defaultValue={titleId}
 											idAttribute="unlockId"
 											instanceId="title"
 											label="Title"
 											labelAttribute="title"
+											name="titleId"
 											options={titleOptions}
 											placeholder="Select title"
-											ref={(ref) => this.title = ref}
+											onChange={this.handleSelectChange}
 										/>
 									}
 									<SearchSelect
-										defaultValue={initialArea}
+										defaultValue={transformedArea}
 										label="Area"
+										name="areaId"
 										placeholder="Select area..."
-										ref={(ref) => this.area = ref}
 										type="area"
+										onChange={this.handleSelectChange}
 									/>
 									<SelectWrapper
 										base={ReactSelect}
-										defaultValue={initialGender}
+										defaultValue={genderId}
 										idAttribute="id"
-										instanceId="gender"
 										label="Gender"
 										labelAttribute="name"
+										name="genderId"
 										options={genderOptions}
 										placeholder="Select Gender"
-										ref={(ref) => this.gender = ref}
+										onChange={this.handleSelectChange}
 									/>
 									{errorComponent}
 								</Panel.Body>
 								<Panel.Footer>
 									<Button
-										bsStyle="primary"
+										bsStyle="success"
+										disabled={!hasChanged}
 										type="submit"
 									>
 										Save changes

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -98,7 +98,7 @@ class ProfileForm extends React.Component {
 
 	valid = () => {
 		const {name} = this.state;
-		return name?.length;
+		return Boolean(name?.length);
 	};
 
 	hasChanged = () => {
@@ -158,9 +158,11 @@ class ProfileForm extends React.Component {
 								<Panel.Body>
 									<CustomInput
 										defaultValue={name}
-										label="Display Name *"
+										help="required"
+										label="Display Name"
 										name="name"
 										type="text"
+										validationState={this.valid() ? 'success' : 'error'}
 										onChange={this.handleValueChange}
 									/>
 									<CustomInput

--- a/src/client/components/forms/profile.js
+++ b/src/client/components/forms/profile.js
@@ -83,7 +83,8 @@ class ProfileForm extends React.Component {
 				method: 'POST'
 			});
 			if (!response.ok) {
-				throw new Error(response.statusText);
+				const {error} = await response.json();
+				throw new Error(error ?? response.statusText);
 			}
 
 			window.location.href = `/editor/${this.props.editor.id}`;

--- a/src/client/components/input/select-wrapper.js
+++ b/src/client/components/input/select-wrapper.js
@@ -58,7 +58,7 @@ class SelectWrapper extends React.Component {
 		this.currentValue = newValue;
 
 		if (this.props.onChange) {
-			this.props.onChange(wangleID(newValue, this.props.idAttribute));
+			this.props.onChange(wangleID(newValue, this.props.idAttribute), this.props.name);
 		}
 	}
 
@@ -121,6 +121,7 @@ SelectWrapper.propTypes = {
 	labelAttribute: PropTypes.string.isRequired,
 	labelClassName: PropTypes.string,
 	multiple: PropTypes.bool,
+	name: PropTypes.string,
 	onChange: PropTypes.func,
 	value: PropTypes.oneOfType([
 		PropTypes.string,
@@ -134,6 +135,7 @@ SelectWrapper.defaultProps = {
 	label: null,
 	labelClassName: null,
 	multiple: false,
+	name: null,
 	onChange: null,
 	value: null,
 	wrapperClassName: null

--- a/src/client/input.tsx
+++ b/src/client/input.tsx
@@ -39,6 +39,7 @@ type IGProps = {
 	buttonAfter?: any,
 	help?: React.ReactNode,
 	hasFeedback?: boolean,
+	name?: string,
 	children?: React.ReactElement,
 	value?: string,
 	[propName: string]: any
@@ -221,6 +222,7 @@ export default class Input extends React.Component<Props> {
 				bsClass={cx({'form-group': !standalone}, groupClassName)}
 				bsSize={bsSize}
 				controlId={id}
+				name={props.name}
 				validationState={validationState}
 			>
 				{label && (

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -220,6 +220,9 @@ export function autocomplete(orm, query, type) {
 }
 
 export function indexEntity(entity) {
+	if (!entity) {
+		return new Promise(resolve => resolve(null));
+	}
 	return _client.index({
 		body: entity,
 		id: entity.bbid,

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -219,16 +219,16 @@ export function autocomplete(orm, query, type) {
 	return _searchForEntities(orm, dslQuery);
 }
 
+// eslint-disable-next-line consistent-return
 export function indexEntity(entity) {
-	if (!entity) {
-		return new Promise(resolve => resolve(null));
+	if (entity) {
+		return _client.index({
+			body: entity,
+			id: entity.bbid,
+			index: _index,
+			type: snakeCase(entity.type)
+		});
 	}
-	return _client.index({
-		body: entity,
-		id: entity.bbid,
-		index: _index,
-		type: snakeCase(entity.type)
-	});
 }
 
 export function deleteEntity(entity) {

--- a/src/server/helpers/handler.js
+++ b/src/server/helpers/handler.js
@@ -22,9 +22,8 @@ import log from 'log';
 
 
 export async function sendPromiseResult(response, promise, processingCallback) {
-	const result = await promise;
-
 	try {
+		const result = await promise;
 		response.send(result);
 
 		if (typeof processingCallback === 'function') {

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -117,7 +117,7 @@ function isCurrentUser(reqUserID, sessionUser) {
 	return reqUserID === sessionUser.id;
 }
 
-router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res, next) => {
+router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res) => {
 	async function runAsync() {
 		const {Editor} = req.app.locals.orm;
 
@@ -169,7 +169,7 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res, next) =>
 		};
 	}
 
-	handler.sendPromiseResult(res, runAsync().catch(next), search.indexEntity);
+	handler.sendPromiseResult(res, runAsync(), search.indexEntity);
 });
 
 async function getEditorTitleJSON(editorJSON, TitleUnlock) {

--- a/src/server/routes/editor.js
+++ b/src/server/routes/editor.js
@@ -134,16 +134,22 @@ router.post('/edit/handler', auth.isAuthenticatedForHandler, (req, res, next) =>
 			.catch(Editor.NotFoundError, () => {
 				throw new error.NotFoundError('Editor not found', req);
 			});
-
+		if (editor.get('areaId') === req.body.areaId &&
+			editor.get('bio') === req.body.bio &&
+			editor.get('name') === req.body.name &&
+			editor.get('titleUnlockId') === req.body.title
+		) {
+			throw new error.FormSubmissionError('No change to the profile');
+		}
 		// Modify the user to match the updates from the form
-		const titleID = _.get(req.body, 'title', null);
 		const modifiedEditor = await editor
-			.set('bio', req.body.bio)
-			.set('areaId', req.body.areaId)
-			.set('genderId', req.body.genderId)
-			.set('name', req.body.name)
-			.set('titleUnlockId', titleID)
-			.save()
+			.save({
+				areaId: req.body.areaId,
+				bio: req.body.bio,
+				genderId: req.body.genderId,
+				name: req.body.name,
+				titleUnlockId: req.body.title
+			})
 			.catch(err => {
 				if (err.constraint === 'editor_name_key') {
 					throw new error.ConflictError('Name already in use');


### PR DESCRIPTION
### Problem
https://tickets.metabrainz.org/browse/BB-544
Errors thrown are being completely swallowed by the editor profile edit form on the server and front-end, leaving the user with a spinning loader and nothing else.


### Solution
First, since we're here, a bit of cleanup and renovating, moving to using await/async and fetch and such.
Second, on the server, do some validation and return better error messages.
Finally show said error messages to the user in the profile form.

