### PR TITLE
feat(elasticSearch): search entities by identifiers

### DIFF
--- a/src/common/helpers/search.js
+++ b/src/common/helpers/search.js
@@ -86,7 +86,7 @@ async function _fetchEntityModelsForESResults(orm, results) {
 		// Regular entity
 		const model = commonUtils.getEntityModelByType(orm, entityStub.type);
 		const entity = await model.forge({bbid: entityStub.bbid})
-			.fetch({require: false, withRelated: ['defaultAlias.language', 'disambiguation', 'aliasSet.aliases']});
+			.fetch({require: false, withRelated: ['defaultAlias.language', 'disambiguation', 'aliasSet.aliases', 'identifierSet.identifiers']});
 
 		return entity?.toJSON();
 	})).catch(err => log.error(err));
@@ -332,7 +332,8 @@ export async function generateIndex(orm) {
 		'annotation',
 		'disambiguation',
 		'defaultAlias',
-		'aliasSet.aliases'
+		'aliasSet.aliases',
+		'identifierSet.identifiers'
 	];
 
 	const entityBehaviors = [
@@ -480,7 +481,8 @@ export function searchByName(orm, name, type, size, from) {
 					fields: [
 						'aliasSet.aliases.name^3',
 						'aliasSet.aliases.name.search',
-						'disambiguation.comment'
+						'disambiguation.comment',
+						'identifierSet.identifiers.value'
 					],
 					minimum_should_match: '80%',
 					query: name,


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Allow searching by enitity identifiers
This PR Fixes: [BB-616](https://tickets.metabrainz.org/projects/BB/issues/BB-616?filter=allissues)



### Solution
<!-- What does this PR do to fix the problem? -->
Added identifiers to elasticSearch index and match query.




Searching **H. P. Lovecraft** using it's VIAF identifier ID **66470391**
### Before
![Screenshot from 2021-05-05 12-58-11](https://user-images.githubusercontent.com/55311336/117109370-2e6af200-ada2-11eb-98c1-fe6c5a851f56.png)

### After

![Screenshot from 2021-05-05 12-57-43](https://user-images.githubusercontent.com/55311336/117109349-2612b700-ada2-11eb-8ca2-db060539bddf.png)





### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

- [helpers/search.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/common/helpers/search.js)
