### PR TITLE
FIX(Revision): "New" badge appears in entity deletion revision

### DIFF
--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -107,6 +107,8 @@ class RevisionPage extends React.Component {
 				<h3>
 					{diff.isNew &&
 					<Badge className="new margin-right-0-5">+ New</Badge>}
+					{diff.isDeletion &&
+					<Badge className="deletion margin-right-0-5">- Deleted</Badge>}
 					<EntityLink
 						entity={diff.entity}
 					/>

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -542,6 +542,10 @@ hr.wide {
 	background-color: @green;
 }
 
+.badge.deletion {
+	background-color: @red;
+}
+
 .label-checkbox {
 	padding: 0 .5em;
 	vertical-align: text-top;

--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -386,8 +386,8 @@ export function formatEntityDiffs(diffs, entityType, entityFormatter) {
 	return _.flatten(diffs).map((diff) => {
 		const formattedDiff = {
 			entity: diff.entity.toJSON(),
-			isNew: diff.isNew,
-			isDeletion: diff.isDeletion
+			isDeletion: diff.isDeletion,
+			isNew: diff.isNew
 		};
 
 		formattedDiff.entity.type = entityType;

--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -386,7 +386,8 @@ export function formatEntityDiffs(diffs, entityType, entityFormatter) {
 	return _.flatten(diffs).map((diff) => {
 		const formattedDiff = {
 			entity: diff.entity.toJSON(),
-			isNew: diff.isNew
+			isNew: diff.isNew,
+			isDeletion: diff.isDeletion
 		};
 
 		formattedDiff.entity.type = entityType;

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -171,8 +171,10 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 					(parent) => {
 						const dataId = revision.get('dataId');
 						let isNew = false;
+						let isDeletion = false;
 						if (!parent) {
 							isNew = dataId;
+							isDeletion = !dataId;
 						}
 						return makePromiseFromObject({
 							changes: revision.diff(parent),
@@ -183,6 +185,7 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 									orm, entityType, revision.get('bbid')
 								),
 							isNew,
+							isDeletion,
 							revision
 						});
 					},
@@ -196,6 +199,7 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 								orm, entityType, revision.get('bbid')
 							),
 						isNew: true,
+						isDeletion,
 						revision
 					})
 				)
@@ -283,7 +287,7 @@ router.get('/:id', async (req, res, next) => {
 			revision: revision.toJSON(),
 			title: 'RevisionPage'
 		});
-
+		
 		const markup = ReactDOMServer.renderToString(
 			<Layout {...propHelpers.extractLayoutProps(props)}>
 				<RevisionPage

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -173,7 +173,7 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 						let isNew = false;
 						let isDeletion = false;
 						if (!parent) {
-							isNew = dataId;
+							isNew = Boolean(dataId);
 							isDeletion = !dataId;
 						}
 						return makePromiseFromObject({

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -169,22 +169,23 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 			revision.parent()
 				.then(
 					(parent) => {
-						let dataId = revision.get('dataId');
+						const dataId = revision.get('dataId');
 						let isNew = false;
-						if(!parent){
+						if (!parent) {
 							isNew = dataId;
 						}
 						return makePromiseFromObject({
-						changes: revision.diff(parent),
-						entity: revision.related('entity'),
-						entityAlias: revision.get('dataId') ?
-							revision.related('data').fetch({require: false, withRelated: ['aliasSet.defaultAlias', 'aliasSet.aliases']}) :
-							orm.func.entity.getEntityParentAlias(
-								orm, entityType, revision.get('bbid')
-							),
-						isNew: isNew,
-						revision
-					})},
+							changes: revision.diff(parent),
+							entity: revision.related('entity'),
+							entityAlias: revision.get('dataId') ?
+								revision.related('data').fetch({require: false, withRelated: ['aliasSet.defaultAlias', 'aliasSet.aliases']}) :
+								orm.func.entity.getEntityParentAlias(
+									orm, entityType, revision.get('bbid')
+								),
+							isNew,
+							revision
+						});
+					},
 					// If calling .parent() is rejected (no parent rev), we still want to go ahead without the parent
 					() => makePromiseFromObject({
 						changes: revision.diff(null),

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -184,8 +184,8 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 								orm.func.entity.getEntityParentAlias(
 									orm, entityType, revision.get('bbid')
 								),
-							isNew,
 							isDeletion,
+							isNew,
 							revision
 						});
 					},
@@ -198,8 +198,8 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 							orm.func.entity.getEntityParentAlias(
 								orm, entityType, revision.get('bbid')
 							),
+						isDeletion: false,
 						isNew: true,
-						isDeletion,
 						revision
 					})
 				)
@@ -287,7 +287,7 @@ router.get('/:id', async (req, res, next) => {
 			revision: revision.toJSON(),
 			title: 'RevisionPage'
 		});
-		
+
 		const markup = ReactDOMServer.renderToString(
 			<Layout {...propHelpers.extractLayoutProps(props)}>
 				<RevisionPage

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -168,7 +168,13 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 		(revision) =>
 			revision.parent()
 				.then(
-					(parent) => makePromiseFromObject({
+					(parent) => {
+						let dataId = revision.get('dataId');
+						let isNew = false;
+						if(!parent){
+							isNew = dataId;
+						}
+						return makePromiseFromObject({
 						changes: revision.diff(parent),
 						entity: revision.related('entity'),
 						entityAlias: revision.get('dataId') ?
@@ -176,9 +182,9 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 							orm.func.entity.getEntityParentAlias(
 								orm, entityType, revision.get('bbid')
 							),
-						isNew: !parent,
+						isNew: isNew,
 						revision
-					}),
+					})},
 					// If calling .parent() is rejected (no parent rev), we still want to go ahead without the parent
 					() => makePromiseFromObject({
 						changes: revision.diff(null),

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -177,7 +177,7 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 						return makePromiseFromObject({
 							changes: revision.diff(parent),
 							entity: revision.related('entity'),
-							entityAlias: revision.get('dataId') ?
+							entityAlias: dataId ?
 								revision.related('data').fetch({require: false, withRelated: ['aliasSet.defaultAlias', 'aliasSet.aliases']}) :
 								orm.func.entity.getEntityParentAlias(
 									orm, entityType, revision.get('bbid')

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -171,10 +171,9 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 					(parent) => {
 						const dataId = revision.get('dataId');
 						let isNew = false;
-						let isDeletion = false;
+						const isDeletion = !dataId;
 						if (!parent) {
 							isNew = Boolean(dataId);
-							isDeletion = !dataId;
 						}
 						return makePromiseFromObject({
 							changes: revision.diff(parent),

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -165,11 +165,11 @@ function formatEditionGroupChange(change) {
 function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 	// entityRevisions - collection of *entityType*_revisions matching id
 	return Promise.all(entityRevisions.map(
-		(revision) =>
-			revision.parent()
+		(revision) => {
+			const dataId = revision.get('dataId');
+			return revision.parent()
 				.then(
 					(parent) => {
-						const dataId = revision.get('dataId');
 						let isNew = false;
 						const isDeletion = !dataId;
 						if (!parent) {
@@ -197,11 +197,12 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 							orm.func.entity.getEntityParentAlias(
 								orm, entityType, revision.get('bbid')
 							),
-						isDeletion: false,
-						isNew: true,
+						isDeletion: !dataId,
+						isNew: Boolean(dataId),
 						revision
 					})
-				)
+				);
+		}
 	));
 }
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
**This PR Fixes: [BB-523](https://tickets.metabrainz.org/projects/BB/issues/BB-523?filter=allopenissues)**


### Solution
<!-- What does this PR do to fix the problem? -->
Refactored the `isNew` property logic in **server/routes/revision.js** by taking advantage of `dataId`( which is **null** for a deleted entity)
 
### Before

![Screenshot from 2021-04-18 21-39-58](https://user-images.githubusercontent.com/55311336/115152536-25361180-a08f-11eb-84e4-6b3d5d054058.png)


### After
![Screenshot from 2021-04-18 21-39-19](https://user-images.githubusercontent.com/55311336/115152554-33842d80-a08f-11eb-9076-5de42a2c31f5.png)



### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
server/routes/revision.js
