### PR TITLE
fix(display): url discrepancy in entities and entity-editor name-section

### DIFF
--- a/src/client/components/pages/entities/work-table.js
+++ b/src/client/components/pages/entities/work-table.js
@@ -54,7 +54,7 @@ function WorkTableRow({showAddedAtColumn, work, showCheckboxes, selectedEntities
 							onClick={() => onToggleRow(work.bbid)}
 						/> : null
 				}
-				<a href={`/Work/${work.bbid}`}>{name}</a>
+				<a href={`/work/${work.bbid}`}>{name}</a>
 				{disambiguation}
 			</td>
 			<td>{languages}</td>

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -187,7 +187,7 @@ class NameSection extends React.Component {
 											(
 												<ListGroupItem
 													bsStyle="warning"
-													href={`/${entityType}/${match.bbid}`}
+													href={`/${_kebabCase(entityType)}/${match.bbid}`}
 													key={`${match.bbid}`}
 													rel="noopener noreferrer" target="_blank"
 												>

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -187,7 +187,7 @@ class NameSection extends React.Component {
 											(
 												<ListGroupItem
 													bsStyle="warning"
-													href={`/${_kebabCase(entityType)}/${match.bbid}`}
+													href={`/${_.kebabCase(entityType)}/${match.bbid}`}
 													key={`${match.bbid}`}
 													rel="noopener noreferrer" target="_blank"
 												>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Fixed the url discrepancy in entities (earlier it used to appear as 'W+ork' instead of 'work' in url).
Also there was a possible discrepancy in name-section url where kebab-casing was missing 


### Solution
<!-- What does this PR do to fix the problem? -->
A pretty straight-forward fix for the first case and a lodash kebabCasing in the second case


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
