### PR TITLE
feat(relationships): Show new entity name in relationship editor

### DIFF
--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -172,10 +172,21 @@ function getInitState(
 	const targetEntity = _.get(initRelationship, ['targetEntity']);
 
 	const baseEntityBBID = _.get(baseEntity, ['bbid']);
-
 	const sourceEntityBBID = _.get(sourceEntity, ['bbid']);
-	const otherEntity = baseEntityBBID === sourceEntityBBID ?
-		targetEntity : sourceEntity;
+
+	const [otherEntity, thisEntity] = baseEntityBBID === sourceEntityBBID ?
+		[targetEntity, sourceEntity] : [sourceEntity, targetEntity];
+
+	/* If one of the entities is being created,
+	update that new entity's name to replace "New Entity" */
+	if (typeof baseEntityBBID === 'undefined') {
+		const defaultAliasPath = ['defaultAlias', 'name'];
+		const thisEntityName = _.get(thisEntity, defaultAliasPath);
+		const baseEntityName = _.get(baseEntity, defaultAliasPath);
+		if (thisEntityName !== baseEntityName) {
+			_.set(thisEntity, defaultAliasPath, baseEntityName);
+		}
+	}
 
 	const searchFormatOtherEntity = otherEntity && {
 		id: _.get(otherEntity, ['bbid']),

--- a/src/client/entity-editor/relationship-editor/relationship-section.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-section.tsx
@@ -63,7 +63,6 @@ export function RelationshipList(
 	{contextEntity, relationships, onEdit, onRemove}: RelationshipListProps
 ) {
 	/* eslint-disable react/jsx-no-bind */
-
 	const renderedRelationships = _.map(
 		relationships,
 		({relationshipType, sourceEntity, targetEntity}, rowID) => (
@@ -155,6 +154,22 @@ function RelationshipSection({
 		disambiguation: _.get(entity, ['disambiguation', 'comment']),
 		type: _.upperFirst(entityType)
 	};
+	const relationshipsObject = relationships.toJS();
+
+	/* If one of the relationships is to a new entity (in creation),
+	update that new entity's name to replace "New Entity" */
+	if (typeof baseEntity.bbid === 'undefined') {
+		_.forEach(relationshipsObject, relationship => {
+			const {sourceEntity, targetEntity} = relationship;
+			const defaultAliasPath = ['defaultAlias', 'name'];
+			const newEntity = [sourceEntity, targetEntity].find(({bbid}) => bbid === baseEntity.bbid);
+			const newRelationshipName = newEntity && _.get(newEntity, defaultAliasPath);
+			const baseEntityName = _.get(baseEntity, defaultAliasPath);
+			if (newRelationshipName !== baseEntityName) {
+				_.set(newEntity, defaultAliasPath, baseEntityName);
+			}
+		});
+	}
 
 	const languageOptionsForDisplay = languageOptions.map((language) => ({
 		label: language.name,
@@ -183,7 +198,7 @@ function RelationshipSection({
 				<Col sm={12}>
 					<RelationshipList
 						contextEntity={baseEntity}
-						relationships={relationships.toJS()}
+						relationships={relationshipsObject}
 						onEdit={canEdit ? onEdit : null}
 						onRemove={canEdit ? onRemove : null}
 					/>


### PR DESCRIPTION
In the relationship section and relationship editor (in entity editor), show the new entity's current name instead of "New Entity":

![Capture d’écran 2021-01-14 à 19 21 34](https://user-images.githubusercontent.com/6179856/104632641-4eb15c80-569e-11eb-9841-d6e39cacebfc.png)


![Capture d’écran 2021-01-14 à 19 21 49](https://user-images.githubusercontent.com/6179856/104632645-507b2000-569e-11eb-963e-e4e0f0aefca5.png)



### Areas of Impact
- src/client/entity-editor/relationship-editor/relationship-editor.js
- src/client/entity-editor/relationship-editor/relationship-section.js