### PR TITLE
fix[BB-630]: fix regex to match ~ in url

### DIFF
--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -180,7 +180,7 @@ export function dateObjectToISOString(value: DateObject) {
 export function stringToHTMLWithLinks(string: string) {
 	const addHttpRegex = /(^| )www\./ig;
 	// eslint-disable-next-line max-len
-	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
+	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~*@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
 	let content = string.replace(addHttpRegex, '$1https://www.');
 	content = content.replace(
 		urlRegex,

--- a/src/client/helpers/utils.tsx
+++ b/src/client/helpers/utils.tsx
@@ -180,7 +180,7 @@ export function dateObjectToISOString(value: DateObject) {
 export function stringToHTMLWithLinks(string: string) {
 	const addHttpRegex = /(^| )www\./ig;
 	// eslint-disable-next-line max-len
-	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
+	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%~@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
 	let content = string.replace(addHttpRegex, '$1https://www.');
 	content = content.replace(
 		urlRegex,


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
BB-630 : URLs with ~ in edit notes do not get parsed properly

### Solution
<!-- What does this PR do to fix the problem? -->
added '~' match in urlRegex

### Areas of Impact
<!-- What parts of the codebase and which behaviors are affected? -->
1. src/client/helpers/utils.tsx