### PR TITLE
BB-543: Enable native html form functionality

### DIFF
--- a/src/client/components/pages/parts/search-field.tsx
+++ b/src/client/components/pages/parts/search-field.tsx
@@ -163,6 +163,7 @@ class SearchField extends React.Component<SearchFieldProps, SearchFieldState> {
 					<form
 						action="/search"
 						className="form-horizontal whole-page-form"
+						role="search"
 						onSubmit={this.handleSubmit}
 					>
 						<CustomInput

--- a/src/client/entity-editor/author-section/author-section-merge.tsx
+++ b/src/client/entity-editor/author-section/author-section-merge.tsx
@@ -205,7 +205,7 @@ function AuthorSectionMerge({
 	const formattedEndDateValue = transformISODateForSelect(endDateValue);
 
 	return (
-		<form>
+		<div>
 			<MergeField
 				currentValue={typeValue}
 				label="Type"
@@ -256,7 +256,7 @@ function AuthorSectionMerge({
 					/>
 				</React.Fragment>
 			}
-		</form>
+		</div>
 	);
 }
 AuthorSectionMerge.displayName = 'AuthorSectionMerge';

--- a/src/client/entity-editor/author-section/author-section.tsx
+++ b/src/client/entity-editor/author-section/author-section.tsx
@@ -175,7 +175,7 @@ function AuthorSection({
 
 
 	return (
-		<form>
+		<div>
 			<h2>
 				What else do you know about the Author?
 			</h2>
@@ -270,7 +270,7 @@ function AuthorSection({
 					</Row>
 				</div>
 			}
-		</form>
+		</div>
 	);
 }
 AuthorSection.displayName = 'AuthorSection';

--- a/src/client/entity-editor/button-bar/button-bar.js
+++ b/src/client/entity-editor/button-bar/button-bar.js
@@ -58,24 +58,22 @@ function ButtonBar({
 }) {
 	return (
 		<div>
-			<form>
-				<Row className="margin-top-1">
-					<Col className="text-center" md={6}>
-						<AliasButton
-							aliasesInvalid={aliasesInvalid}
-							numAliases={numAliases}
-							onClick={onAliasButtonClick}
-						/>
-					</Col>
-					<Col className="text-center" md={6}>
-						<IdentifierButton
-							identifiersInvalid={identifiersInvalid}
-							numIdentifiers={numIdentifiers}
-							onClick={onIdentifierButtonClick}
-						/>
-					</Col>
-				</Row>
-			</form>
+			<Row className="margin-top-1">
+				<Col className="text-center" md={6}>
+					<AliasButton
+						aliasesInvalid={aliasesInvalid}
+						numAliases={numAliases}
+						onClick={onAliasButtonClick}
+					/>
+				</Col>
+				<Col className="text-center" md={6}>
+					<IdentifierButton
+						identifiersInvalid={identifiersInvalid}
+						numIdentifiers={numIdentifiers}
+						onClick={onIdentifierButtonClick}
+					/>
+				</Col>
+			</Row>
 		</div>
 	);
 }

--- a/src/client/entity-editor/edition-group-section/edition-group-section-merge.tsx
+++ b/src/client/entity-editor/edition-group-section/edition-group-section-merge.tsx
@@ -71,7 +71,7 @@ function EditionGroupSectionMerge({
 	});
 
 	return (
-		<form>
+		<div>
 			<MergeField
 				currentValue={typeValue}
 				label="Type"
@@ -83,7 +83,7 @@ function EditionGroupSectionMerge({
 				entity={mergingEntities[0]}
 				showAdd={false}
 			/>
-		</form>
+		</div>
 	);
 }
 EditionGroupSectionMerge.displayName = 'EditionGroupSectionMerge';

--- a/src/client/entity-editor/edition-group-section/edition-group-section.tsx
+++ b/src/client/entity-editor/edition-group-section/edition-group-section.tsx
@@ -72,7 +72,7 @@ function EditionGroupSection({
 	}));
 
 	return (
-		<form>
+		<div>
 			<h2>
 				What else do you know about the Edition Group?
 			</h2>
@@ -95,7 +95,7 @@ function EditionGroupSection({
 					</CustomInput>
 				</Col>
 			</Row>
-		</form>
+		</div>
 	);
 }
 EditionGroupSection.displayName = 'EditionGroupSection';

--- a/src/client/entity-editor/edition-section/edition-section-merge.tsx
+++ b/src/client/entity-editor/edition-section/edition-section-merge.tsx
@@ -210,7 +210,7 @@ function EditionSectionMerge({
 		}
 	});
 	return (
-		<form>
+		<div>
 			<MergeField
 				currentValue={editionGroupValue}
 				label="Edition Group"
@@ -284,7 +284,7 @@ function EditionSectionMerge({
 					value={languageValues}
 				/>
 			</CustomInput>
-		</form>
+		</div>
 	);
 }
 EditionSectionMerge.displayName = 'EditionSectionMerge';

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -246,7 +246,7 @@ function EditionSection({
 	);
 
 	return (
-		<form>
+		<div>
 			<h2>
 				What else do you know about the Edition?
 			</h2>
@@ -427,7 +427,7 @@ function EditionSection({
 					</Col>
 				</Row>
 			}
-		</form>
+		</div>
 	);
 }
 EditionSection.displayName = 'EditionSection';

--- a/src/client/entity-editor/entity-editor.tsx
+++ b/src/client/entity-editor/entity-editor.tsx
@@ -27,6 +27,7 @@ import {Panel} from 'react-bootstrap';
 import RelationshipSection from './relationship-editor/relationship-section';
 import SubmissionSection from './submission-section/submission-section';
 import {connect} from 'react-redux';
+import {submit} from './submission-section/actions';
 
 
 type OwnProps = {
@@ -39,7 +40,11 @@ type StateProps = {
 	identifierEditorVisible: boolean,
 };
 
-type Props = StateProps & OwnProps;
+type DispatchProps = {
+	onSubmit: () => unknown
+};
+
+type Props = StateProps & DispatchProps & OwnProps;
 
 /**
  * Container component. Renders all of the sections of the entity editing form.
@@ -51,6 +56,8 @@ type Props = StateProps & OwnProps;
  *        editor modal should be made visible.
  * @param {React.Node} props.children - The child content to wrap with this
  *        entity editor form.
+ * @param {Function} props.onSubmit - A function to be called when the
+ *        submit button is clicked.
  * @returns {ReactElement} React element containing the rendered EntityEditor.
  */
 const EntityEditor = (props: Props) => {
@@ -58,34 +65,37 @@ const EntityEditor = (props: Props) => {
 		aliasEditorVisible,
 		children,
 		heading,
-		identifierEditorVisible
+		identifierEditorVisible,
+		onSubmit
 	} = props;
 
 	return (
-		<Panel>
-			<Panel.Heading>
-				<Panel.Title componentClass="h3">
-					{heading}
-				</Panel.Title>
-			</Panel.Heading>
-			<Panel.Body>
-				<AliasEditor show={aliasEditorVisible} {...props}/>
-				<NameSection {...props}/>
-				<ButtonBar {...props}/>
-				<RelationshipSection {...props}/>
-				{
-					React.cloneElement(
-						React.Children.only(children),
-						{...props}
-					)
-				}
-				<IdentifierEditor show={identifierEditorVisible} {...props}/>
-				<AnnotationSection {...props}/>
-			</Panel.Body>
-			<Panel.Footer>
-				<SubmissionSection {...props}/>
-			</Panel.Footer>
-		</Panel>
+		<form onSubmit={onSubmit}>
+			<Panel>
+				<Panel.Heading>
+					<Panel.Title componentClass="h3">
+						{heading}
+					</Panel.Title>
+				</Panel.Heading>
+				<Panel.Body>
+					<AliasEditor show={aliasEditorVisible} {...props}/>
+					<NameSection {...props}/>
+					<ButtonBar {...props}/>
+					<RelationshipSection {...props}/>
+					{
+						React.cloneElement(
+							React.Children.only(children),
+							{...props}
+						)
+					}
+					<IdentifierEditor show={identifierEditorVisible} {...props}/>
+					<AnnotationSection {...props}/>
+				</Panel.Body>
+				<Panel.Footer>
+					<SubmissionSection {...props}/>
+				</Panel.Footer>
+			</Panel>
+		</form>
 	);
 };
 EntityEditor.displayName = 'EntityEditor';
@@ -98,4 +108,10 @@ function mapStateToProps(rootState): StateProps {
 	};
 }
 
-export default connect(mapStateToProps)(EntityEditor);
+function mapDispatchToProps(dispatch, {submissionUrl}) {
+	return {
+		onSubmit: () => dispatch(submit(submissionUrl))
+	};
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EntityEditor);

--- a/src/client/entity-editor/entity-editor.tsx
+++ b/src/client/entity-editor/entity-editor.tsx
@@ -110,7 +110,10 @@ function mapStateToProps(rootState): StateProps {
 
 function mapDispatchToProps(dispatch, {submissionUrl}) {
 	return {
-		onSubmit: () => dispatch(submit(submissionUrl))
+		onSubmit: (event:React.FormEvent) => {
+			event.preventDefault();
+			dispatch(submit(submissionUrl));
+		}
 	};
 }
 

--- a/src/client/entity-editor/name-section/name-section-merge.js
+++ b/src/client/entity-editor/name-section/name-section-merge.js
@@ -98,7 +98,7 @@ function NameSectionMerge({
 	});
 
 	return (
-		<form>
+		<div>
 			<MergeField
 				currentValue={nameValue}
 				label="Name"
@@ -130,7 +130,7 @@ function NameSectionMerge({
 				tooltipText="In case there is another distinct entity with the same name"
 				onChange={onDisambiguationChange}
 			/>
-		</form>
+		</div>
 	);
 }
 

--- a/src/client/entity-editor/name-section/name-section.js
+++ b/src/client/entity-editor/name-section/name-section.js
@@ -153,56 +153,55 @@ class NameSection extends React.Component {
 		return (
 			<div>
 				<h2>{`What is the ${_.startCase(entityType)} called?`}</h2>
-				<form>
-					<Row>
-						<Col md={6} mdOffset={3}>
-							<NameField
-								defaultValue={nameValue}
-								empty={isAliasEmpty(
-									nameValue, sortNameValue, languageValue
-								)}
-								error={!validateNameSectionName(nameValue)}
-								inputRef={this.updateNameFieldInputRef}
-								tooltipText={`Official name of the ${_.startCase(entityType)} in its original language.
+				<Row>
+					<Col md={6} mdOffset={3}>
+						<NameField
+							defaultValue={nameValue}
+							empty={isAliasEmpty(
+								nameValue, sortNameValue, languageValue
+							)}
+							error={!validateNameSectionName(nameValue)}
+							inputRef={this.updateNameFieldInputRef}
+							tooltipText={`Official name of the ${_.startCase(entityType)} in its original language.
 								Names in other languages should be added as aliases.`}
-								warn={(isRequiredDisambiguationEmpty(
-									warnIfExists,
-									disambiguationDefaultValue
-								))}
-								onChange={this.handleNameChange}
-							/>
-						</Col>
-						<Col md={6} mdOffset={3}>
-							{isRequiredDisambiguationEmpty(
+							warn={(isRequiredDisambiguationEmpty(
 								warnIfExists,
 								disambiguationDefaultValue
-							) ?
-								<Alert bsStyle="warning">
+							))}
+							onChange={this.handleNameChange}
+						/>
+					</Col>
+					<Col md={6} mdOffset={3}>
+						{isRequiredDisambiguationEmpty(
+							warnIfExists,
+							disambiguationDefaultValue
+						) ?
+							<Alert bsStyle="warning">
 									We found the following&nbsp;
-									{_.startCase(entityType)}{exactMatches.length > 1 ? 's' : ''} with
+								{_.startCase(entityType)}{exactMatches.length > 1 ? 's' : ''} with
 									exactly the same name or alias:
-									<br/><small className="help-block">Click on a name to open it (Ctrl/Cmd + click to open in a new tab)</small>
-									<ListGroup className="margin-top-1 margin-bottom-1">
-										{exactMatches.map((match) =>
-											(
-												<ListGroupItem
-													bsStyle="warning"
-													href={`/${_.kebabCase(entityType)}/${match.bbid}`}
-													key={`${match.bbid}`}
-													rel="noopener noreferrer" target="_blank"
-												>
-													{match.defaultAlias.name} {getEntityDisambiguation(match)}
-												</ListGroupItem>
-											))}
-									</ListGroup>
+								<br/><small className="help-block">Click on a name to open it (Ctrl/Cmd + click to open in a new tab)</small>
+								<ListGroup className="margin-top-1 margin-bottom-1">
+									{exactMatches.map((match) =>
+										(
+											<ListGroupItem
+												bsStyle="warning"
+												href={`/${_.kebabCase(entityType)}/${match.bbid}`}
+												key={`${match.bbid}`}
+												rel="noopener noreferrer" target="_blank"
+											>
+												{match.defaultAlias.name} {getEntityDisambiguation(match)}
+											</ListGroupItem>
+										))}
+								</ListGroup>
 									If you are sure your entry is different, please fill the
 									disambiguation field below to help us differentiate between them.
-								</Alert> : null
-							}
-						</Col>
-					</Row>
-					{
-						!warnIfExists &&
+							</Alert> : null
+						}
+					</Col>
+				</Row>
+				{
+					!warnIfExists &&
 						!_.isEmpty(searchResults) &&
 						<Row>
 							<Col md={6} mdOffset={3}>
@@ -212,52 +211,51 @@ class NameSection extends React.Component {
 								<SearchResults condensed results={searchResults}/>
 							</Col>
 						</Row>
-					}
-					<Row>
-						<Col md={6} mdOffset={3}>
-							<SortNameField
-								defaultValue={sortNameValue}
-								empty={isAliasEmpty(
-									nameValue, sortNameValue, languageValue
-								)}
-								error={!validateNameSectionSortName(sortNameValue)}
-								storedNameValue={nameValue}
-								onChange={onSortNameChange}
-							/>
-						</Col>
-					</Row>
-					<Row>
-						<Col md={6} mdOffset={3}>
-							<LanguageField
-								empty={isAliasEmpty(
-									nameValue, sortNameValue, languageValue
-								)}
-								error={!validateNameSectionLanguage(languageValue)}
-								instanceId="language"
-								options={languageOptionsForDisplay}
-								tooltipText="Language used for the above name"
-								value={languageValue}
-								onChange={onLanguageChange}
-							/>
-						</Col>
-					</Row>
-					<Row>
-						<Col md={6} mdOffset={3}>
-							<DisambiguationField
-								defaultValue={disambiguationDefaultValue}
-								error={isRequiredDisambiguationEmpty(
-									warnIfExists,
-									disambiguationDefaultValue
-								) ||
+				}
+				<Row>
+					<Col md={6} mdOffset={3}>
+						<SortNameField
+							defaultValue={sortNameValue}
+							empty={isAliasEmpty(
+								nameValue, sortNameValue, languageValue
+							)}
+							error={!validateNameSectionSortName(sortNameValue)}
+							storedNameValue={nameValue}
+							onChange={onSortNameChange}
+						/>
+					</Col>
+				</Row>
+				<Row>
+					<Col md={6} mdOffset={3}>
+						<LanguageField
+							empty={isAliasEmpty(
+								nameValue, sortNameValue, languageValue
+							)}
+							error={!validateNameSectionLanguage(languageValue)}
+							instanceId="language"
+							options={languageOptionsForDisplay}
+							tooltipText="Language used for the above name"
+							value={languageValue}
+							onChange={onLanguageChange}
+						/>
+					</Col>
+				</Row>
+				<Row>
+					<Col md={6} mdOffset={3}>
+						<DisambiguationField
+							defaultValue={disambiguationDefaultValue}
+							error={isRequiredDisambiguationEmpty(
+								warnIfExists,
+								disambiguationDefaultValue
+							) ||
 								!validateNameSectionDisambiguation(
 									disambiguationDefaultValue
 								)}
-								required={warnIfExists}
-								onChange={onDisambiguationChange}
-							/>
-						</Col>
-					</Row>
-				</form>
+							required={warnIfExists}
+							onChange={onDisambiguationChange}
+						/>
+					</Col>
+				</Row>
 			</div>
 		);
 	}

--- a/src/client/entity-editor/publisher-section/publisher-section-merge.tsx
+++ b/src/client/entity-editor/publisher-section/publisher-section-merge.tsx
@@ -151,7 +151,7 @@ function PublisherSectionMerge({
 	const {isValid: isValidEndDate, errorMessage: errorMessageEndDate} = validatePublisherSectionEndDate(beginDateValue, endDateValue, endedChecked);
 
 	return (
-		<form>
+		<div>
 			<MergeField
 				currentValue={typeValue}
 				label="Type"
@@ -190,7 +190,7 @@ function PublisherSectionMerge({
 					onChange={onEndDateChange}
 				/>
 			}
-		</form>
+		</div>
 	);
 }
 PublisherSectionMerge.displayName = 'PublisherSectionMerge';

--- a/src/client/entity-editor/publisher-section/publisher-section.tsx
+++ b/src/client/entity-editor/publisher-section/publisher-section.tsx
@@ -129,7 +129,7 @@ function PublisherSection({
 	const {isValid: isValidBeginDate, errorMessage: errorMessageBeginDate} = validatePublisherSectionBeginDate(beginDateValue);
 	const {isValid: isValidEndDate, errorMessage: errorMessageEndDate} = validatePublisherSectionEndDate(beginDateValue, endDateValue, endedChecked);
 	return (
-		<form>
+		<div>
 			<h2>
 				What else do you know about the Publisher?
 			</h2>
@@ -201,7 +201,7 @@ function PublisherSection({
 					</Row>
 				</div>
 			}
-		</form>
+		</div>
 	);
 }
 PublisherSection.displayName = 'PublisherSection';

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -414,14 +414,14 @@ class RelationshipModal
 					<hr/>
 					<Row>
 						<Col md={10} mdOffset={1}>
-							<form>
+							<div>
 								<div>
 									{entitySelect}
 								</div>
 								<div>
 									{this.renderRelationshipSelect()}
 								</div>
-							</form>
+							</div>
 						</Col>
 					</Row>
 				</Modal.Body>

--- a/src/client/entity-editor/submission-section/submission-section.js
+++ b/src/client/entity-editor/submission-section/submission-section.js
@@ -37,8 +37,6 @@ import {connect} from 'react-redux';
  *        validated successfully or if it contains errors
  * @param {Function} props.onNoteChange - A function to be called when the
  *        revision note is changed.
- * @param {Function} props.onSubmit - A function to be called when the
- *        submit button is clicked.
  * @param {boolean} props.submitted - Boolean indicating if the form has been submitted
  *        (i.e. submit button clicked) to prevent submitting again
  * @returns {ReactElement} React element containing the rendered
@@ -48,7 +46,6 @@ function SubmissionSection({
 	errorText,
 	formValid,
 	onNoteChange,
-	onSubmit,
 	submitted
 }) {
 	const errorAlertClass =
@@ -87,7 +84,7 @@ function SubmissionSection({
 				<Button
 					bsStyle="success"
 					disabled={!formValid || submitted}
-					onClick={onSubmit}
+					type="submit"
 				>
 					Submit
 				</Button>
@@ -103,7 +100,6 @@ SubmissionSection.propTypes = {
 	errorText: PropTypes.node.isRequired,
 	formValid: PropTypes.bool.isRequired,
 	onNoteChange: PropTypes.func.isRequired,
-	onSubmit: PropTypes.func.isRequired,
 	submitted: PropTypes.bool.isRequired
 };
 
@@ -117,11 +113,10 @@ function mapStateToProps(rootState, {validate, identifierTypes}) {
 }
 
 
-function mapDispatchToProps(dispatch, {submissionUrl}) {
+function mapDispatchToProps(dispatch) {
 	return {
 		onNoteChange: (event) =>
-			dispatch(debounceUpdateRevisionNote(event.target.value)),
-		onSubmit: () => dispatch(submit(submissionUrl))
+			dispatch(debounceUpdateRevisionNote(event.target.value))
 	};
 }
 

--- a/src/client/entity-editor/work-section/work-section-merge.tsx
+++ b/src/client/entity-editor/work-section/work-section-merge.tsx
@@ -83,7 +83,7 @@ function WorkSectionMerge({
 	});
 
 	return (
-		<form>
+		<div>
 			<MergeField
 				currentValue={typeValue}
 				label="Type"
@@ -98,7 +98,7 @@ function WorkSectionMerge({
 					value={languageValues}
 				/>
 			</CustomInput>
-		</form>
+		</div>
 	);
 }
 WorkSectionMerge.displayName = 'WorkSectionMerge';

--- a/src/client/entity-editor/work-section/work-section.tsx
+++ b/src/client/entity-editor/work-section/work-section.tsx
@@ -101,7 +101,7 @@ function WorkSection({
 	}));
 
 	return (
-		<form>
+		<div>
 			<h2>
 				What else do you know about the Work?
 			</h2>
@@ -137,7 +137,7 @@ function WorkSection({
 					/>
 				</Col>
 			</Row>
-		</form>
+		</div>
 	);
 }
 WorkSection.displayName = 'WorkSection';


### PR DESCRIPTION
As reported in [BB-543](https://tickets.metabrainz.org/browse/BB-543), pressing enter in a field in the entity editor page does not submit the page as a user should expect.

We were not using a properly formatted form in the entity editor, which was breaking default browser functionality.
One issue was the lack of a parent `<form>` element with an `onSubmit` property, and making our submit button of `type="submit"`.
The other issue was multiple nested form elements, which is not supported like that in HTML.

This PR fixes the form structure and re-enables default browser behavior.