### PR TITLE
FIX: Sorting does not work when there are many items

### DIFF
--- a/src/client/entity-editor/helpers.ts
+++ b/src/client/entity-editor/helpers.ts
@@ -25,6 +25,7 @@ import EditionSection from './edition-section/edition-section';
 import EditionSectionMerge from './edition-section/edition-section-merge';
 import PublisherSection from './publisher-section/publisher-section';
 import PublisherSectionMerge from './publisher-section/publisher-section-merge';
+import { RelationshipForDisplay } from './relationship-editor/types';
 import SeriesSection from './series-section/series-section';
 import SeriesSectionMerge from './series-section/series-section-merge';
 import WorkSection from './work-section/work-section';
@@ -152,7 +153,7 @@ export function shouldDevToolsBeInjected(): boolean {
  *
  * @param {Array} relationships the array of relationships
  */
-export function attachAttribToRelForDisplay(relationships) {
+export function attachAttribToRelForDisplay(relationships: RelationshipForDisplay[]) {
 	relationships.forEach((relationship) => {
 		relationship.attributes.forEach(attribute => {
 			const attributeName = getAttributeName(attribute.attributeType);

--- a/src/client/entity-editor/helpers.ts
+++ b/src/client/entity-editor/helpers.ts
@@ -36,6 +36,7 @@ import buttonBarReducer from './button-bar/reducer';
 import {combineReducers} from 'redux-immutable';
 import editionGroupSectionReducer from './edition-group-section/reducer';
 import editionSectionReducer from './edition-section/reducer';
+import {getAttributeName} from './relationship-editor/helper';
 import identifierEditorReducer from './identifier-editor/reducer';
 import nameSectionReducer from './name-section/reducer';
 import publisherSectionReducer from './publisher-section/reducer';
@@ -143,4 +144,19 @@ export function shouldDevToolsBeInjected(): boolean {
 		typeof window === 'object' &&
 		(window as ReduxWindow).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
 	);
+}
+
+/**
+ * Takes an array of relationships and attach the deeply nested
+ * relationship attributes to the first level of the relationship object.
+ *
+ * @param {Array} relationships the array of relationships
+ */
+export function attachAttribToRelForDisplay(relationships) {
+	relationships.forEach((relationship) => {
+		relationship.attributes.forEach(attribute => {
+			const attributeName = getAttributeName(attribute.attributeType);
+			relationship[attributeName] = attribute.value.textValue;
+		});
+	});
 }

--- a/src/client/entity-editor/series-section/actions.ts
+++ b/src/client/entity-editor/series-section/actions.ts
@@ -20,6 +20,7 @@
 
 import type {Attribute, Relationship, RelationshipForDisplay} from '../relationship-editor/types';
 import arrayMove from 'array-move';
+import {attachAttribToRelForDisplay} from '../helpers';
 import {sortRelationshipOrdinal} from '../../../common/helpers/utils';
 
 
@@ -101,25 +102,20 @@ export function sortSeriesItems(oldIndex, newIndex):any {
 		const seriesItems = state.get('seriesSection').get('seriesItems');
 		const orderTypeValue = state.get('seriesSection').get('orderType');
 		const seriesItemsObject = seriesItems.toJS();
-		const seriesItemsArray = Object.values(seriesItemsObject);
-		const automaticSort = [];
-		let automaticSortedArr: Relationship[]; // stores the sorted array of series items(sorting performed on number)
-
+		const seriesItemsArray: RelationshipForDisplay[] = Object.values(seriesItemsObject);
+		attachAttribToRelForDisplay(seriesItemsArray);
 		if (orderTypeValue === 1) { // OrderType 1 for Automatic Ordering
-			seriesItemsArray.forEach((seriesItem: Relationship) => {
-				seriesItem.attributes.forEach((attribute: Attribute) => {
-					if (attribute.attributeType === 2) { // Attribute Type 2 for number
-						automaticSort.push({number: attribute.value.textValue, seriesItem});
-					}
-				});
-			});
-			automaticSort.sort(sortRelationshipOrdinal('number')); // sorts the array of series items on number attribute
-			automaticSortedArr = automaticSort.map(item => item.seriesItem);
+			seriesItemsArray.sort(sortRelationshipOrdinal('number')); // sorts the array of series items on number attribute
 		}
-
-		// eslint-disable-next-line max-len
-		const sortedSeriesItems = orderTypeValue === 1 ? arrayMove(automaticSortedArr, oldIndex, newIndex) : arrayMove(seriesItemsArray, oldIndex, newIndex);
-		sortedSeriesItems.forEach((seriesItem: Relationship, index: number) => {
+		else {
+		    seriesItemsArray.sort(sortRelationshipOrdinal('position'));
+		}
+		seriesItemsArray.forEach((seriesItem: any) => {
+			delete seriesItem.number;
+			delete seriesItem.position;
+		});
+		const sortedSeriesItems = arrayMove(seriesItemsArray, oldIndex, newIndex);
+		sortedSeriesItems.forEach((seriesItem: RelationshipForDisplay, index: number) => {
 			seriesItem.attributes.forEach((attribute: Attribute) => {
 				if (attribute.attributeType === 1) { // Attribute type 1 for position
 					attribute.value.textValue = `${index}`; // assigns the position value to the sorted series item array

--- a/src/client/entity-editor/series-section/reducer.ts
+++ b/src/client/entity-editor/series-section/reducer.ts
@@ -49,11 +49,14 @@ function reducer(
 		}
 		case SORT_SERIES_ITEM:
 			return state.set('seriesItems', Immutable.fromJS(action.payload));
-		case EDIT_SERIES_ITEM:
+		case EDIT_SERIES_ITEM: {
+			// index of number attribute in the attributes array
+			const index = state.getIn(['seriesItems', payload.rowID, 'attributes']).findIndex(attribute => attribute.get('attributeType') === 2);
 			return state.setIn(
-				['seriesItems', payload.rowID, 'attributes'],
-				Immutable.fromJS([...payload.data])
+				['seriesItems', payload.rowID, 'attributes', index],
+				Immutable.fromJS({...payload.data})
 			);
+		}
 		case REMOVE_SERIES_ITEM:
 			return state.deleteIn(['seriesItems', payload.rowID]);
 		// no default

--- a/src/client/entity-editor/series-section/series-editor.tsx
+++ b/src/client/entity-editor/series-section/series-editor.tsx
@@ -180,11 +180,7 @@ function SeriesEditor({baseEntity, relationshipTypes, seriesType, orderType, onR
 			attributeType: 2,
 			value: {textValue: value}
 		};
-		const attributePosition = {
-			attributeType: 1,
-			value: {textValue: null}
-		};
-		onEdit([attributePosition, attributeNumber], rowID);
+		onEdit(attributeNumber, rowID);
 		onSort({newIndex: null, oldIndex: null});
 	};
 	return (

--- a/src/client/entity-editor/series-section/series-section.tsx
+++ b/src/client/entity-editor/series-section/series-section.tsx
@@ -27,7 +27,9 @@ import type {Dispatch} from 'redux';
 import Select from 'react-select';
 import SeriesEditor from './series-editor';
 import _ from 'lodash';
+import {attachAttribToRelForDisplay} from '../helpers';
 import {connect} from 'react-redux';
+import {sortRelationshipOrdinal} from '../../../common/helpers/utils';
 
 
 type SeriesOrderingType = {
@@ -133,7 +135,14 @@ function SeriesSection({
 		});
 	}
 	const seriesItemsArray: Array<RelationshipForDisplay> = Object.values(seriesItemsObject);
-
+	attachAttribToRelForDisplay(seriesItemsArray);
+	// Sort the series items according to the ordering type before displaying
+	if (orderTypeValue === 2) {
+		seriesItemsArray.sort(sortRelationshipOrdinal('position'));
+	}
+	else {
+		seriesItemsArray.sort(sortRelationshipOrdinal('number'));
+	}
 	const seriesOrderingTypesForDisplay = seriesOrderingTypes.map((type) => ({
 		label: type.label,
 		value: type.id

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -1,3 +1,4 @@
+import {Relationship, RelationshipForDisplay} from '../../client/entity-editor/relationship-editor/types';
 
 /**
  * Regular expression for valid BookBrainz UUIDs (bbid)
@@ -86,10 +87,10 @@ export function makePromiseFromObject<T>(obj: Unresolved<T>): Promise<T> {
  */
 /* eslint-disable no-param-reassign */
 export function sortRelationshipOrdinal(sortByProperty: string) {
-	return (a:string, b:string) => {
-		a = a[sortByProperty] || '';
-		b = b[sortByProperty] || '';
+	return (a: RelationshipForDisplay | Relationship, b: RelationshipForDisplay | Relationship) => {
+		const value1 = a[sortByProperty] || '';
+		const value2 = b[sortByProperty] || '';
 		// eslint-disable-next-line no-undefined
-		return a.localeCompare(b, undefined, {numeric: true});
+		return value1.localeCompare(value2, undefined, {numeric: true});
 	};
 }

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -168,16 +168,6 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 	entityRoutes.updateDisplayedRevisions(req, res, next, SeriesRevision);
 });
 
-function formatRelationships(relationship) {
-	return {
-		attributeSetId: relationship.attributeSetId,
-		attributes: relationship.attributeSet ? relationship.attributeSet.relationshipAttributes : [],
-		relationshipType: relationship.type,
-		rowID: `n${relationship.id}`,
-		sourceEntity: relationship.source,
-		targetEntity: relationship.target
-	};
-}
 function seriesToFormState(series) {
 	const aliases = series.aliasSet ?
 		series.aliasSet.aliases.map(({languageId, ...rest}) => ({
@@ -228,24 +218,22 @@ function seriesToFormState(series) {
 		relationships: {}
 	};
 
-	const seriesItems = _.remove(series.relationships, (relationship) => relationship.typeId > 69 && relationship.typeId < 75);
-	seriesItems.forEach((seriesItem) => {
-		seriesItem.attributeSet.relationshipAttributes.forEach(attribute => {
-			seriesItem[`${attribute.type.name}`] = attribute.value.textValue;
-		});
-	});
-
-	if (series.seriesOrderingType.label === 'Manual') {
-		seriesItems.sort(sortRelationshipOrdinal('position'));
-	}
-	else {
-		seriesItems.sort(sortRelationshipOrdinal('number'));
-	}
-	seriesItems.forEach((seriesItem) => {
-		seriesSection.seriesItems[`n${seriesItem.id}`] = formatRelationships(seriesItem);
-	});
 	series.relationships.forEach((relationship) => {
-		relationshipSection.relationships[`n${relationship.id}`] = formatRelationships(relationship);
+		const formattedRelationship = {
+			attributeSetId: relationship.attributeSetId,
+			attributes: relationship.attributeSet ? relationship.attributeSet.relationshipAttributes : [],
+			relationshipType: relationship.type,
+			rowID: `n${relationship.id}`,
+			sourceEntity: relationship.source,
+			targetEntity: relationship.target
+		};
+		// separate series items from relationships
+		if (relationship.typeId > 69 && relationship.typeId < 75) {
+			seriesSection.seriesItems[`n${relationship.id}`] = formattedRelationship;
+		}
+		else {
+			relationshipSection.relationships[`n${relationship.id}`] = formattedRelationship;
+		}
 	});
 
 	const optionalSections = {};


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
Sorting isn't working as expected and undesirable results are observed when there are **more than 8** series items.

#### Cause: 
When an object is saved to the redux store in this order  **` { n3: { ... }, n2: { ... }, n1: { ... } }`** and when retrieved back , it is returned in a sorted order by default  **` { n1 { ... }, n2: { ... }, n3: { ... } }`**
### Solution
<!-- What does this PR do to fix the problem? -->

We need to  sort the items in the frontend here, once the object are converted to array.

