### PR TITLE
fix(revision): show type changes in revision page

### DIFF
--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -76,7 +76,15 @@ export function formatEndedChange(change) {
 }
 
 export function formatTypeChange(change, label) {
-	return formatChange(change, label, (side) => (typeof side === 'string' ? [side] : side && [side.label]));
+	// eslint-disable-next-line consistent-return
+	return formatChange(change, label, (side) => {
+		if (typeof side === 'string') {
+			return [side];
+		 }
+		 else if (side) {
+			 return [side.label];
+		 }
+	});
 }
 
 export function formatScalarChange(change, label) {

--- a/src/server/helpers/diffFormatters/base.js
+++ b/src/server/helpers/diffFormatters/base.js
@@ -76,7 +76,7 @@ export function formatEndedChange(change) {
 }
 
 export function formatTypeChange(change, label) {
-	return formatChange(change, label, (side) => side && [side.label]);
+	return formatChange(change, label, (side) => (typeof side === 'string' ? [side] : side && [side.label]));
 }
 
 export function formatScalarChange(change, label) {

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -58,8 +58,8 @@ function formatAuthorChange(change) {
 	if (_.isEqual(change.path, ['ended'])) {
 		return baseFormatter.formatEndedChange(change);
 	}
-
-	if (_.isEqual(change.path, ['authorType'])) {
+	if (_.isEqual(change.path, ['authorType']) ||
+			_.isEqual(change.path, ['authorType', 'label'])) {
 		return baseFormatter.formatTypeChange(change, 'Author Type');
 	}
 
@@ -106,11 +106,13 @@ function formatEditionChange(change) {
 		return baseFormatter.formatScalarChange(change, 'Page Count');
 	}
 
-	if (_.isEqual(change.path, ['editionFormat'])) {
+	if (_.isEqual(change.path, ['editionFormat']) ||
+			_.isEqual(change.path, ['editionFormat', 'label'])) {
 		return baseFormatter.formatTypeChange(change, 'Edition Format');
 	}
 
-	if (_.isEqual(change.path, ['editionStatus'])) {
+	if (_.isEqual(change.path, ['editionStatus']) ||
+			_.isEqual(change.path, ['editionStatus', 'label'])) {
 		return baseFormatter.formatTypeChange(change, 'Edition Status');
 	}
 
@@ -129,8 +131,8 @@ function formatPublisherChange(change) {
 	if (_.isEqual(change.path, ['ended'])) {
 		return baseFormatter.formatEndedChange(change);
 	}
-
-	if (_.isEqual(change.path, ['publisherType'])) {
+	if (_.isEqual(change.path, ['publisherType']) ||
+			_.isEqual(change.path, ['publisherType', 'label'])) {
 		return baseFormatter.formatTypeChange(change, 'Publisher Type');
 	}
 
@@ -146,8 +148,8 @@ function formatWorkChange(change) {
 	if (languageSetFormatter.changed(change)) {
 		return languageSetFormatter.format(change);
 	}
-
-	if (_.isEqual(change.path, ['workType'])) {
+	if (_.isEqual(change.path, ['workType']) ||
+			_.isEqual(change.path, ['workType', 'label'])) {
 		return baseFormatter.formatTypeChange(change, 'Work Type');
 	}
 
@@ -155,7 +157,8 @@ function formatWorkChange(change) {
 }
 
 function formatEditionGroupChange(change) {
-	if (_.isEqual(change.path, ['editionGroupType'])) {
+	if (_.isEqual(change.path, ['editionGroupType']) ||
+			_.isEqual(change.path, ['editionGroupType', 'label'])) {
 		return baseFormatter.formatTypeChange(change, 'Edition Group Type');
 	}
 

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -59,7 +59,7 @@ function formatAuthorChange(change) {
 		return baseFormatter.formatEndedChange(change);
 	}
 
-	if (_.isEqual(change.path, ['type'])) {
+	if (_.isEqual(change.path, ['authorType'])) {
 		return baseFormatter.formatTypeChange(change, 'Author Type');
 	}
 
@@ -130,7 +130,7 @@ function formatPublisherChange(change) {
 		return baseFormatter.formatEndedChange(change);
 	}
 
-	if (_.isEqual(change.path, ['type'])) {
+	if (_.isEqual(change.path, ['publisherType'])) {
 		return baseFormatter.formatTypeChange(change, 'Publisher Type');
 	}
 
@@ -147,7 +147,7 @@ function formatWorkChange(change) {
 		return languageSetFormatter.format(change);
 	}
 
-	if (_.isEqual(change.path, ['type'])) {
+	if (_.isEqual(change.path, ['workType'])) {
 		return baseFormatter.formatTypeChange(change, 'Work Type');
 	}
 
@@ -155,7 +155,7 @@ function formatWorkChange(change) {
 }
 
 function formatEditionGroupChange(change) {
-	if (_.isEqual(change.path, ['type'])) {
+	if (_.isEqual(change.path, ['editionGroupType'])) {
 		return baseFormatter.formatTypeChange(change, 'Edition Group Type');
 	}
 


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Revisions for **workType, authorType, publisherType, editionGroupType, editionFormat and editionStatus** are not shown in the revision page.


### Solution
<!-- What does this PR do to fix the problem? -->

- Fixed some incorrect path name.
- Modified formatChange function and conditional statement.

### Screenshot:
<details>

<summary>1</summary>

# New

### Before
![Screenshot from 2021-07-02 11-51-59](https://user-images.githubusercontent.com/55311336/124229967-08f12f00-db2c-11eb-9c9f-499d5304482b.png)

### After
![Screenshot from 2021-07-02 11-49-39](https://user-images.githubusercontent.com/55311336/124229989-0ee71000-db2c-11eb-9cd9-c68e1b1b7870.png)

</details>



<details>

<summary>2</summary>

# Edited

### Before
![Screenshot from 2021-07-02 11-52-07](https://user-images.githubusercontent.com/55311336/124230015-1a3a3b80-db2c-11eb-906e-3d51038d656c.png)

### After
![Screenshot from 2021-07-02 11-57-00](https://user-images.githubusercontent.com/55311336/124230455-a64c6300-db2c-11eb-81c2-e52487aa2c3e.png)

</details>

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
- [diffFormatters/base.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/server/helpers/diffFormatters/base.js)
- [routes/revision.js](https://github.com/bookbrainz/bookbrainz-site/blob/master/src/server/routes/revision.js)