### PR TITLE
[DOCS] Fixed invalid link in NODEJS_SETUP.md

### DIFF
--- a/NODEJS_SETUP.md
+++ b/NODEJS_SETUP.md
@@ -3,7 +3,7 @@
 ### These instruction are only valid for specific cases when you do not want to use Docker (`./develop.sh`) to run the server on your machine.
 
 If for some reason you do not want to use our standard development environment (Docker), you can run the server code manually (
-regardless of whether you are running dependencies (database, search,…) with Docker or you [are running them manually](./MANUAL_INSTALL.md))
+regardless of whether you are running dependencies (database, search,…) with Docker or you [are running them manually](./DEPENDENCIES_MANUAL_INSTALL.md))
 
 ## Installing NodeJS
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
The link associated with the keyword `are running them manually` seems to be broken and resulting in 404 error page

<img width="941" alt="Screenshot 2021-03-15 100529" src="https://user-images.githubusercontent.com/55311336/111104171-0adfb400-8576-11eb-98d9-e969ceef6588.png">

### Solution
<!-- What does this PR do to fix the problem? -->
Updated [NODEJS_SETUP.md](https://github.com/bookbrainz/bookbrainz-site/blob/master/NODEJS_SETUP.md) with the correct link.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
[NODEJS_SETUP.md](https://github.com/bookbrainz/bookbrainz-site/blob/master/NODEJS_SETUP.md) 