### PR TITLE
[BB-621]: Physical data section should be disabled if eBook is chosen

### DIFF
--- a/src/client/entity-editor/edition-section/actions.ts
+++ b/src/client/entity-editor/edition-section/actions.ts
@@ -51,6 +51,7 @@ export const UPDATE_WIDTH = 'UPDATE_WIDTH';
 export const UPDATE_HEIGHT = 'UPDATE_HEIGHT';
 export const UPDATE_DEPTH = 'UPDATE_DEPTH';
 export const SHOW_PHYSICAL = 'SHOW_PHYSICAL';
+export const HIDE_PHYSICAL = 'HIDE_PHYSICAL';
 export const TOGGLE_SHOW_EDITION_GROUP = 'TOGGLE_SHOW_EDITION_GROUP';
 export const UPDATE_WARN_IF_EDITION_GROUP_EXISTS = 'UPDATE_WARN_IF_EDITION_GROUP_EXISTS';
 
@@ -125,6 +126,18 @@ export function updateLanguages(newLanguages: Array<LanguageOption>): Action {
 export function showPhysical(): Action {
 	return {
 		type: SHOW_PHYSICAL
+	};
+}
+
+/**
+ * Produces an action indicating that the physical section of the edition
+ * form should be hidden.
+ *
+ * @returns {Action} The resulting HIDE_PHYSICAL action.
+ */
+export function hidePhysical(): Action {
+	return {
+		type: HIDE_PHYSICAL
 	};
 }
 

--- a/src/client/entity-editor/edition-section/actions.ts
+++ b/src/client/entity-editor/edition-section/actions.ts
@@ -39,6 +39,8 @@ export type Action = {
 };
 
 
+export const DISABLE_PHYSICAL = 'DISABLE_PHYSICAL';
+export const ENABLE_PHYSICAL = 'ENABLE_PHYSICAL';
 export const UPDATE_EDITION_GROUP = 'UPDATE_EDITION_GROUP';
 export const UPDATE_PUBLISHER = 'UPDATE_PUBLISHER';
 export const UPDATE_RELEASE_DATE = 'UPDATE_RELEASE_DATE';
@@ -50,8 +52,6 @@ export const UPDATE_PAGES = 'UPDATE_PAGES';
 export const UPDATE_WIDTH = 'UPDATE_WIDTH';
 export const UPDATE_HEIGHT = 'UPDATE_HEIGHT';
 export const UPDATE_DEPTH = 'UPDATE_DEPTH';
-export const SHOW_PHYSICAL = 'SHOW_PHYSICAL';
-export const HIDE_PHYSICAL = 'HIDE_PHYSICAL';
 export const TOGGLE_SHOW_EDITION_GROUP = 'TOGGLE_SHOW_EDITION_GROUP';
 export const UPDATE_WARN_IF_EDITION_GROUP_EXISTS = 'UPDATE_WARN_IF_EDITION_GROUP_EXISTS';
 
@@ -119,25 +119,25 @@ export function updateLanguages(newLanguages: Array<LanguageOption>): Action {
 
 /**
  * Produces an action indicating that the physical section of the edition
- * form should be shown.
+ * form should be editable.
  *
- * @returns {Action} The resulting SHOW_PHYSICAL action.
+ * @returns {Action} The resulting ENABLE_PHYSICAL action.
  */
-export function showPhysical(): Action {
+export function enablePhysical(): Action {
 	return {
-		type: SHOW_PHYSICAL
+		type: ENABLE_PHYSICAL
 	};
 }
 
 /**
  * Produces an action indicating that the physical section of the edition
- * form should be hidden.
+ * form should not be editable.
  *
- * @returns {Action} The resulting HIDE_PHYSICAL action.
+ * @returns {Action} The resulting DISABLE_PHYSICAL action.
  */
-export function hidePhysical(): Action {
+export function disablePhysical(): Action {
 	return {
-		type: HIDE_PHYSICAL
+		type: DISABLE_PHYSICAL
 	};
 }
 

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -26,8 +26,8 @@ import {
 	debouncedUpdateReleaseDate,
 	debouncedUpdateWeight,
 	debouncedUpdateWidth,
-	hidePhysical,
-	showPhysical,
+	disablePhysical,
+	enablePhysical,
 	toggleShowEditionGroup,
 	updateEditionGroup,
 	updateFormat,
@@ -105,7 +105,7 @@ type StateProps = {
 	heightValue: OptionalNumber,
 	languageValues: List<LanguageOption>,
 	pagesValue: OptionalNumber,
-	physicalVisible: OptionalBool,
+	physicalEnable: OptionalBool,
 	publisherValue: Map<string, any>,
 	editionGroupRequired: OptionalBool,
 	editionGroupVisible: OptionalBool,
@@ -175,7 +175,7 @@ function EditionSection({
 	onWeightChange,
 	onWidthChange,
 	pagesValue,
-	physicalVisible,
+	physicalEnable,
 	editionGroupRequired,
 	editionGroupValue,
 	editionGroupVisible,
@@ -377,12 +377,12 @@ function EditionSection({
 				</Col>
 			</Row>
 			{
-				physicalVisible &&
 				<Row>
 					<Col md={3} mdOffset={3}>
 						<NumericField
 							addonAfter="mm"
 							defaultValue={widthValue}
+							disabled={!physicalEnable}
 							empty={_.isNil(widthValue)}
 							error={!validateEditionSectionWidth(widthValue)}
 							label="Width"
@@ -391,6 +391,7 @@ function EditionSection({
 						<NumericField
 							addonAfter="mm"
 							defaultValue={heightValue}
+							disabled={!physicalEnable}
 							empty={_.isNil(heightValue)}
 							error={!validateEditionSectionHeight(heightValue)}
 							label="Height"
@@ -401,6 +402,7 @@ function EditionSection({
 						<NumericField
 							addonAfter="g"
 							defaultValue={weightValue}
+							disabled={!physicalEnable}
 							empty={_.isNil(weightValue)}
 							error={!validateEditionSectionWeight(weightValue)}
 							label="Weight"
@@ -409,6 +411,7 @@ function EditionSection({
 						<NumericField
 							addonAfter="mm"
 							defaultValue={depthValue}
+							disabled={!physicalEnable}
 							empty={_.isNil(depthValue)}
 							error={!validateEditionSectionDepth(depthValue)}
 							label="Depth"
@@ -437,7 +440,7 @@ function mapStateToProps(rootState: RootState): StateProps {
 		languageValues: state.get('languages'),
 		matchingNameEditionGroups,
 		pagesValue: state.get('pages'),
-		physicalVisible: state.get('physicalVisible'),
+		physicalEnable: state.get('physicalEnable'),
 		publisherValue: state.get('publisher'),
 		releaseDateValue: state.get('releaseDate'),
 		statusValue: state.get('status'),
@@ -454,11 +457,11 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 		onEditionGroupChange: (value) => dispatch(updateEditionGroup(value)),
 		onFormatChange: (value: {value: number} | null) => {
 			dispatch(updateFormat(value && value.value));
-			if (value.value === 3 || value.value === 5) {
-				dispatch(hidePhysical());
+			if (value.value === 3) {
+				dispatch(disablePhysical());
 			}
 			else {
-				dispatch(showPhysical());
+				dispatch(enablePhysical());
 			}
 		},
 		onHeightChange: (event) => dispatch(debouncedUpdateHeight(

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -27,6 +27,7 @@ import {
 	debouncedUpdateWeight,
 	debouncedUpdateWidth,
 	showPhysical,
+	hidePhysical,
 	toggleShowEditionGroup,
 	updateEditionGroup,
 	updateFormat,
@@ -122,7 +123,6 @@ type DispatchProps = {
 	onHeightChange: (arg: React.ChangeEvent<HTMLInputElement>) => unknown,
 	onLanguagesChange: (arg: Array<LanguageOption>) => unknown,
 	onPagesChange: (arg: React.ChangeEvent<HTMLInputElement>) => unknown,
-	onPhysicalButtonClick: () => unknown,
 	onPublisherChange: (arg: Publisher) => unknown,
 	onToggleShowEditionGroupSection: (showEGSection: boolean) => unknown,
 	onEditionGroupChange: (arg: EditionGroup) => unknown,
@@ -166,7 +166,6 @@ function EditionSection({
 	onDepthChange,
 	onFormatChange,
 	onHeightChange,
-	onPhysicalButtonClick,
 	onReleaseDateChange,
 	onPagesChange,
 	onToggleShowEditionGroupSection,
@@ -365,6 +364,18 @@ function EditionSection({
 					</CustomInput>
 				</Col>
 			</Row>
+			<Row>
+				<Col md={3} mdOffset={3}>
+						<NumericField
+							addonAfter="pages"
+							defaultValue={pagesValue}
+							empty={_.isNil(pagesValue)}
+							error={!validateEditionSectionPages(pagesValue)}
+							label="Page Count"
+							onChange={onPagesChange}
+						/>
+				</Col>
+			</Row>
 			{
 				physicalVisible &&
 				<Row>
@@ -385,14 +396,6 @@ function EditionSection({
 							label="Height"
 							onChange={onHeightChange}
 						/>
-						<NumericField
-							addonAfter="mm"
-							defaultValue={depthValue}
-							empty={_.isNil(depthValue)}
-							error={!validateEditionSectionDepth(depthValue)}
-							label="Depth"
-							onChange={onDepthChange}
-						/>
 					</Col>
 					<Col md={3}>
 						<NumericField
@@ -404,26 +407,13 @@ function EditionSection({
 							onChange={onWeightChange}
 						/>
 						<NumericField
-							addonAfter="pages"
-							defaultValue={pagesValue}
-							empty={_.isNil(pagesValue)}
-							error={!validateEditionSectionPages(pagesValue)}
-							label="Page Count"
-							onChange={onPagesChange}
+							addonAfter="mm"
+							defaultValue={depthValue}
+							empty={_.isNil(depthValue)}
+							error={!validateEditionSectionDepth(depthValue)}
+							label="Depth"
+							onChange={onDepthChange}
 						/>
-					</Col>
-				</Row>
-			}
-			{
-				!physicalVisible &&
-				<Row>
-					<Col className="text-center" md={4} mdOffset={4}>
-						<Button
-							bsStyle="link"
-							onClick={onPhysicalButtonClick}
-						>
-							Add physical data…
-						</Button>
 					</Col>
 				</Row>
 			}
@@ -462,8 +452,14 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 			event.target.value ? parseInt(event.target.value, 10) : null
 		)),
 		onEditionGroupChange: (value) => dispatch(updateEditionGroup(value)),
-		onFormatChange: (value: {value: number} | null) =>
-			dispatch(updateFormat(value && value.value)),
+		onFormatChange: (value: {value: number} | null) => {
+			dispatch(updateFormat(value && value.value))
+			if(value.value === 3 || value.value === 5) {
+				dispatch(hidePhysical())
+			} else {
+				dispatch(showPhysical())
+			}
+		},	
 		onHeightChange: (event) => dispatch(debouncedUpdateHeight(
 			event.target.value ? parseInt(event.target.value, 10) : null
 		)),
@@ -472,7 +468,6 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 		onPagesChange: (event) => dispatch(debouncedUpdatePages(
 			event.target.value ? parseInt(event.target.value, 10) : null
 		)),
-		onPhysicalButtonClick: () => dispatch(showPhysical()),
 		onPublisherChange: (value) => dispatch(updatePublisher(value)),
 		onReleaseDateChange: (releaseDate) =>
 			dispatch(debouncedUpdateReleaseDate(releaseDate)),

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -376,50 +376,48 @@ function EditionSection({
 					/>
 				</Col>
 			</Row>
-			{
-				<Row>
-					<Col md={3} mdOffset={3}>
-						<NumericField
-							addonAfter="mm"
-							defaultValue={widthValue}
-							disabled={!physicalEnable}
-							empty={_.isNil(widthValue)}
-							error={!validateEditionSectionWidth(widthValue)}
-							label="Width"
-							onChange={onWidthChange}
-						/>
-						<NumericField
-							addonAfter="mm"
-							defaultValue={heightValue}
-							disabled={!physicalEnable}
-							empty={_.isNil(heightValue)}
-							error={!validateEditionSectionHeight(heightValue)}
-							label="Height"
-							onChange={onHeightChange}
-						/>
-					</Col>
-					<Col md={3}>
-						<NumericField
-							addonAfter="g"
-							defaultValue={weightValue}
-							disabled={!physicalEnable}
-							empty={_.isNil(weightValue)}
-							error={!validateEditionSectionWeight(weightValue)}
-							label="Weight"
-							onChange={onWeightChange}
-						/>
-						<NumericField
-							addonAfter="mm"
-							defaultValue={depthValue}
-							disabled={!physicalEnable}
-							empty={_.isNil(depthValue)}
-							error={!validateEditionSectionDepth(depthValue)}
-							label="Depth"
-							onChange={onDepthChange}
-						/>
-					</Col>
-				</Row>
-			}
+			<Row>
+				<Col md={3} mdOffset={3}>
+					<NumericField
+						addonAfter="mm"
+						defaultValue={widthValue}
+						disabled={!physicalEnable}
+						empty={_.isNil(widthValue)}
+						error={!validateEditionSectionWidth(widthValue)}
+						label="Width"
+						onChange={onWidthChange}
+					/>
+					<NumericField
+						addonAfter="mm"
+						defaultValue={heightValue}
+						disabled={!physicalEnable}
+						empty={_.isNil(heightValue)}
+						error={!validateEditionSectionHeight(heightValue)}
+						label="Height"
+						onChange={onHeightChange}
+					/>
+				</Col>
+				<Col md={3}>
+					<NumericField
+						addonAfter="g"
+						defaultValue={weightValue}
+						disabled={!physicalEnable}
+						empty={_.isNil(weightValue)}
+						error={!validateEditionSectionWeight(weightValue)}
+						label="Weight"
+						onChange={onWeightChange}
+					/>
+					<NumericField
+						addonAfter="mm"
+						defaultValue={depthValue}
+						disabled={!physicalEnable}
+						empty={_.isNil(depthValue)}
+						error={!validateEditionSectionDepth(depthValue)}
+						label="Depth"
+						onChange={onDepthChange}
+					/>
+				</Col>
+			</Row>
 		</div>
 	);
 }

--- a/src/client/entity-editor/edition-section/edition-section.tsx
+++ b/src/client/entity-editor/edition-section/edition-section.tsx
@@ -26,8 +26,8 @@ import {
 	debouncedUpdateReleaseDate,
 	debouncedUpdateWeight,
 	debouncedUpdateWidth,
-	showPhysical,
 	hidePhysical,
+	showPhysical,
 	toggleShowEditionGroup,
 	updateEditionGroup,
 	updateFormat,
@@ -366,14 +366,14 @@ function EditionSection({
 			</Row>
 			<Row>
 				<Col md={3} mdOffset={3}>
-						<NumericField
-							addonAfter="pages"
-							defaultValue={pagesValue}
-							empty={_.isNil(pagesValue)}
-							error={!validateEditionSectionPages(pagesValue)}
-							label="Page Count"
-							onChange={onPagesChange}
-						/>
+					<NumericField
+						addonAfter="pages"
+						defaultValue={pagesValue}
+						empty={_.isNil(pagesValue)}
+						error={!validateEditionSectionPages(pagesValue)}
+						label="Page Count"
+						onChange={onPagesChange}
+					/>
 				</Col>
 			</Row>
 			{
@@ -453,13 +453,14 @@ function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
 		)),
 		onEditionGroupChange: (value) => dispatch(updateEditionGroup(value)),
 		onFormatChange: (value: {value: number} | null) => {
-			dispatch(updateFormat(value && value.value))
-			if(value.value === 3 || value.value === 5) {
-				dispatch(hidePhysical())
-			} else {
-				dispatch(showPhysical())
+			dispatch(updateFormat(value && value.value));
+			if (value.value === 3 || value.value === 5) {
+				dispatch(hidePhysical());
 			}
-		},	
+			else {
+				dispatch(showPhysical());
+			}
+		},
 		onHeightChange: (event) => dispatch(debouncedUpdateHeight(
 			event.target.value ? parseInt(event.target.value, 10) : null
 		)),

--- a/src/client/entity-editor/edition-section/reducer.ts
+++ b/src/client/entity-editor/edition-section/reducer.ts
@@ -21,8 +21,8 @@ import * as Immutable from 'immutable';
 
 import {
 	Action,
-	HIDE_PHYSICAL,
-	SHOW_PHYSICAL,
+	DISABLE_PHYSICAL,
+	ENABLE_PHYSICAL,
 	TOGGLE_SHOW_EDITION_GROUP,
 	UPDATE_DEPTH,
 	UPDATE_EDITION_GROUP,
@@ -45,7 +45,7 @@ function reducer(
 	state: State = Immutable.Map({
 		format: null,
 		languages: Immutable.List([]),
-		physicalVisible: true,
+		physicalEnable: true,
 		publisher: null,
 		releaseDate: '',
 		status: null
@@ -54,10 +54,10 @@ function reducer(
 ): State {
 	const {type, payload} = action;
 	switch (type) {
-		case SHOW_PHYSICAL:
-			return state.set('physicalVisible', true);
-		case HIDE_PHYSICAL:
-			return state.set('physicalVisible', false);
+		case ENABLE_PHYSICAL:
+			return state.set('physicalEnable', true);
+		case DISABLE_PHYSICAL:
+			return state.set('physicalEnable', false);
 		case TOGGLE_SHOW_EDITION_GROUP:
 			return state.set('editionGroupVisible', payload);
 		case UPDATE_LANGUAGES:

--- a/src/client/entity-editor/edition-section/reducer.ts
+++ b/src/client/entity-editor/edition-section/reducer.ts
@@ -21,6 +21,7 @@ import * as Immutable from 'immutable';
 
 import {
 	Action,
+	HIDE_PHYSICAL,
 	SHOW_PHYSICAL,
 	TOGGLE_SHOW_EDITION_GROUP,
 	UPDATE_DEPTH,
@@ -54,6 +55,8 @@ function reducer(
 	switch (type) {
 		case SHOW_PHYSICAL:
 			return state.set('physicalVisible', true);
+		case HIDE_PHYSICAL:
+			return state.set('physicalVisible', false);
 		case TOGGLE_SHOW_EDITION_GROUP:
 			return state.set('editionGroupVisible', payload);
 		case UPDATE_LANGUAGES:

--- a/src/client/entity-editor/edition-section/reducer.ts
+++ b/src/client/entity-editor/edition-section/reducer.ts
@@ -45,6 +45,7 @@ function reducer(
 	state: State = Immutable.Map({
 		format: null,
 		languages: Immutable.List([]),
+		physicalVisible: true,
 		publisher: null,
 		releaseDate: '',
 		status: null


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR deals with BB-621 .

### Solution
<!-- What does this PR do to fix the problem? -->
The "page count" field has been taken out of the "physical data" section, i.e., it will be available even if the physical data section is disabled. If eBook is chosen, the physical data section will be disabled. "physical data" section have been fixed into the default editing flow, i.e, the button for showing it has been removed.

https://user-images.githubusercontent.com/56965261/117302540-60ab4b00-ae99-11eb-9173-5716e49f5dae.mov




### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
modified:   src/client/entity-editor/edition-section/edition-section.tsx
modified:   src/client/entity-editor/edition-section/reducer.ts
modified:   src/client/entity-editor/edition-section/actions.ts

Initially we used SHOW_PHYSICAL actions to make changes to the physicalVisible flag. Now, I have changed its name to ENABLE_PHYSICAL and added one more action DISABLE_PHYSICAL. The name of the flag has been changed to physicalEnable.







