### PR TITLE
fix(BB-405):Search: Tabulated results columns have dynamic width

### DIFF
--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -97,8 +97,7 @@ table {
 	table-layout: fixed;
 }
 table td {
-	text-overflow: ellipsis;
-	overflow: hidden;
+	word-break: break-word;
 }
 .whole-page-form {
 	margin-top: 3em;

--- a/src/client/stylesheets/style.less
+++ b/src/client/stylesheets/style.less
@@ -93,6 +93,13 @@ body {
 
 /* Site-wide styling */
 /* ================= */
+table {
+	table-layout: fixed;
+}
+table td {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
 .whole-page-form {
 	margin-top: 3em;
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
This PR deals with https://tickets.metabrainz.org/browse/BB-405


### Solution
<!-- What does this PR do to fix the problem? -->
Added some css to fix the layout of all tables, as this problem also occurs in other places where table is used.

BEFORE:
![searchcolumn-initial](https://user-images.githubusercontent.com/56965261/117324008-06b48080-aead-11eb-983c-b0687d5b84a9.png)


AFTER:
![SearchColumnsImproved](https://user-images.githubusercontent.com/56965261/117327074-dcb08d80-aeaf-11eb-8db9-a71195af43de.png)





### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->

Modified: src/client/stylesheets/style.less
