### PR TITLE
fix: Collections page bug when no logged in user

### DIFF
--- a/src/client/components/pages/parts/collections-table.js
+++ b/src/client/components/pages/parts/collections-table.js
@@ -74,39 +74,41 @@ class CollectionsTable extends React.Component {
 				</MenuItem>
 			</DropdownButton>
 		);
-		const newCollectionButton = (
-			<Button
-				bsStyle="warning"
-				className="margin-bottom-d5"
-				href="/collection/create"
-				type="button"
-			>
-				<FontAwesomeIcon icon={faPlus}/>
-				&nbsp;Create Collection
-			</Button>
-		);
 
+		let newCollectionButton;
 		// 1.Check if user is logged In if so checks the page ownerId with users id
 		// OR
 		// 2.Check if user is logged In if so checks the page is central public collections page or not
-		const showNewCollectionButton = (user && user.id === ownerId) ||
-		(user && !ownerId);
+		if (user && (user.id === ownerId || !ownerId)) {
+			newCollectionButton = (
+				<Button
+					bsStyle="warning"
+					className="margin-bottom-d5"
+					href="/collection/create"
+					type="button"
+				>
+					<FontAwesomeIcon icon={faPlus}/>
+					&nbsp;Create Collection
+				</Button>
+			);
+		}
 
-		const myCollectionButton = (
-			<Button
-				bsStyle="success"
-				className="margin-bottom-d5"
-				href={`/editor/${user.id}/collections`}
-				type="button"
-			>
-				My Collections
-			</Button>
-		);
-
-		// Display My collections button when
+		let myCollectionButton;
+		// Display "My collections" button when
 		// 1.the user is logged in and not viewing the user's collections
 		// 2.the user is logged in and viewing public collections
-		const showMyCollectionButton = user && (user.id !== ownerId || !ownerId);
+		if (user && (!ownerId || user.id !== ownerId)) {
+			myCollectionButton = (
+				<Button
+					bsStyle="success"
+					className="margin-bottom-d5"
+					href={`/editor/${user.id}/collections`}
+					type="button"
+				>
+					My Collections
+				</Button>
+			);
+		}
 
 		return (
 			<div>
@@ -115,10 +117,8 @@ class CollectionsTable extends React.Component {
 						{tableHeading}
 					</h1>
 					<div className="collection-page-buttons">
-				        {showMyCollectionButton &&
-							myCollectionButton}
-						{showNewCollectionButton &&
-							newCollectionButton}
+				        {myCollectionButton}
+						{newCollectionButton}
 						{entityTypeSelect}
 					</div>
 				</div>


### PR DESCRIPTION
A bug was introduced in PR #592 when the template string `/editor/${user.id}/collections` would throw an error if no user is logged in ("Cannot read property 'id' of null")

Refactored these buttons to only be defined if the relevant conditions apply, rather than having a separate boolean to determine if they should be shown (while creating the button every time nonetheless)