### PR TITLE
chore: fix postgres client tools installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ ARG GIT_COMMIT_SHA
 
 ARG BUILD_DEPS=" \
     build-essential \
-    python-dev \
-    libpq5 \
-    libpq-dev"
+    python-dev"
 
 ARG RUN_DEPS=" \
     bzip2 \
     git \
     rsync \
+    libpq5 \
+    libpq-dev \
     ca-certificates"
 
 
@@ -27,7 +27,7 @@ RUN apt-get update && \
 # PostgreSQL client
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ENV PG_MAJOR 12
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I found out the postgres-client package was being removed following removal of packages that are erroneously in the list of build deps (to be removed).

Also made OS release name automatic rather than hardcoded in apt package repo addition.
