### PR TITLE
[BB-592]-1: Fix alias language diff formatter

### DIFF
--- a/src/server/helpers/diffFormatters/entity.js
+++ b/src/server/helpers/diffFormatters/entity.js
@@ -96,7 +96,7 @@ function formatAliasModified(change) {
 
 	const REQUIRED_DEPTH = 4;
 	const aliasLanguageChanged =
-		change.path.length > REQUIRED_DEPTH && change.path[3] === 'language' &&
+		change.path.length >= REQUIRED_DEPTH && change.path[3] === 'language' &&
 		change.path[4] === 'name';
 	if (aliasLanguageChanged) {
 		return [
@@ -108,7 +108,7 @@ function formatAliasModified(change) {
 		];
 	}
 
-	if (change.path.length > 3 && change.path[3] === 'primary') {
+	if (change.path.length >= 3 && change.path[3] === 'primary') {
 		return [
 			base.formatChange(
 				change,


### PR DESCRIPTION
Part of the issue [BB-592] is that the path length comparison used to determine if an alias language has changed excluded language name changes.

I believe this partly replaces #603, although I am seeing another issue: when doing the diff between revisions, sometimes the alias language properties are attached to the revision and some other times not, which breaks the diff.
In particular this PR does not solve the issue of the link in the description of BB-592.

Before:
![image](https://user-images.githubusercontent.com/6179856/120845938-c3b00080-c571-11eb-956b-1c5f32af1788.png)

After:
![image](https://user-images.githubusercontent.com/6179856/120845950-c7438780-c571-11eb-94fe-974ae23f93bc.png)
