### PR TITLE
Added No. of Entities in Collection Page

### DIFF
--- a/src/client/components/pages/collection.js
+++ b/src/client/components/pages/collection.js
@@ -75,6 +75,10 @@ function CollectionAttributes({collection}) {
 					<dd>{collection.entityType}</dd>
 				</Col>
 				<Col md={3}>
+					<dt>No. of Entity</dt>
+					<dd>{collection.items.length}</dd>
+				</Col>
+				<Col md={3}>
 					<dt>Created At</dt>
 					<dd>{formatDate(new Date(collection.createdAt), true)}</dd>
 				</Col>


### PR DESCRIPTION
<!--
Before making a pull request, please:
1. Read the guidelines for contributing
2. Verify that your changes match our coding style
3. Fill out the requested information
-->

### Problem
<!-- What are you trying to solve? -->
 Display number of items in a collection on that collection's page (#BB-638)

### Solution
 I've added "No. of Entity" section in the Collection Page 


### Areas of Impact
 /home/[UserName]/bookbrainz-site/src/client/components/pages/collection.js (line : 77-80) 
