### PR TITLE
fix: Removed trailing space in getEntityLabel (BB-601)

### DIFF
--- a/src/client/helpers/entity.tsx
+++ b/src/client/helpers/entity.tsx
@@ -165,7 +165,7 @@ export function entityToOption(entity) {
 
 export function getEntityLabel(entity, returnHTML = true) {
 	if (entity.defaultAlias) {
-		return `${entity.defaultAlias.name} `;
+		return `${entity.defaultAlias.name}`;
 	}
 
 	// Deleted entities


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Remove trailing space so that selections will not contain a space at the end


### Solution
<!-- What does this PR do to fix the problem? -->
Currently `getLabelEntity` adds a space at the end. Looks like Label is always followed by disambiguation and `getEntityDisambiguation` already [prefixes a space](https://github.com/bookbrainz/bookbrainz-site/blob/c908c2135aaed62c7448977a74ece5c6fd462524/src/client/helpers/entity.tsx#L217). So this should not be a problem :)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
Text selection in title will be easier