### PR TITLE
Update Docker prod image to use Node v16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/node:10 as bookbrainz-base
+FROM metabrainz/node:16 as bookbrainz-base
 
 ARG DEPLOY_ENV
 ARG GIT_COMMIT_SHA
@@ -6,6 +6,7 @@ ARG GIT_COMMIT_SHA
 ARG BUILD_DEPS=" \
     build-essential \
     python-dev \
+    libpq5 \
     libpq-dev"
 
 ARG RUN_DEPS=" \
@@ -22,7 +23,7 @@ RUN apt-get update && \
 # PostgreSQL client
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ENV PG_MAJOR 12
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Node 10 is end-of-life, so it's time to upgrade !
Chose to upgrade to Node 16 which will be LTS later this year.

Had to upgrade postgres-client version (jessie distribution not available anymore, see https://github.com/metabrainz/listenbrainz-server/commit/e9d4b804e72705b8527ec8d1603de7af28bb67ab) and install libpq5 package.

There has also been a change in how NPM runs as root in Docker, which required a couple of adjustments and making sure we run various commands as the right user
