### PR TITLE
Previous and next page buttons now have have responsive design in collections

### DIFF
--- a/src/client/components/pages/parts/pager.js
+++ b/src/client/components/pages/parts/pager.js
@@ -143,6 +143,12 @@ class PagerElement extends React.Component {
 								>
 									&larr; Previous Page
 								</Pager.Item>
+								<Pager.Item
+									next disabled={!this.state.nextEnabled}
+									href="#" onClick={this.handleClickNext}
+								>
+									Next Page &rarr;
+								</Pager.Item>
 								<ButtonGroup>
 									<Button disabled>Results {this.state.from + 1} —
 										{this.state.results.length < this.state.size ?
@@ -162,12 +168,6 @@ class PagerElement extends React.Component {
 										<MenuItem eventKey="100">100 per page</MenuItem>
 									</DropdownButton>
 								</ButtonGroup>
-								<Pager.Item
-									next disabled={!this.state.nextEnabled}
-									href="#" onClick={this.handleClickNext}
-								>
-									Next Page &rarr;
-								</Pager.Item>
 							</Pager>
 
 						</div> :

--- a/src/client/entity-editor/common/sort-name-field.tsx
+++ b/src/client/entity-editor/common/sort-name-field.tsx
@@ -166,7 +166,7 @@ function SortNameField({
 			label={label}
 			ref={(node) => { input = node; }}
 			tooltipText="Alphabetical sorting name. Examples: 'Dickens, Charles', 'Christmas Carol, A'.
-			<br>You can try to fill it automatically with the guess button"
+			You can try to fill it automatically with the guess button"
 			type="text"
 			onChange={onChange}
 			{...rest}

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -414,6 +414,10 @@ hr.wide {
 	}
 }
 
+.next, .previous > a {
+	margin-bottom: 5%;
+}
+
 @media only screen and (max-width: 600px) {
 	#searchpage-button-group > * {
 		width: 100%;


### PR DESCRIPTION
### Problem
https://tickets.metabrainz.org/browse/BB-579

### Solution
By changing the order in which the buttons are rendered, whenever the screen gets smaller, now the next and previous buttons are aligned and also added some margin in the bottom so that way there is some space between the lower level buttons and the top ones.

Before
![BB](https://user-images.githubusercontent.com/67782664/110830051-18a4e900-8299-11eb-9875-b7486aef2a91.png)
 After
![BBetter (1)](https://user-images.githubusercontent.com/67782664/110830067-1e023380-8299-11eb-8275-33c9a70c7a85.png)

### Areas of Impact
Only ascetic ones in the collections component.