### PR TITLE
FIX: Do not mutate the relationshipsTypes array.

### DIFF
--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -118,13 +118,14 @@ export function generateRelationshipSelection(
 }
 
 function getValidOtherEntityTypes(
-	relationshipTypes: Array<RelationshipType>,
+	relTypes: Array<RelationshipType>,
 	baseEntity: Entity
 ) {
+	let relationshipTypes = relTypes;
 	if (baseEntity.type === 'Series') {
 		// When the base entity is Series, remove relationship type 70 - 74.
 		// We don't want to generate entity types corresponding to these relationship type.
-		_.remove(relationshipTypes, (type) => type.id > 69 && type.id < 75);
+		relationshipTypes = relationshipTypes.filter(relationshipType => !(relationshipType.id > 69 && relationshipType.id < 75));
 	}
 	const validEntityTypes = relationshipTypes.map((relationshipType) => {
 		if (relationshipType.deprecated === true) {


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
> **`Uncaught TypeError: Cannot set property 'attributes' of undefined`**

**Steps to reproduce:**

1) Navigate to  `/series/create` endpoint.
2) Add a relationship.
3) Then add a series item. 

#### Cause:
When you add a relationship, **relationshipTypes** array gets mutated [here](https://github.com/bookbrainz/bookbrainz-site/blob/series-entity/src/client/entity-editor/relationship-editor/relationship-editor.tsx#L124-L128) and the relationship type 69-74 is permanently removed. So when you come back to the series editor and tries to add a item to the series, the relationship type 69-74 is not present this time in the **relationshipTypes** array [here](https://github.com/bookbrainz/bookbrainz-site/blob/series-entity/src/client/entity-editor/series-section/series-editor.tsx#L154), hence leading to an error. 


### Solution
<!-- What does this PR do to fix the problem? -->
Do not mutate the **relationshipsTypes** array. 


### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
https://github.com/bookbrainz/bookbrainz-site/blob/series-entity/src/client/entity-editor/relationship-editor/relationship-editor.tsx
