### PR TITLE
FIX(BB-615): Copy/Paste annotation text  in FireFox <= 60

### DIFF
--- a/src/client/components/pages/entities/annotation.js
+++ b/src/client/components/pages/entities/annotation.js
@@ -46,7 +46,7 @@ class EntityAnnotation extends React.Component {
 				<Col md={12}>
 					<h2>Annotation</h2>
 					<Collapse in={this.state.open}>
-						<p className="annotation-content">{annotation.content}</p>
+						<pre className="annotation-content">{annotation.content}</pre>
 					</Collapse>
 					<Button bsStyle="link" onClick={this.handleToggleCollapse}>
 						Show {this.state.open ? 'less' : 'more…'}

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -461,6 +461,15 @@ hr.wide {
 .annotation-content {
 	white-space: pre-wrap;
 	position: relative;
+	font-family: inherit;
+	font-size: inherit;
+	padding: initial;
+	background: initial;
+	color: inherit;
+    line-height: inherit;
+	border: none;
+	border-radius: initial;
+	z-index: 1;
 	min-height: 3em;
 	margin: 0;
 	&.collapse{


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
**This PR Fixes: [BB-615](https://tickets.metabrainz.org/projects/BB/issues/BB-615?filter=allissues)**


### Solution
<!-- What does this PR do to fix the problem? -->
**Replaced the current `<p class="annotation-content">` with a `<pre class="annotation-content">` and overridden the existing `<pre>` css styles when className `annotation-content` is present.**

**Also Tested in some older version of Firefox browsers using BrowserStack.** 

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
[annotation.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/components/pages/entities/annotation.js)
[style.less](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/stylesheets/style.less)