### PR TITLE
FIX(BB-527): Paste values into react-select input using mouse

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -326,6 +326,14 @@ a.contact-text:visited {
 	pointer-events: none;
 }
 
+.Select-input{
+	width: 100%;
+}
+
+.Select-input input{
+	width: 100% !important;
+}
+
 /* react-datepicker styling */
 .form-group {
 	.react-datepicker-wrapper, .react-datepicker__input-container {

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -319,6 +319,11 @@ a.contact-text:visited {
 
 .Select-placeholder {
 	color: @input-color-placeholder;
+	user-select: none;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	pointer-events: none;
 }
 
 /* react-datepicker styling */


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
**This PR Fixes: [BB-527](https://tickets.metabrainz.org/browse/BB-527)**



### Solution
<!-- What does this PR do to fix the problem? -->
Applied some **CSS** rules to react-select `<Select />` Component

**Now we can paste values into the input field with mouse click**

https://user-images.githubusercontent.com/55311336/113511977-23912780-9580-11eb-87e1-0241261b51bd.mp4

### Note for Maintainer

This issue can be fixed without upgrading to react-select v2

In the ticket it is mentioned that

> This will probably require updating to react-select v2 (https://react-select.com/upgrade-guide)

If we wish to upgrade to react-select v > 1. Then we need to tackle some changes in our  **style.less** file. Since react-select v1 uses **LESS / SCSS** stylesheets but version > 1 removed LESS / SCSS for styling and adapted emotion.

So first we will need to remove the following from style.less file as it will no longer work in react-select v2**
```
@import "~react-select/less/select.less";

/* react-select styling */
.Select-control {
	height: @input-height-base;
	border-radius: @input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
	.transition(~"border-color ease-in-out .15s, box-shadow ease-in-out .15s");
	.form-control-focus();

}

.Select-placeholder {
	color: @input-color-placeholder;
	user-select: none;
	-moz-user-select: none;
	-webkit-user-select: none;
	-ms-user-select: none;
	pointer-events: none;
}

.Select-input{
	width: 100%;
}

.Select-input input{
	width: 100% !important;
}

```
The work around if  we use v2 will involve creating the above custom styles in  a separte file:
**react-select-styles.js:**
```
export const customStyles = {

    placeholder: (provided) => ({
        ...provided,
        color: "#7e7868"
        pointerEvents: "none",
        userSelect: "none",
        MozUserSelect: "none",
        WebkitUserSelect: "none",
        msUserSelect: "none"
      }),

      input: (css) => ({
        ...css,
        "> div": {
          width: "100%"
        },
        input: {
          width: "100% !important",
        }
      }),
      
    control: (provided) => ({
        ...provided,
        height: "34px",
        border-radius: "6px",
        transition: "border-color ease-in-out .15s, box-shadow ease-in-out .15s"
    })
  }

  
```
And then importing this custom styles and passing to the **[styles prop](https://react-select.com/upgrade-guide#new-styles-api)** (introduced in v2) of each `<Select />` Component  as `<Select styles={customStyles} />`  in our codebase.
  
What Do you think @MonkeyDo ? Should we stick to the current version or upgrade to newer.