### PR TITLE
feat(Collections): added a 'No.of Entities' column to Collections table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4261,7 +4261,7 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "resolved": "",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
     },
     "argparse": {
@@ -4871,19 +4871,19 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bookbrainz-data": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/bookbrainz-data/-/bookbrainz-data-2.8.0.tgz",
-      "integrity": "sha512-FI3PThJQGqz5tvZ6lmDo0FRG1vZS8mH4phe2lsOMB1d1R6LeeehScdr0oPTTWCxNpUE4jRnlbAOAcdRqQgYLoQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/bookbrainz-data/-/bookbrainz-data-2.9.0.tgz",
+      "integrity": "sha512-tCZzcLiyIQwHsDd3ORpAjvQozJLhZ9Aq0mNLMramH9sc8kNrxhb+0AjUmD7Z56LUpyCd/XpOLeq9kEz6EuIVXA==",
       "requires": {
         "bluebird": "^3.7.2",
         "bookshelf": "^1.2.0",
         "bookshelf-virtuals-plugin": "^0.1.1",
         "deep-diff": "^1.0.2",
         "immutable": "^3.8.2",
-        "knex": "^0.21.9",
-        "lodash": "^4.17.20",
+        "knex": "^0.21.12",
+        "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "pg": "^8.5.0"
+        "pg": "^8.5.1"
       }
     },
     "bookshelf": {
@@ -9008,8 +9008,7 @@
     "interpret": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
-      "dev": true
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
     },
     "into-stream": {
       "version": "5.1.1",
@@ -9564,41 +9563,36 @@
       "dev": true
     },
     "knex": {
-      "version": "0.21.12",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.12.tgz",
-      "integrity": "sha512-AEyyiTM9p/x/Pb38TPZkvphKPmn8UWxP7MdIphzjAOielOfFFeU6pjP6y3M7UJ7rxrQsCrAYHwdonLQ3l1JCDw==",
+      "version": "0.21.19",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.19.tgz",
+      "integrity": "sha512-6etvrq9XI1Ck6mEc/XiXFGVpD1Lmj6v9XWojqZgEbOvyMbW7XRvgZ99yIhN/kaBH+43FEy3xv/AcbRaH+1pJtw==",
       "requires": {
         "colorette": "1.2.1",
-        "commander": "^5.1.0",
-        "debug": "4.1.1",
+        "commander": "^6.2.0",
+        "debug": "4.3.1",
         "esm": "^3.2.25",
         "getopts": "2.2.5",
         "interpret": "^2.2.0",
         "liftoff": "3.1.0",
         "lodash": "^4.17.20",
-        "pg-connection-string": "2.3.0",
+        "pg-connection-string": "2.4.0",
         "tarn": "^3.0.1",
         "tildify": "2.0.0",
         "v8flags": "^3.2.0"
       },
       "dependencies": {
         "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
-        },
-        "interpret": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-          "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
         },
         "ms": {
           "version": "2.1.2",
@@ -11937,30 +11931,30 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
-      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.4.0",
-        "pg-pool": "^3.2.2",
-        "pg-protocol": "^1.4.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
       "dependencies": {
         "pg-connection-string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
-          "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
         }
       }
     },
     "pg-connection-string": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz",
-      "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -11968,14 +11962,14 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-pool": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
-      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg=="
     },
     "pg-protocol": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
-      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "bookbrainz-data": "^2.8.0",
+    "bookbrainz-data": "^2.9.0",
     "chart.js": "^2.9.4",
     "chartjs-adapter-date-fns": "^1.0.0",
     "classnames": "^2.2.5",

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -64,7 +64,7 @@ class CollectionsTable extends React.Component {
 						{_.startCase(entityType)}
 					</MenuItem>
 				))}
-				<MenuItem divider />
+				<MenuItem divider/>
 				<MenuItem
 					eventKey={null}
 					key="allTypes"
@@ -79,7 +79,7 @@ class CollectionsTable extends React.Component {
 				href="/collection/create"
 				type="button"
 			>
-				<FontAwesomeIcon icon={faPlus} />
+				<FontAwesomeIcon icon={faPlus}/>
 				&nbsp;Create Collection
 			</Button>
 		);
@@ -94,7 +94,7 @@ class CollectionsTable extends React.Component {
 						{entityTypeSelect}
 					</div>
 				</div>
-				<hr className="thin" />
+				<hr className="thin"/>
 				{
 					results.length > 0 ?
 						<Table
@@ -166,7 +166,7 @@ class CollectionsTable extends React.Component {
 
 						<div>
 							<h4> No collections to show</h4>
-							<hr className="wide" />
+							<hr className="wide"/>
 						</div>
 				}
 			</div>

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -18,16 +18,16 @@
 
 import * as bootstrap from 'react-bootstrap';
 import * as utilsHelper from '../../../helpers/utils';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import {faPlus} from '@fortawesome/free-solid-svg-icons';
-import {genEntityIconHTMLElement} from '../../../helpers/entity';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { genEntityIconHTMLElement } from '../../../helpers/entity';
 
 
-const {Button, DropdownButton, MenuItem, Table} = bootstrap;
-const {formatDate} = utilsHelper;
+const { Button, DropdownButton, MenuItem, Table } = bootstrap;
+const { formatDate } = utilsHelper;
 
 
 class CollectionsTable extends React.Component {
@@ -42,12 +42,12 @@ class CollectionsTable extends React.Component {
 	}
 
 	handleEntitySelect(type) {
-		this.setState({type});
+		this.setState({ type });
 		this.props.onTypeChange(type);
 	}
 
 	render() {
-		const {showLastModified, showOwner, showIfOwnerOrCollaborator, showPrivacy, results, tableHeading} = this.props;
+		const { showLastModified, showOwner, showIfOwnerOrCollaborator, showPrivacy, results, tableHeading } = this.props;
 		const entityTypeSelect = (
 			<DropdownButton
 				bsStyle="primary"
@@ -64,7 +64,7 @@ class CollectionsTable extends React.Component {
 						{_.startCase(entityType)}
 					</MenuItem>
 				))}
-				<MenuItem divider/>
+				<MenuItem divider />
 				<MenuItem
 					eventKey={null}
 					key="allTypes"
@@ -79,7 +79,7 @@ class CollectionsTable extends React.Component {
 				href="/collection/create"
 				type="button"
 			>
-				<FontAwesomeIcon icon={faPlus}/>
+				<FontAwesomeIcon icon={faPlus} />
 				&nbsp;Create Collection
 			</Button>
 		);
@@ -94,7 +94,7 @@ class CollectionsTable extends React.Component {
 						{entityTypeSelect}
 					</div>
 				</div>
-				<hr className="thin"/>
+				<hr className="thin" />
 				{
 					results.length > 0 ?
 						<Table
@@ -106,6 +106,7 @@ class CollectionsTable extends React.Component {
 									<th className="col-sm-2">Name</th>
 									<th className="col-sm-4">Description</th>
 									<th className="col-sm-2">Entity Type</th>
+									<th className="col-sm-2">No. of Entities</th>
 									{
 										showPrivacy ?
 											<th className="col-sm-2">Privacy</th> : null
@@ -139,6 +140,7 @@ class CollectionsTable extends React.Component {
 											</td>
 											<td>{collection.description}</td>
 											<td>{collection.entityType}</td>
+											<td>{collection.noOfEntities}</td>
 											{
 												showPrivacy ?
 													<td>{collection.public ? 'Public' : 'Private'}</td> : null
@@ -164,7 +166,7 @@ class CollectionsTable extends React.Component {
 
 						<div>
 							<h4> No collections to show</h4>
-							<hr className="wide"/>
+							<hr className="wide" />
 						</div>
 				}
 			</div>

--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -64,7 +64,7 @@ class CollectionsTable extends React.Component {
 						{_.startCase(entityType)}
 					</MenuItem>
 				))}
-				<MenuItem divider/>
+				<MenuItem divider />
 				<MenuItem
 					eventKey={null}
 					key="allTypes"
@@ -79,7 +79,7 @@ class CollectionsTable extends React.Component {
 				href="/collection/create"
 				type="button"
 			>
-				<FontAwesomeIcon icon={faPlus}/>
+				<FontAwesomeIcon icon={faPlus} />
 				&nbsp;Create Collection
 			</Button>
 		);
@@ -94,7 +94,7 @@ class CollectionsTable extends React.Component {
 						{entityTypeSelect}
 					</div>
 				</div>
-				<hr className="thin"/>
+				<hr className="thin" />
 				{
 					results.length > 0 ?
 						<Table
@@ -106,7 +106,7 @@ class CollectionsTable extends React.Component {
 									<th className="col-sm-2">Name</th>
 									<th className="col-sm-4">Description</th>
 									<th className="col-sm-2">Entity Type</th>
-									<th className="col-sm-2">No. of Entities</th>
+									<th className="col-sm-2">Entities</th>
 									{
 										showPrivacy ?
 											<th className="col-sm-2">Privacy</th> : null
@@ -140,7 +140,7 @@ class CollectionsTable extends React.Component {
 											</td>
 											<td>{collection.description}</td>
 											<td>{collection.entityType}</td>
-											<td>{collection.noOfEntities}</td>
+											<td>{collection.itemCount}</td>
 											{
 												showPrivacy ?
 													<td>{collection.public ? 'Public' : 'Private'}</td> : null
@@ -166,7 +166,7 @@ class CollectionsTable extends React.Component {
 
 						<div>
 							<h4> No collections to show</h4>
-							<hr className="wide"/>
+							<hr className="wide" />
 						</div>
 				}
 			</div>

--- a/src/client/input.tsx
+++ b/src/client/input.tsx
@@ -209,11 +209,7 @@ export default class Input extends React.Component<Props> {
 		const helpIconElement = tooltipText && (
 			<OverlayTrigger
 				delayShow={50}
-				overlay={<Tooltip id={`tooltip-${id}`}><div
-				dangerouslySetInnerHTML={{
-					__html: tooltipText,
-				}}
-			></div></Tooltip>}
+				overlay={<Tooltip id={`tooltip-${id}`}>{tooltipText}</Tooltip>}
 			>
 				<FontAwesomeIcon
 					className="margin-left-0-5"

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -86,7 +86,7 @@ export async function getCollectionSize(collectionId, orm) {
 	const { UserCollectionItem } = orm;
 
 	const result = await UserCollectionItem.where('collection_id', collectionId).count()
-	return parseInt(result)
+	return Number(result)
 }
 
 

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -104,7 +104,7 @@ export async function getOrderedPublicCollections(from, size, entityType, orm) {
 		});
 
 	const collectionsJSON = allCollections ? allCollections.toJSON() : [];
-	
+
 	return collectionsJSON;
 }
 

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -75,6 +75,21 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
 	return collectionsJSON;
 }
 
+
+/**
+ * Fetches no of entities in the collection
+ * @param {uuid} collectionId - collectionId
+ * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @returns {number} - returns the no. of entities in this collection
+ */
+export async function getCollectionSize(collectionId, orm) {
+	const { UserCollectionItem } = orm;
+
+	const result = await UserCollectionItem.where('collection_id', collectionId).count()
+	return parseInt(result)
+}
+
+
 /**
  * Fetches public collections for Show All Collections/Index Page
  * Fetches the last 'size' number of collections with offset 'from'
@@ -136,17 +151,4 @@ export async function getCollectionItems(collectionId, from, size, orm) {
 						LIMIT ${size}
 						OFFSET ${from}`);
 	return result.rows;
-}
-
-/**
- * Fetches no of entities in the collection
- * @param {uuid} collectionId - collectionId
- * @param {object} orm - the BookBrainz ORM, initialized during app setup
- * @returns {array} - returns the no. of entities in this collection
- */
-export async function getCollectionSize(collectionId, orm) {
-	const { UserCollectionItem } = orm;
-
-	const result = await UserCollectionItem.where('collection_id', collectionId).count()
-	return parseInt(result)
 }

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -76,8 +76,6 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
 }
 
 
-
-
 /**
  * Fetches public collections for Show All Collections/Index Page
  * Fetches the last 'size' number of collections with offset 'from'

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -33,9 +33,9 @@ import * as error from '../../common/helpers/error';
  * If the user is not the editor, then only "Public' collections are returned
  */
 export async function getOrderedCollectionsForEditorPage(from, size, entityType, req) {
-	const {Editor, UserCollection} = req.app.locals.orm;
+	const { Editor, UserCollection } = req.app.locals.orm;
 	// If editor isn't present, throw an error
-	await new Editor({id: req.params.id})
+	await new Editor({ id: req.params.id })
 		.fetch()
 		.catch(Editor.NotFoundError, () => {
 			throw new error.NotFoundError('Editor not found', req);
@@ -86,7 +86,7 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
  * @returns {array} - orderedCollections
  */
 export async function getOrderedPublicCollections(from, size, entityType, orm) {
-	const {UserCollection} = orm;
+	const { UserCollection } = orm;
 
 	const allCollections = await new UserCollection()
 		.where((builder) => {
@@ -103,6 +103,16 @@ export async function getOrderedPublicCollections(from, size, entityType, orm) {
 		});
 
 	const collectionsJSON = allCollections ? allCollections.toJSON() : [];
+
+	// We need to add the no. of entities in each collection
+	collectionsJSON.forEach((collection) => {
+		collection['noOfEntities'] = getCollectionSize(collection.id, orm)
+	})
+	// Resolving the promises
+	await Promise.all(collectionsJSON.map(async collection => {
+		const resolvedValue = await collection.noOfEntities
+		collection['noOfEntities'] = resolvedValue;
+	}))
 
 	return collectionsJSON;
 }
@@ -126,4 +136,17 @@ export async function getCollectionItems(collectionId, from, size, orm) {
 						LIMIT ${size}
 						OFFSET ${from}`);
 	return result.rows;
+}
+
+/**
+ * Fetches no of entities in the collection
+ * @param {uuid} collectionId - collectionId
+ * @param {object} orm - the BookBrainz ORM, initialized during app setup
+ * @returns {array} - returns the no. of entities in this collection
+ */
+export async function getCollectionSize(collectionId, orm) {
+	const { UserCollectionItem } = orm;
+
+	const result = await UserCollectionItem.where('collection_id', collectionId).count()
+	return parseInt(result)
 }

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -75,7 +75,6 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
 	return collectionsJSON;
 }
 
-
 /**
  * Fetches public collections for Show All Collections/Index Page
  * Fetches the last 'size' number of collections with offset 'from'
@@ -105,6 +104,7 @@ export async function getOrderedPublicCollections(from, size, entityType, orm) {
 		});
 
 	const collectionsJSON = allCollections ? allCollections.toJSON() : [];
+	
 	return collectionsJSON;
 }
 

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -76,18 +76,6 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
 }
 
 
-/**
- * Fetches no of entities in the collection
- * @param {uuid} collectionId - collectionId
- * @param {object} orm - the BookBrainz ORM, initialized during app setup
- * @returns {number} - returns the no. of entities in this collection
- */
-export async function getCollectionSize(collectionId, orm) {
-	const {UserCollectionItem} = orm;
-
-	const result = await UserCollectionItem.where('collection_id', collectionId).count();
-	return Number(result);
-}
 
 
 /**
@@ -114,21 +102,11 @@ export async function getOrderedPublicCollections(from, size, entityType, orm) {
 		.fetchPage({
 			limit: size,
 			offset: from,
+			withItemCount: true,
 			withRelated: ['owner']
 		});
 
 	const collectionsJSON = allCollections ? allCollections.toJSON() : [];
-
-	// We need to add the no. of entities in each collection
-	collectionsJSON.forEach((collection) => {
-		collection.noOfEntities = getCollectionSize(collection.id, orm);
-	});
-	// Resolving the promises
-	await Promise.all(collectionsJSON.map(async collection => {
-		const resolvedValue = await collection.noOfEntities;
-		collection.noOfEntities = resolvedValue;
-	}));
-
 	return collectionsJSON;
 }
 

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -33,9 +33,9 @@ import * as error from '../../common/helpers/error';
  * If the user is not the editor, then only "Public' collections are returned
  */
 export async function getOrderedCollectionsForEditorPage(from, size, entityType, req) {
-	const { Editor, UserCollection } = req.app.locals.orm;
+	const {Editor, UserCollection} = req.app.locals.orm;
 	// If editor isn't present, throw an error
-	await new Editor({ id: req.params.id })
+	await new Editor({id: req.params.id})
 		.fetch()
 		.catch(Editor.NotFoundError, () => {
 			throw new error.NotFoundError('Editor not found', req);
@@ -83,10 +83,10 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
  * @returns {number} - returns the no. of entities in this collection
  */
 export async function getCollectionSize(collectionId, orm) {
-	const { UserCollectionItem } = orm;
+	const {UserCollectionItem} = orm;
 
-	const result = await UserCollectionItem.where('collection_id', collectionId).count()
-	return Number(result)
+	const result = await UserCollectionItem.where('collection_id', collectionId).count();
+	return Number(result);
 }
 
 
@@ -101,7 +101,7 @@ export async function getCollectionSize(collectionId, orm) {
  * @returns {array} - orderedCollections
  */
 export async function getOrderedPublicCollections(from, size, entityType, orm) {
-	const { UserCollection } = orm;
+	const {UserCollection} = orm;
 
 	const allCollections = await new UserCollection()
 		.where((builder) => {

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -63,6 +63,7 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
 		.orderBy('created_at')
 		.fetchPage({
 			limit: size,
+			withItemCount: true,
 			offset: from
 		});
 

--- a/src/server/helpers/collections.js
+++ b/src/server/helpers/collections.js
@@ -63,8 +63,8 @@ export async function getOrderedCollectionsForEditorPage(from, size, entityType,
 		.orderBy('created_at')
 		.fetchPage({
 			limit: size,
-			withItemCount: true,
-			offset: from
+			offset: from,
+			withItemCount: true
 		});
 
 	const collectionsJSON = allCollections ? allCollections.toJSON() : [];

--- a/test/src/server/helpers/collections.js
+++ b/test/src/server/helpers/collections.js
@@ -25,16 +25,16 @@ import {
 } from '../../../../src/server/helpers/collections';
 import assertArrays from 'chai-arrays';
 import chai from 'chai';
-import {date} from 'faker';
+import { date } from 'faker';
 import isSorted from 'chai-sorted';
 import orm from '../../../bookbrainz-data';
 
 
-const {expect} = chai;
+const { expect } = chai;
 chai.use(isSorted);
 chai.use(assertArrays);
 
-const {UserCollection, UserCollectionCollaborator} = orm;
+const { UserCollection, UserCollectionCollaborator } = orm;
 
 
 describe('getOrderedPublicCollections', () => {
@@ -53,19 +53,19 @@ describe('getOrderedPublicCollections', () => {
 			collectionAttrib.lastModified = date.recent();
 			collectionAttrib.createdAt = date.recent();
 			promiseArray.push(
-				new UserCollection(collectionAttrib).save(null, {method: 'insert'})
+				new UserCollection(collectionAttrib).save(null, { method: 'insert' })
 			);
 		}
 		// create 1 private author collection
 		collectionAttrib.public = false;
 		promiseArray.push(
-			new UserCollection(collectionAttrib).save(null, {method: 'insert'})
+			new UserCollection(collectionAttrib).save(null, { method: 'insert' })
 		);
 		// create 1 public Edition collection
 		collectionAttrib.public = true;
 		collectionAttrib.entityType = 'Edition';
 		promiseArray.push(
-			new UserCollection(collectionAttrib).save(null, {method: 'insert'})
+			new UserCollection(collectionAttrib).save(null, { method: 'insert' })
 		);
 		await Promise.all(promiseArray);
 	});
@@ -83,7 +83,8 @@ describe('getOrderedPublicCollections', () => {
 				'public',
 				'createdAt',
 				'lastModified',
-				'owner'
+				'owner',
+				'noOfEntities'
 			);
 		});
 		expect(orderedCollections.length).to.equal(6);
@@ -102,7 +103,8 @@ describe('getOrderedPublicCollections', () => {
 				'public',
 				'createdAt',
 				'lastModified',
-				'owner'
+				'owner',
+				'noOfEntities'
 			);
 			expect(collection.entityType).to.equal('Author');
 		});
@@ -139,34 +141,34 @@ describe('getOrderedCollectionsForEditorPage', () => {
 		};
 
 		// create a public collections owned by editor1
-		const collection = await new UserCollection(collectionAttrib).save(null, {method: 'insert'});
+		const collection = await new UserCollection(collectionAttrib).save(null, { method: 'insert' });
 		collectionID = collection.get('id');
 
 		// create a public collections owned by editor1 and editor2 as collaborator
-		const collection2 = await new UserCollection(collectionAttrib).save(null, {method: 'insert'});
+		const collection2 = await new UserCollection(collectionAttrib).save(null, { method: 'insert' });
 		collectionID2 = collection2.get('id');
 		await new UserCollectionCollaborator({
 			collaboratorId: editor2.get('id'),
 			collectionId: collectionID2
-		}).save(null, {method: 'insert'});
+		}).save(null, { method: 'insert' });
 
 		// create a private collection owned by editor1
 		collectionAttrib.public = false;
-		const collection3 = await new UserCollection(collectionAttrib).save(null, {method: 'insert'});
+		const collection3 = await new UserCollection(collectionAttrib).save(null, { method: 'insert' });
 		collectionID3 = collection3.get('id');
 
 		// create a private collection owned by editor1 and editor2 as collaborator
-		const collection4 = await new UserCollection(collectionAttrib).save(null, {method: 'insert'});
+		const collection4 = await new UserCollection(collectionAttrib).save(null, { method: 'insert' });
 		collectionID4 = collection4.get('id');
 		await new UserCollectionCollaborator({
 			collaboratorId: editor2.get('id'),
 			collectionId: collectionID4
-		}).save(null, {method: 'insert'});
+		}).save(null, { method: 'insert' });
 
 		// create one Edition collection with editor1 as owner
 		collectionAttrib.public = true;
 		collectionAttrib.entityType = 'Edition';
-		const collection5 = await new UserCollection(collectionAttrib).save(null, {method: 'insert'});
+		const collection5 = await new UserCollection(collectionAttrib).save(null, { method: 'insert' });
 		collectionID5 = collection5.get('id');
 	});
 	after(truncateEntities);

--- a/test/src/server/helpers/collections.js
+++ b/test/src/server/helpers/collections.js
@@ -84,7 +84,7 @@ describe('getOrderedPublicCollections', () => {
 				'createdAt',
 				'lastModified',
 				'owner',
-				'noOfEntities'
+				'itemCount'
 			);
 		});
 		expect(orderedCollections.length).to.equal(6);
@@ -104,7 +104,7 @@ describe('getOrderedPublicCollections', () => {
 				'createdAt',
 				'lastModified',
 				'owner',
-				'noOfEntities'
+				'itemCount'
 			);
 			expect(collection.entityType).to.equal('Author');
 		});

--- a/test/src/server/helpers/collections.js
+++ b/test/src/server/helpers/collections.js
@@ -200,7 +200,8 @@ describe('getOrderedCollectionsForEditorPage', () => {
 				'public',
 				'createdAt',
 				'lastModified',
-				'isOwner'
+				'isOwner',
+				'itemCount'
 			);
 		});
 	});


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
https://tickets.metabrainz.org/browse/BB-580
Adding a column which displays No. of entities in a collection 


### Solution
<!-- What does this PR do to fix the problem? -->
I have created a helper function getCollectionSize() which returns the count of UserCollectionItems in each collection. I then used this function to add a property named 'noOfEntities' to each item in the collectionsJSON array which was returned from getOrderedPublicCollections()


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Now the function getOrderedPublicCollections() will return an additional property with each collection object : noOfEntities




![CollectionsTableNew](https://user-images.githubusercontent.com/56965261/111068634-96fac880-84ef-11eb-892b-15a36f7c153e.png)


