### PR TITLE
Fix[BB-458]: Showing error conflict page on deleting entity twice

### DIFF
--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -21,6 +21,7 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
@@ -142,6 +143,9 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+	if(!res.locals.entity.dataId){
+		return next(new ConflictError('This entity has already been deleted'));
+	}
 	_setAuthorTitle(res);
 	entityRoutes.displayDeleteEntity(req, res);
 });

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -142,7 +142,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 	entityRoutes.displayEntity(req, res);
 });
 
-router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
 	if(!res.locals.entity.dataId){
 		return next(new ConflictError('This entity has already been deleted'));
 	}

--- a/src/server/routes/entity/author.js
+++ b/src/server/routes/entity/author.js
@@ -21,7 +21,6 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
-import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
@@ -29,6 +28,7 @@ import {
 	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 
+import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
@@ -143,11 +143,11 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
-	if(!res.locals.entity.dataId){
+	if (!res.locals.entity.dataId) {
 		return next(new ConflictError('This entity has already been deleted'));
 	}
 	_setAuthorTitle(res);
-	entityRoutes.displayDeleteEntity(req, res);
+	return entityRoutes.displayDeleteEntity(req, res);
 });
 
 router.post(

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -21,6 +21,7 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
@@ -134,6 +135,9 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+	if(!res.locals.entity.dataId){
+		return next(new ConflictError('This entity has already been deleted'));
+	}
 	_setEditionGroupTitle(res);
 	entityRoutes.displayDeleteEntity(req, res);
 });

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -134,7 +134,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 	entityRoutes.displayEntity(req, res);
 });
 
-router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
 	if(!res.locals.entity.dataId){
 		return next(new ConflictError('This entity has already been deleted'));
 	}

--- a/src/server/routes/entity/edition-group.js
+++ b/src/server/routes/entity/edition-group.js
@@ -21,7 +21,6 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
-import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
@@ -29,6 +28,7 @@ import {
 	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 
+import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
@@ -135,11 +135,11 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
-	if(!res.locals.entity.dataId){
+	if (!res.locals.entity.dataId) {
 		return next(new ConflictError('This entity has already been deleted'));
 	}
 	_setEditionGroupTitle(res);
-	entityRoutes.displayDeleteEntity(req, res);
+	return entityRoutes.displayDeleteEntity(req, res);
 });
 
 router.post(

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -255,7 +255,7 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 });
 
 
-router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
 	if(!res.locals.entity.dataId){
 		return next(new ConflictError('This entity has already been deleted'));
 	}

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -21,6 +21,7 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	addInitialRelationship,
@@ -255,6 +256,9 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+	if(!res.locals.entity.dataId){
+		return next(new ConflictError('This entity has already been deleted'));
+	}
 	_setEditionTitle(res);
 	entityRoutes.displayDeleteEntity(req, res);
 });

--- a/src/server/routes/entity/edition.js
+++ b/src/server/routes/entity/edition.js
@@ -21,7 +21,6 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
-import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	addInitialRelationship,
@@ -30,6 +29,7 @@ import {
 	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 
+import {ConflictError} from '../../../common/helpers/error';
 import {RelationshipTypes} from '../../../client/entity-editor/relationship-editor/types';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
@@ -256,11 +256,11 @@ router.get('/:bbid/revisions/revisions', (req, res, next) => {
 
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
-	if(!res.locals.entity.dataId){
+	if (!res.locals.entity.dataId) {
 		return next(new ConflictError('This entity has already been deleted'));
 	}
 	_setEditionTitle(res);
-	entityRoutes.displayDeleteEntity(req, res);
+	return entityRoutes.displayDeleteEntity(req, res);
 });
 
 router.post(

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -21,13 +21,14 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
-import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
 	generateEntityProps,
 	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
+
+import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
@@ -157,11 +158,11 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
-	if(!res.locals.entity.dataId){
+	if (!res.locals.entity.dataId) {
 		return next(new ConflictError('This entity has already been deleted'));
 	}
 	_setPublisherTitle(res);
-	entityRoutes.displayDeleteEntity(req, res);
+	return entityRoutes.displayDeleteEntity(req, res);
 });
 
 router.post(

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -156,7 +156,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 		.catch(next);
 });
 
-router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
 	if(!res.locals.entity.dataId){
 		return next(new ConflictError('This entity has already been deleted'));
 	}

--- a/src/server/routes/entity/publisher.js
+++ b/src/server/routes/entity/publisher.js
@@ -21,6 +21,8 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import {ConflictError} from '../../../common/helpers/error';
+
 import {
 	entityEditorMarkup,
 	generateEntityProps,
@@ -155,6 +157,9 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res, next) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+	if(!res.locals.entity.dataId){
+		return next(new ConflictError('This entity has already been deleted'));
+	}
 	_setPublisherTitle(res);
 	entityRoutes.displayDeleteEntity(req, res);
 });

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -141,7 +141,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, middleware.loadSeriesIt
 	entityRoutes.displayEntity(req, res);
 });
 
-router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
 	if(!res.locals.entity.dataId){
 		return next(new ConflictError('This entity has already been deleted'));
 	}

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -21,6 +21,7 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
@@ -141,6 +142,9 @@ router.get('/:bbid', middleware.loadEntityRelationships, middleware.loadSeriesIt
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+	if(!res.locals.entity.dataId){
+		return next(new ConflictError('This entity has already been deleted'));
+	}
 	_setSeriesTitle(res);
 	entityRoutes.displayDeleteEntity(req, res);
 });

--- a/src/server/routes/entity/series.js
+++ b/src/server/routes/entity/series.js
@@ -21,7 +21,6 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
-import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	entityEditorMarkup,
@@ -29,10 +28,10 @@ import {
 	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 
+import {ConflictError} from '../../../common/helpers/error';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
 import express from 'express';
-import {sortRelationshipOrdinal} from '../../../common/helpers/utils';
 import target from '../../templates/target';
 
 /** ****************************
@@ -142,11 +141,11 @@ router.get('/:bbid', middleware.loadEntityRelationships, middleware.loadSeriesIt
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
-	if(!res.locals.entity.dataId){
+	if (!res.locals.entity.dataId) {
 		return next(new ConflictError('This entity has already been deleted'));
 	}
 	_setSeriesTitle(res);
-	entityRoutes.displayDeleteEntity(req, res);
+	return entityRoutes.displayDeleteEntity(req, res);
 });
 
 router.post(

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -21,6 +21,7 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
+import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	addInitialRelationship,
@@ -173,6 +174,9 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+	if(!res.locals.entity.dataId){
+		return next(new ConflictError('This entity has already been deleted'));
+	}
 	_setWorkTitle(res);
 	entityRoutes.displayDeleteEntity(req, res);
 });

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -21,7 +21,6 @@ import * as auth from '../../helpers/auth';
 import * as entityRoutes from './entity';
 import * as middleware from '../../helpers/middleware';
 import * as utils from '../../helpers/utils';
-import {ConflictError} from '../../../common/helpers/error';
 
 import {
 	addInitialRelationship,
@@ -30,6 +29,7 @@ import {
 	makeEntityCreateOrEditHandler
 } from '../../helpers/entityRouteUtils';
 
+import {ConflictError} from '../../../common/helpers/error';
 import {RelationshipTypes} from '../../../client/entity-editor/relationship-editor/types';
 import _ from 'lodash';
 import {escapeProps} from '../../helpers/props';
@@ -174,11 +174,11 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 });
 
 router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
-	if(!res.locals.entity.dataId){
+	if (!res.locals.entity.dataId) {
 		return next(new ConflictError('This entity has already been deleted'));
 	}
 	_setWorkTitle(res);
-	entityRoutes.displayDeleteEntity(req, res);
+	return entityRoutes.displayDeleteEntity(req, res);
 });
 
 router.post(

--- a/src/server/routes/entity/work.js
+++ b/src/server/routes/entity/work.js
@@ -173,7 +173,7 @@ router.get('/:bbid', middleware.loadEntityRelationships, (req, res) => {
 	entityRoutes.displayEntity(req, res);
 });
 
-router.get('/:bbid/delete', auth.isAuthenticated, (req, res) => {
+router.get('/:bbid/delete', auth.isAuthenticated, (req, res, next) => {
 	if(!res.locals.entity.dataId){
 		return next(new ConflictError('This entity has already been deleted'));
 	}


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
fixing BB-458 bug

### Solution
<!-- What does this PR do to fix the problem? -->
show  error conflict page when user tries to delete same entity twice.

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
1. src/server/routes/entity/author.js
2. src/server/routes/entity/edition-group.js
3. src/server/routes/entity/edition.js
4. src/server/routes/entity/publisher.js
5. src/server/routes/entity/series.js
6. src/server/routes/entity/work.js

![image](https://user-images.githubusercontent.com/6179856/144224520-c2aa15da-16f2-48a8-893f-1000756a750e.png)
