### PR TITLE
Autocomplete search limit

### DIFF
--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -202,7 +202,8 @@ export function autocomplete(orm, query, type) {
 
 	const dslQuery = {
 		body: {
-			query: queryBody
+			query: queryBody,
+		    size: 10000
 		},
 		index: _index
 	};

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -202,7 +202,8 @@ export function autocomplete(orm, query, type) {
 
 	const dslQuery = {
 		body: {
-			query: queryBody
+			query: queryBody ,
+			size: 10000
 		},
 		index: _index
 	};

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -202,8 +202,7 @@ export function autocomplete(orm, query, type) {
 
 	const dslQuery = {
 		body: {
-			query: queryBody,
-		    size: 10000
+			query: queryBody
 		},
 		index: _index
 	};

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -202,7 +202,7 @@ export function autocomplete(orm, query, type) {
 
 	const dslQuery = {
 		body: {
-			query: queryBody ,
+			query: queryBody,
 			size: 10000
 		},
 		index: _index

--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -203,7 +203,7 @@ export function autocomplete(orm, query, type) {
 	const dslQuery = {
 		body: {
 			query: queryBody,
-			size: 10000
+			size: 42
 		},
 		index: _index
 	};


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->
Closes BB-577
### Problem
<!-- What are you trying to solve? -->
Search autocomplete endpoint responses are limited to 10 results

### Solution
<!-- What does this PR do to fix the problem? -->
Changed the search autocomplete endpoint limit by including  size property in dslQuery object body

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/common/helpers/search.js