### PR TITLE
Improve[UI]: added left margin to buttons on collection page for better UI

### DIFF
--- a/src/client/components/pages/collection.js
+++ b/src/client/components/pages/collection.js
@@ -270,7 +270,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="success"
-								className="margin-bottom-d5"
+								className="margin-bottom-d5 margin-left-d5"
 								title={`Add ${this.props.collection.entityType}`}
 								onClick={this.handleShowAddEntityModal}
 							>
@@ -283,7 +283,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="danger"
-								className="margin-bottom-d5"
+								className="margin-bottom-d5 margin-left-d5"
 								disabled={!this.state.selectedEntities.length}
 								title={`Remove selected ${_.kebabCase(this.props.collection.entityType)}s`}
 								onClick={this.handleRemoveEntities}
@@ -298,7 +298,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="warning"
-								className="margin-bottom-d5"
+								className="margin-bottom-d5 margin-left-d5"
 								href={`/collection/${this.props.collection.id}/edit`}
 								title="Edit Collection"
 							>
@@ -310,7 +310,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="danger"
-								className="margin-bottom-d5"
+								className="margin-bottom-d5  margin-left-d5"
 								title="Delete Collection"
 								onClick={this.handleShowDeleteModal}
 							>
@@ -322,7 +322,7 @@ class CollectionPage extends React.Component {
 							<Button
 								bsSize="small"
 								bsStyle="warning"
-								className="margin-bottom-d5"
+								className="margin-bottom-d5  margin-left-d5"
 								title="Remove yourself as a collaborator"
 								onClick={this.handleShowDeleteModal}
 							>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
Buttons on collection page are collapsing or touching each other'a boundary,  which not only looks less better but also may temp user to press wrong button as no boundary space is given. 
![Screenshot from 2021-04-05 07-23-03](https://user-images.githubusercontent.com/43696525/113529147-5834cb80-95e0-11eb-8c00-2e91d8e97904.png)



### Solution
<!-- What does this PR do to fix the problem? -->
![Screenshot from 2021-04-05 07-22-15](https://user-images.githubusercontent.com/43696525/113529153-5e2aac80-95e0-11eb-8415-6b76ce897080.png)



### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
src/client/components/pages/collection.js