### PR TITLE
FIX: Disallow to add dissimilar entity to series

### DIFF
--- a/src/client/entity-editor/common/entity-search-field-option.js
+++ b/src/client/entity-editor/common/entity-search-field-option.js
@@ -97,6 +97,11 @@ class EntitySearchFieldOption extends React.Component {
 				type: this.props.type
 			});
 		const options = response.body.filter(entity => entity.bbid !== this.props.bbid);
+		if (this.props.isRelationshipEditor) {
+			const {baseEntity} = this.props;
+			// If series entities entityType doesn't match with the baseEntity type, remove them from the options.
+			_.remove(options, entity => entity.type === 'Series' && baseEntity.type !== entity.entityType);
+		}
 		return {
 			options: options.map(this.entityToOption)
 		};
@@ -122,9 +127,11 @@ class EntitySearchFieldOption extends React.Component {
 
 EntitySearchFieldOption.displayName = 'EntitySearchFieldOption';
 EntitySearchFieldOption.propTypes = {
+	baseEntity: PropTypes.object,
 	bbid: PropTypes.string,
 	empty: PropTypes.bool,
 	error: PropTypes.bool,
+	isRelationshipEditor: PropTypes.bool,
 	label: PropTypes.string.isRequired,
 	languageOptions: PropTypes.array,
 	tooltipText: PropTypes.string,
@@ -134,9 +141,11 @@ EntitySearchFieldOption.propTypes = {
 	]).isRequired
 };
 EntitySearchFieldOption.defaultProps = {
+	baseEntity: null,
 	bbid: null,
 	empty: true,
 	error: false,
+	isRelationshipEditor: false,
 	languageOptions: [],
 	tooltipText: null
 };

--- a/src/client/entity-editor/common/entity-search-field-option.js
+++ b/src/client/entity-editor/common/entity-search-field-option.js
@@ -96,14 +96,12 @@ class EntitySearchFieldOption extends React.Component {
 				q: manipulatedQuery,
 				type: this.props.type
 			});
-		const options = response.body.filter(entity => entity.bbid !== this.props.bbid);
-		if (this.props.isRelationshipEditor) {
-			const {baseEntity} = this.props;
-			// If series entities entityType doesn't match with the baseEntity type, remove them from the options.
-			_.remove(options, entity => entity.type === 'Series' && baseEntity.type !== entity.entityType);
-		}
+		const isSameBBIDFilter = (entity) => entity.bbid !== this.props.bbid;
+		const combineFilters = (...filters) => (item) => filters.map((filter) => filter(item)).every((x) => x === true);
+		const combinedFilters = combineFilters(isSameBBIDFilter, ...this.props.filters);
+		const filteredOptions = response.body.filter(combinedFilters);
 		return {
-			options: options.map(this.entityToOption)
+			options: filteredOptions.map(this.entityToOption)
 		};
 	}
 
@@ -127,11 +125,10 @@ class EntitySearchFieldOption extends React.Component {
 
 EntitySearchFieldOption.displayName = 'EntitySearchFieldOption';
 EntitySearchFieldOption.propTypes = {
-	baseEntity: PropTypes.object,
 	bbid: PropTypes.string,
 	empty: PropTypes.bool,
 	error: PropTypes.bool,
-	isRelationshipEditor: PropTypes.bool,
+	filters: PropTypes.array,
 	label: PropTypes.string.isRequired,
 	languageOptions: PropTypes.array,
 	tooltipText: PropTypes.string,
@@ -141,11 +138,10 @@ EntitySearchFieldOption.propTypes = {
 	]).isRequired
 };
 EntitySearchFieldOption.defaultProps = {
-	baseEntity: null,
 	bbid: null,
 	empty: true,
 	error: false,
-	isRelationshipEditor: false,
+	filters: [],
 	languageOptions: [],
 	tooltipText: null
 };

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -355,13 +355,17 @@ class RelationshipModal
 			</Button>
 		);
 		const bbid = this.props.baseEntity?.bbid;
+		// Filter out Series of a different entityType than the current entity.
+		// This ensures we don't add an entity of type X to a Series of entityType Y.
+		// For Example, a Work cannot be added to an Author Series.
+		const filterDifferentTypeSeries = (entity) => (entity.type === 'Series' ? baseEntity.type === entity.entityType : true);
+		const additionalFilters = [filterDifferentTypeSeries];
 		return (
 			<EntitySearchFieldOption
-				isRelationshipEditor
-				baseEntity={baseEntity}
 				bbid={bbid}
 				buttonAfter={openButton}
 				cache={false}
+				filters={additionalFilters}
 				instanceId="relationshipEntitySearchField"
 				label={label}
 				languageOptions={this.props.languageOptions}

--- a/src/client/entity-editor/relationship-editor/relationship-editor.tsx
+++ b/src/client/entity-editor/relationship-editor/relationship-editor.tsx
@@ -357,6 +357,8 @@ class RelationshipModal
 		const bbid = this.props.baseEntity?.bbid;
 		return (
 			<EntitySearchFieldOption
+				isRelationshipEditor
+				baseEntity={baseEntity}
 				bbid={bbid}
 				buttonAfter={openButton}
 				cache={false}


### PR DESCRIPTION
**Summary:**

Do not show **series** entities whose **`entityType`** is not same as the **`baseEntity.type`** in the search results of the relationship editor.