### PR TITLE
Add a scrollbar in the 'add to collection' modal

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -544,6 +544,8 @@ hr.wide {
 .addToCollectionModal-body {
 	margin-right: 1em;
 	margin-left: 1em;
+	height: 18em;
+	overflow-y:scroll;
 }
 
 .checkboxes {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
1. Verify that your changes match our coding style
1. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
https://tickets.metabrainz.org/projects/BB/issues/BB-582?filter=allopenissues

### Solution
<!-- What does this PR do to fix the problem? -->
Add a scrollbar to prevent the content from overflowing and to give a better user experience. 
Here are the Screenshots,

Before,
![Screenshot (246)](https://user-images.githubusercontent.com/68822438/109426691-eaabe300-7a14-11eb-9924-53366474c4a2.png)

After,
![Screenshot (245)](https://user-images.githubusercontent.com/68822438/109426709-02836700-7a15-11eb-8cfd-a3d511c8de34.png)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/client/stylesheets/style.less