### PR TITLE
FIX: Allow sorting with numeric value

### DIFF
--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -89,6 +89,7 @@ export function sortRelationshipOrdinal(sortByProperty: string) {
 	return (a:string, b:string) => {
 		a = a[sortByProperty] || '';
 		b = b[sortByProperty] || '';
-		return a.localeCompare(b);
+		// eslint-disable-next-line no-undefined
+		return a.localeCompare(b, undefined, {numeric: true});
 	};
 }


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
https://github.com/bookbrainz/bookbrainz-site/pull/690#discussion_r690578719

### Solution
<!-- What does this PR do to fix the problem? -->

Pass **`{numeric: true}`** option to **localeCompare.**

#### Numeric sorting
```
// by default, "2" > "10"
console.log("2".localeCompare("10")); // 1

// numeric using options:
console.log("2".localeCompare("10", undefined, {numeric: true})); // -1
```

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
https://github.com/bookbrainz/bookbrainz-site/blob/series-entity/src/common/helpers/utils.ts