### PR TITLE
fixes date picker popper position in author section on smaller viewports

### DIFF
--- a/src/client/entity-editor/common/new-date-field.js
+++ b/src/client/entity-editor/common/new-date-field.js
@@ -182,10 +182,10 @@ class DateField extends React.Component {
 								dateFormat="uuuuuu-MM-dd"
 								disabled={!isCommonEraDate}
 								dropdownMode="select"
+								popperPlacement="top-end"
 								selected={isValid(selectedDate) ? selectedDate : null}
 								timeFormat="false"
 								onChange={this.handleChangeOfDatePicker}
-								popperPlacement="top-end"
 							/>
 						</InputGroup.Button>
 					</InputGroup>

--- a/src/client/entity-editor/common/new-date-field.js
+++ b/src/client/entity-editor/common/new-date-field.js
@@ -185,6 +185,7 @@ class DateField extends React.Component {
 								selected={isValid(selectedDate) ? selectedDate : null}
 								timeFormat="false"
 								onChange={this.handleChangeOfDatePicker}
+								popperPlacement="top-end"
 							/>
 						</InputGroup.Button>
 					</InputGroup>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->
Closes BB-604

### Problem
<!-- What are you trying to solve? -->
fixes date picker popper position in author section
![calendar](https://user-images.githubusercontent.com/50094420/113250362-343a5880-9275-11eb-8d10-8b4a18819c43.JPG)


### Solution
<!-- What does this PR do to fix the problem? -->
Changed the position by setting popperPlacement prop
![dob](https://user-images.githubusercontent.com/50094420/113271023-f34f3d80-928e-11eb-8449-e1c1c2223729.JPG)

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/client/entity-editor/common/new-date-field.js