### PR TITLE
FIX:  Alignment of Achievement Title

### DIFF
--- a/src/client/components/pages/parts/editor-profile.js
+++ b/src/client/components/pages/parts/editor-profile.js
@@ -170,7 +170,7 @@ class EditorProfileTab extends React.Component {
 								<p className="text-center">
 									{model.achievement.name}
 								</p>
-								<p className="text=center">
+								<p className="text-center">
 									{model.achievement.description}
 								</p>
 								<p className="text-center">


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
The **alignment** of achievement title is not **center** aligned because of a small typo in the code.
![Screenshot from 2021-05-08 21-26-50](https://user-images.githubusercontent.com/55311336/117547999-1b7d4980-b050-11eb-95c0-2c4618792c4f.png)


### Solution
<!-- What does this PR do to fix the problem? -->
Fixed the incorrent classname `text=center`
![Screenshot from 2021-05-08 21-27-09](https://user-images.githubusercontent.com/55311336/117548024-52ebf600-b050-11eb-8924-18153104ebd5.png)


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
- [editor-profile.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/client/components/pages/parts/editor-profile.js)