### PR TITLE
FIX(BB-565): Removed extraneous quotation marks from revision notes

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -435,13 +435,6 @@ hr.wide {
 		padding-bottom: 0.3em;
 	}
 	.note-content {
-		quotes: "\201C" "\201D";
-		&::before {
-			content: open-quote;
-		}
-		&::after {
-			content: close-quote;
-		}
 		white-space: pre-wrap;
 	}
 	.note-author {


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR Fixes: [BB-565](https://tickets.metabrainz.org/browse/BB-565)


### Solution
<!-- What does this PR do to fix the problem? -->

**Removed the css rule that was adding the quotes**

### Before 
<img width="936" alt="Screenshot 2021-03-14 124949" src="https://user-images.githubusercontent.com/55311336/111060637-6487a600-84c4-11eb-9ee9-220efff7fe01.png">

### After

<img width="944" alt="Screenshot 2021-03-14 124900" src="https://user-images.githubusercontent.com/55311336/111060644-6d787780-84c4-11eb-80ea-1aa12503c21c.png">

### Areas of Impact

**Stylesheet**
