### PR TITLE
feat(AC): Add author_credit_id column to Edition Group schema

### DIFF
--- a/sql/migrations/2021-author-credits/down.sql
+++ b/sql/migrations/2021-author-credits/down.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+DROP VIEW bookbrainz.edition_group;
+
+CREATE VIEW bookbrainz.edition_group AS
+	SELECT
+		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, pcd.disambiguation_id,
+		als.default_alias_id, pcd.type_id, pcd.alias_set_id, pcd.identifier_set_id,
+		pcd.relationship_set_id, e.type
+	FROM bookbrainz.edition_group_revision pcr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
+	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
+	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	WHERE e.type = 'EditionGroup';
+
+
+ALTER TABLE bookbrainz.edition_group_data DROP CONSTRAINT author_credit_author_credit_id_fkey;
+ALTER TABLE bookbrainz.edition_group_data DROP COLUMN author_credit_id;
+
+COMMIT;

--- a/sql/migrations/2021-author-credits/up.sql
+++ b/sql/migrations/2021-author-credits/up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+ALTER TABLE bookbrainz.edition_group_data ADD COLUMN author_credit_id INT;
+ALTER TABLE bookbrainz.edition_group_data ADD FOREIGN KEY (author_credit_id) REFERENCES bookbrainz.author_credit (id);
+
+CREATE OR REPLACE VIEW bookbrainz.edition_group AS
+	SELECT
+		e.bbid, pcd.id AS data_id, pcr.id AS revision_id, (pcr.id = pc.master_revision_id) AS master, pcd.annotation_id, pcd.disambiguation_id,
+		als.default_alias_id, pcd.type_id, pcd.alias_set_id, pcd.identifier_set_id,
+		pcd.relationship_set_id, e.type, pcd.author_credit_id
+	FROM bookbrainz.edition_group_revision pcr
+	LEFT JOIN bookbrainz.entity e ON e.bbid = pcr.bbid
+	LEFT JOIN bookbrainz.edition_group_header pc ON pc.bbid = e.bbid
+	LEFT JOIN bookbrainz.edition_group_data pcd ON pcr.data_id = pcd.id
+	LEFT JOIN bookbrainz.alias_set als ON pcd.alias_set_id = als.id
+	WHERE e.type = 'EditionGroup';
+
+COMMIT;

--- a/sql/scripts/create_triggers.sql
+++ b/sql/scripts/create_triggers.sql
@@ -181,10 +181,10 @@ CREATE OR REPLACE FUNCTION bookbrainz.process_edition_group() RETURNS TRIGGER
 		IF (TG_OP <> 'DELETE') THEN
 			INSERT INTO bookbrainz.edition_group_data(
 				alias_set_id, identifier_set_id, relationship_set_id, annotation_id,
-				disambiguation_id, type_id
+				disambiguation_id, type_id, author_credit_id
 			) VALUES (
 				NEW.alias_set_id, NEW.identifier_set_id, NEW.relationship_set_id,
-				NEW.annotation_id, NEW.disambiguation_id, NEW.type_id
+				NEW.annotation_id, NEW.disambiguation_id, NEW.type_id, NEW.author_credit_id
 			) RETURNING bookbrainz.edition_group_data.id INTO edition_group_data_id;
 
 			INSERT INTO bookbrainz.edition_group_revision VALUES(NEW.revision_id, NEW.bbid, edition_group_data_id);


### PR DESCRIPTION
As it says on the tin, this PR adds an `author_credit_id` column to the database schema definition and trigger for Edition Groups, allowing us to link an Author Credit to an Edition Group as we do for Editions.