### PR TITLE
chore: drop support for node 10, which is EOL today

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "lts/*"
-  - "10"
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dupreport": "npx jsinspect src/ || true"
   },
   "engines": {
-    "node": ">= 10.13.0"
+    "node": ">= 12.22.1"
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {


### PR DESCRIPTION
### Problem
Node.js 10.x is end-of-life on 2021-04-30.

### Solution
Bump the minimum supported version to Node 12, which is now the oldest LTS release.

### Areas of Impact
None.