### PR TITLE
fix(collection-form):Position of "Add another collaborator" button

### DIFF
--- a/src/client/components/forms/userCollection.js
+++ b/src/client/components/forms/userCollection.js
@@ -230,12 +230,12 @@ class UserCollectionForm extends React.Component {
 							/>
 							<h3><b>Collaborators</b></h3>
 							<div className="row margin-bottom-2">
-							<div className="col-sm-6 margin-top-d5">
-							<p className="help-block">
+								<div className="col-sm-6 margin-top-d5">
+									<p className="help-block">
 								Collaborators can add/remove entities from your collection
-							</p>
-							</div>
-							<div className="col-sm-6 margin-top-d5">
+									</p>
+								</div>
+								<div className="col-sm-6 margin-top-d5">
 									<Button
 										block
 										bsStyle="primary"

--- a/src/client/components/forms/userCollection.js
+++ b/src/client/components/forms/userCollection.js
@@ -229,9 +229,24 @@ class UserCollectionForm extends React.Component {
 								ref={(ref) => this.privacy = ref}
 							/>
 							<h3><b>Collaborators</b></h3>
+							<div className="row margin-bottom-2">
+							<div className="col-sm-6 margin-top-d5">
 							<p className="help-block">
 								Collaborators can add/remove entities from your collection
 							</p>
+							</div>
+							<div className="col-sm-6 margin-top-d5">
+									<Button
+										block
+										bsStyle="primary"
+										type="button"
+										onClick={this.handleAddCollaborator}
+									>
+										<FontAwesomeIcon icon={faPlus}/>
+										&nbsp;Add another collaborator
+									</Button>
+								</div>
+							</div>
 							{
 								this.state.collaborators.map((collaborator, index) => {
 									const buttonAfter = (
@@ -264,17 +279,6 @@ class UserCollectionForm extends React.Component {
 								<Alert bsStyle="danger">Error: {errorText}</Alert>
 							</div>
 							<div className="row margin-bottom-2">
-								<div className="col-sm-6 margin-top-d5">
-									<Button
-										block
-										bsStyle="primary"
-										type="button"
-										onClick={this.handleAddCollaborator}
-									>
-										<FontAwesomeIcon icon={faPlus}/>
-										&nbsp;Add another collaborator
-									</Button>
-								</div>
 								<div className="col-sm-6 margin-top-d5">
 									<Button
 										block


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Position of "Add another collaborator" button is not intutive.

### Solution
<!-- What does this PR do to fix the problem? -->
Instead of displaying the button at the bottom, I have moved it next to the Collaborator's heading as suggested.


![ss done](https://user-images.githubusercontent.com/56965261/107275195-6f8b8880-6a77-11eb-9c20-1589110547ed.png)

