### PR TITLE
NPM lockfile update issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "morgan": "^1.10.0",
         "nodemailer": "^6.5.0",
         "passport": "^0.4.1",
-        "passport-musicbrainz-oauth2": "github:LordSputnik/passport-musicbrainz-oauth2",
+        "passport-musicbrainz-oauth2": "https://github.com/LordSputnik/passport-musicbrainz-oauth2.git",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-bootstrap": "^0.33.1",
@@ -34183,7 +34183,7 @@
     },
     "passport-musicbrainz-oauth2": {
       "version": "git+ssh://git@github.com/LordSputnik/passport-musicbrainz-oauth2.git#695f1cd35b0e4ae63472cc3ad4af50cf7bdecd26",
-      "from": "passport-musicbrainz-oauth2@github:LordSputnik/passport-musicbrainz-oauth2",
+      "from": "passport-musicbrainz-oauth2@https://github.com/LordSputnik/passport-musicbrainz-oauth2.git",
       "requires": {
         "lodash.defaults": "^4.0.1",
         "passport-oauth2": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "morgan": "^1.10.0",
     "nodemailer": "^6.5.0",
     "passport": "^0.4.1",
-    "passport-musicbrainz-oauth2": "github:LordSputnik/passport-musicbrainz-oauth2",
+    "passport-musicbrainz-oauth2": "https://github.com/LordSputnik/passport-musicbrainz-oauth2.git",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-bootstrap": "^0.33.1",


### PR DESCRIPTION
### Edit: Nope, that hasn't fixed the issue. I'm going to revert the package-lock file version (regenerate it with Node 14/NPM 6 and re-commit) and wait until the issue is fixed or a good solution appears.


After updating to Node 16 and NPM v7 (and committing a package-lock.json file with `lockfileVersion: 2`), I'm hitting an issue in CI with a package we install from Github: https://github.com/npm/cli/issues/2610
The issue occurs on Node v14.17.0 / NPM v6.14.13 but not on [Node 16/ NPM 7](https://travis-ci.org/github/bookbrainz/bookbrainz-site/jobs/771783859)

The issue is that generating the lockfile locally sets the package in the lockfile to be downloaded with SSH, which isn't available in CI environment.

For an example of the breaking CI: https://travis-ci.org/github/bookbrainz/bookbrainz-site/jobs/771783860
```
/usr/bin/git ls-remote -h -t ssh://git@github.com/LordSputnik/passport-musicbrainz-oauth2.git
npm ERR! 
npm ERR! Warning: Permanently added the RSA host key for IP address '140.82.112.4' to the list of known hosts.
npm ERR! Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
```