### PR TITLE
FIX(BB-591): Added margin to buttons on collections page 

### DIFF
--- a/src/client/components/pages/collection.js
+++ b/src/client/components/pages/collection.js
@@ -270,6 +270,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="success"
+								className="margin-bottom-d5"
 								title={`Add ${this.props.collection.entityType}`}
 								onClick={this.handleShowAddEntityModal}
 							>
@@ -282,6 +283,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="danger"
+								className="margin-bottom-d5"
 								disabled={!this.state.selectedEntities.length}
 								title={`Remove selected ${_.kebabCase(this.props.collection.entityType)}s`}
 								onClick={this.handleRemoveEntities}
@@ -296,6 +298,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="warning"
+								className="margin-bottom-d5"
 								href={`/collection/${this.props.collection.id}/edit`}
 								title="Edit Collection"
 							>
@@ -307,6 +310,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="danger"
+								className="margin-bottom-d5"
 								title="Delete Collection"
 								onClick={this.handleShowDeleteModal}
 							>
@@ -318,6 +322,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="warning"
+								className="margin-bottom-d5"
 								title="Remove yourself as a collaborator"
 								onClick={this.handleShowDeleteModal}
 							>


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR Fixes [BB-591](https://tickets.metabrainz.org/projects/BB/issues/BB-591?filter=allopenissues)

### Solution
<!-- What does this PR do to fix the problem? -->
added margin to buttons

### BEFORE
![Screenshot from 2021-03-18 21-20-03](https://user-images.githubusercontent.com/55311336/111658018-fa5b6200-8831-11eb-9b56-651df67a9c04.png)
![Screenshot from 2021-03-18 21-21-19](https://user-images.githubusercontent.com/55311336/111658033-ff201600-8831-11eb-941b-37b8f517a3cd.png)

### AFTER
![Screenshot from 2021-03-18 21-20-24](https://user-images.githubusercontent.com/55311336/111658056-05ae8d80-8832-11eb-9bbf-30fabfc431e3.png)
![Screenshot from 2021-03-18 21-21-06](https://user-images.githubusercontent.com/55311336/111658075-0a734180-8832-11eb-9aca-528c564b4723.png)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

[Collection page](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/components/pages/collection.js)
