### PR TITLE
FIX(Revision): Alias language change not shown in revisions

### DIFF
--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -49,7 +49,15 @@ class RevisionPage extends React.Component {
 		);
 	}
 
-	static formatChange(change) {
+	static formatChange(change,languageOptions) {	
+		if(change.isLanguage){
+			if(change.lhs){
+				const lhs = languageOptions.find(language => language.id === change.lhs[0]);
+				change.lhs = [lhs.name];
+			}
+			const rhs = languageOptions.find(language => language.id === change.rhs[0]); 
+			change.rhs = [rhs.name];
+		}
 		const isChangeADate = change.key.toLowerCase().match(/\bdate\b/);
 		if (change.kind === 'N') {
 			return (
@@ -93,9 +101,10 @@ class RevisionPage extends React.Component {
 	}
 
 	static formatDiff(diff) {
+		const languageOptions= diff.entity.languageOptions;
 		const result = diff.changes.map(
 			(change) =>
-				RevisionPage.formatChange(change)
+				RevisionPage.formatChange(change,languageOptions)
 		);
 
 		return _.compact(result);
@@ -156,7 +165,8 @@ class RevisionPage extends React.Component {
 	}
 
 	render() {
-		const {revision, diffs, user} = this.props;
+		const {revision, diffs, user, languageOptions} = this.props;
+		diffs[0].entity.languageOptions = languageOptions;
 		let regularDiffs = diffs;
 		let mergeDiffDivs;
 

--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -49,14 +49,14 @@ class RevisionPage extends React.Component {
 		);
 	}
 
-	static formatChange(change,languageOptions) {	
-		if(change.isLanguage){
-			if(change.lhs){
+	static formatChange(change, languageOptions) {
+		if (change.isLanguage) {
+			if (change.lhs) {
 				const lhs = languageOptions.find(language => language.id === change.lhs[0]);
 				change.lhs = [lhs.name];
 			}
-			if(change.rhs){
-				const rhs = languageOptions.find(language => language.id === change.rhs[0]); 
+			if (change.rhs) {
+				const rhs = languageOptions.find(language => language.id === change.rhs[0]);
 				change.rhs = [rhs.name];
 			}
 		}
@@ -103,10 +103,10 @@ class RevisionPage extends React.Component {
 	}
 
 	static formatDiff(diff) {
-		const languageOptions= diff.entity.languageOptions;
+		const {languageOptions} = diff.entity;
 		const result = diff.changes.map(
 			(change) =>
-				RevisionPage.formatChange(change,languageOptions)
+				RevisionPage.formatChange(change, languageOptions)
 		);
 
 		return _.compact(result);
@@ -301,9 +301,9 @@ class RevisionPage extends React.Component {
 RevisionPage.displayName = 'RevisionPage';
 RevisionPage.propTypes = {
 	diffs: PropTypes.any.isRequired,
+	languageOptions: PropTypes.object.isRequired,
 	revision: PropTypes.any.isRequired,
-	user: PropTypes.object,
-	languageOptions: PropTypes.object
+	user: PropTypes.object
 };
 RevisionPage.defaultProps = {
 	user: null

--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -302,7 +302,8 @@ RevisionPage.displayName = 'RevisionPage';
 RevisionPage.propTypes = {
 	diffs: PropTypes.any.isRequired,
 	revision: PropTypes.any.isRequired,
-	user: PropTypes.object
+	user: PropTypes.object,
+	languageOptions: PropTypes.object
 };
 RevisionPage.defaultProps = {
 	user: null

--- a/src/client/components/pages/revision.js
+++ b/src/client/components/pages/revision.js
@@ -55,8 +55,10 @@ class RevisionPage extends React.Component {
 				const lhs = languageOptions.find(language => language.id === change.lhs[0]);
 				change.lhs = [lhs.name];
 			}
-			const rhs = languageOptions.find(language => language.id === change.rhs[0]); 
-			change.rhs = [rhs.name];
+			if(change.rhs){
+				const rhs = languageOptions.find(language => language.id === change.rhs[0]); 
+				change.rhs = [rhs.name];
+			}
 		}
 		const isChangeADate = change.key.toLowerCase().match(/\bdate\b/);
 		if (change.kind === 'N') {

--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -19,7 +19,7 @@
 import _ from 'lodash';
 
 
-export function formatRow(kind, key, lhs, rhs) {
+export function formatRow(kind, key, lhs, rhs, isLanguage) {
 	if (_.isNil(lhs) && _.isNil(rhs)) {
 		return [];
 	}
@@ -28,7 +28,8 @@ export function formatRow(kind, key, lhs, rhs) {
 		return {
 			key,
 			kind: 'N',
-			rhs
+			rhs,
+			isLanguage
 		};
 	}
 
@@ -36,7 +37,8 @@ export function formatRow(kind, key, lhs, rhs) {
 		return {
 			key,
 			kind: 'D',
-			lhs
+			lhs,
+			isLanguage
 		};
 	}
 
@@ -44,7 +46,8 @@ export function formatRow(kind, key, lhs, rhs) {
 		key,
 		kind,
 		lhs,
-		rhs
+		rhs,
+		isLanguage
 	};
 }
 
@@ -53,7 +56,8 @@ export function formatChange(change, label, transformer) {
 		change.kind,
 		label,
 		transformer(change.lhs),
-		transformer(change.rhs)
+		transformer(change.rhs),
+		change.isLanguage
 	);
 }
 

--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -26,28 +26,28 @@ export function formatRow(kind, key, lhs, rhs, isLanguage) {
 
 	if (kind === 'N' || _.isNil(lhs)) {
 		return {
+			isLanguage,
 			key,
 			kind: 'N',
-			rhs,
-			isLanguage
+			rhs
 		};
 	}
 
 	if (kind === 'D' || _.isNil(rhs)) {
 		return {
+			isLanguage,
 			key,
 			kind: 'D',
-			lhs,
-			isLanguage
+			lhs
 		};
 	}
 
 	return {
+		isLanguage,
 		key,
 		kind,
 		lhs,
-		rhs,
-		isLanguage
+		rhs
 	};
 }
 

--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -402,7 +402,7 @@ export function formatEntityDiffs(diffs, entityType, entityFormatter) {
 				formattedDiff.entity.defaultAlias = diff.entityAlias;
 			}
 		}
-		
+
 		if (!diff.changes) {
 			formattedDiff.changes = [];
 

--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -94,7 +94,6 @@ function formatAliasModified(change) {
 		];
 	}
 
-	const REQUIRED_DEPTH = 4;
 	const aliasLanguageChanged =
 		change.path.length > 3 && change.path[3] === 'languageId';
 	if (aliasLanguageChanged) {

--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -96,9 +96,9 @@ function formatAliasModified(change) {
 
 	const REQUIRED_DEPTH = 4;
 	const aliasLanguageChanged =
-		change.path.length > REQUIRED_DEPTH && change.path[3] === 'language' &&
-		change.path[4] === 'name';
+		change.path.length > 3 && change.path[3] === 'languageId';
 	if (aliasLanguageChanged) {
+		change.isLanguage = true;
 		return [
 			base.formatChange(
 				change,
@@ -403,7 +403,7 @@ export function formatEntityDiffs(diffs, entityType, entityFormatter) {
 				formattedDiff.entity.defaultAlias = diff.entityAlias;
 			}
 		}
-
+		
 		if (!diff.changes) {
 			formattedDiff.changes = [];
 

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -38,6 +38,7 @@ import express from 'express';
 import log from 'log';
 import {makePromiseFromObject} from '../../common/helpers/utils';
 import target from '../templates/target';
+import * as middleware from '../helpers/middleware';
 
 
 const router = express.Router();
@@ -195,7 +196,7 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 	));
 }
 
-router.get('/:id', async (req, res, next) => {
+router.get('/:id',middleware.loadLanguages, async (req, res, next) => {
 	const {
 		AuthorRevision, EditionRevision, EditionGroupRevision,
 		PublisherRevision, Revision, WorkRevision
@@ -283,6 +284,7 @@ router.get('/:id', async (req, res, next) => {
 					diffs={props.diffs}
 					revision={props.revision}
 					user={props.user}
+					languageOptions={props.languages}
 				/>
 			</Layout>
 		);

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -22,6 +22,7 @@ import * as entityFormatter from '../helpers/diffFormatters/entity';
 import * as entityRoutes from './entity/entity';
 import * as error from '../../common/helpers/error';
 import * as languageSetFormatter from '../helpers/diffFormatters/languageSet';
+import * as middleware from '../helpers/middleware';
 import * as propHelpers from '../../client/helpers/props';
 import * as publisherSetFormatter from '../helpers/diffFormatters/publisherSet';
 import * as releaseEventSetFormatter from
@@ -38,7 +39,6 @@ import express from 'express';
 import log from 'log';
 import {makePromiseFromObject} from '../../common/helpers/utils';
 import target from '../templates/target';
-import * as middleware from '../helpers/middleware';
 
 
 const router = express.Router();
@@ -196,7 +196,7 @@ function diffRevisionsWithParents(orm, entityRevisions, entityType) {
 	));
 }
 
-router.get('/:id',middleware.loadLanguages, async (req, res, next) => {
+router.get('/:id', middleware.loadLanguages, async (req, res, next) => {
 	const {
 		AuthorRevision, EditionRevision, EditionGroupRevision,
 		PublisherRevision, Revision, WorkRevision
@@ -282,9 +282,9 @@ router.get('/:id',middleware.loadLanguages, async (req, res, next) => {
 			<Layout {...propHelpers.extractLayoutProps(props)}>
 				<RevisionPage
 					diffs={props.diffs}
+					languageOptions={props.languages}
 					revision={props.revision}
 					user={props.user}
-					languageOptions={props.languages}
 				/>
 			</Layout>
 		);


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR Fixes: [BB-592](https://tickets.metabrainz.org/browse/BB-592)



### Solution
<!-- What does this PR do to fix the problem? -->
- Used the **loadLanguages middleware** to get all the languagesOptions. 
- Converted the alias **languageId** to corresponding language **name** utilizing the languageOptions array of objects.
- Implemented an **isLanguage** property. If the revision includes change in **alias language** then **isLanguage** will be turned **true** and convert the alias **languageId** to corresponding language **name** before displaying.  

### Before

![Screenshot from 2021-04-22 17-23-59](https://user-images.githubusercontent.com/55311336/115717294-a8a97880-a397-11eb-8316-107fc3da8a4b.png)

### After

![Screenshot from 2021-04-22 08-53-41](https://user-images.githubusercontent.com/55311336/115717351-b959ee80-a397-11eb-9626-633f59b0ecd8.png)







### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

- [server/routes/revision.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/server/routes/revision.js)
- [server/helpers/diffFormatters/base.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/server/helpers/diffFormatters/base.js)
- [server/helpers/diffFormatters/entity.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/server/helpers/diffFormatters/entity.js)
- [client/components/pages/revision.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/components/pages/revision.js)
