### PR TITLE
FIX(BB-606): Buttons overlapping in merge entity section

### DIFF
--- a/src/client/components/pages/parts/merge-queue.js
+++ b/src/client/components/pages/parts/merge-queue.js
@@ -98,6 +98,7 @@ class MergeQueue extends React.Component {
 				<ButtonGroup>
 					<Button
 						bsStyle="success"
+						className="margin-bottom-d5"
 						disabled={isNil(this.state.selectedOption)}
 						href={`/merge/submit/${this.state.selectedOption}`}
 						title="Merge entities"
@@ -107,6 +108,7 @@ class MergeQueue extends React.Component {
 					</Button>
 					<Button
 						bsStyle="warning"
+						className="margin-bottom-d5"
 						disabled={isNil(this.state.selectedOption)}
 						href={`/merge/remove/${this.state.selectedOption}`}
 						title="Remove from merge"
@@ -116,6 +118,7 @@ class MergeQueue extends React.Component {
 					</Button>
 					<Button
 						bsStyle="danger"
+						className="margin-bottom-d5"
 						href="/merge/cancel"
 						title="Cancel merge"
 					>

--- a/src/client/components/pages/parts/merge-queue.js
+++ b/src/client/components/pages/parts/merge-queue.js
@@ -98,7 +98,6 @@ class MergeQueue extends React.Component {
 				<ButtonGroup>
 					<Button
 						bsStyle="success"
-						className="margin-bottom-d5"
 						disabled={isNil(this.state.selectedOption)}
 						href={`/merge/submit/${this.state.selectedOption}`}
 						title="Merge entities"
@@ -108,7 +107,6 @@ class MergeQueue extends React.Component {
 					</Button>
 					<Button
 						bsStyle="warning"
-						className="margin-bottom-d5"
 						disabled={isNil(this.state.selectedOption)}
 						href={`/merge/remove/${this.state.selectedOption}`}
 						title="Remove from merge"

--- a/src/client/components/pages/parts/merge-queue.js
+++ b/src/client/components/pages/parts/merge-queue.js
@@ -118,7 +118,6 @@ class MergeQueue extends React.Component {
 					</Button>
 					<Button
 						bsStyle="danger"
-						className="margin-bottom-d5"
 						href="/merge/cancel"
 						title="Cancel merge"
 					>

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -87,6 +87,9 @@ body {
     margin-right: 0;
 }
 
+.btn-group > .btn:not(:last-child) {
+    margin-bottom: 0.5em;
+}
 
 /* Site-wide styling */
 /* ================= */


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
**This PR Fixes: [BB-606](https://tickets.metabrainz.org/projects/BB/issues/BB-606?filter=allissues)**


### Solution
<!-- What does this PR do to fix the problem? -->
**Added some margins to buttons** 

### Before

![Screenshot from 2021-04-03 14-33-15](https://user-images.githubusercontent.com/55311336/113481642-42c48200-94b8-11eb-84e0-6428daf7a40e.png)


### After
![Screenshot from 2021-04-03 14-31-29](https://user-images.githubusercontent.com/55311336/113481646-49eb9000-94b8-11eb-934c-4a9bfb3ac78b.png)


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
[merge-queue.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/components/pages/parts/merge-queue.js)

